### PR TITLE
Redirect to base_uri after login/logout

### DIFF
--- a/www/controllers/Index.php
+++ b/www/controllers/Index.php
@@ -21,8 +21,10 @@ class Index {
         $view = new \helpers\View();
 
         // logout
-        if(isset($_GET['logout']))
+        if(isset($_GET['logout'])) {
             \F3::get('auth')->logout();
+            \F3::reroute(\F3::get('base_url'));
+        }
 
         // show login?
         if( 
@@ -44,6 +46,8 @@ class Index {
             // show login
             if(count($_POST)==0 || isset($view->error))
                 die($view->render('templates/login.phtml'));
+            else
+                \F3::reroute(\F3::get('base_url'));
                 
         }
 


### PR DESCRIPTION
This is less performant, but fixes the annoyance when refreshing after
login.

Currently, when logging in, the first page gets sent via POST. You still see the `?login=1` in the URL. If you try to refresh, the browser warns you about "resending data". This commit fixes it.
