### PR TITLE
Add a throw (mark as read & open next/previous) shortcut.

### DIFF
--- a/_docs/website/index.html
+++ b/_docs/website/index.html
@@ -250,6 +250,14 @@
                         <td>mark and unmark current selected entry as read/unread</td>
                     </tr>
                     <tr>
+                        <td class="documentation-first-column">t</td>
+                        <td>throw current item (mark as read and open next)</td>
+                    </tr>
+                    <tr>
+                        <td class="documentation-first-column">shift + t</td>
+                        <td>throw current item (mark as read and open previous)</td>
+                    </tr>
+                    <tr>
                         <td class="documentation-first-column">v</td>
                         <td>open url of current entry in new tab/window</td>
                     </tr>

--- a/public/js/selfoss-shortcuts.js
+++ b/public/js/selfoss-shortcuts.js
@@ -36,6 +36,20 @@ selfoss.shortcuts = {
         $(document).bind('keydown', 'ctrl+m', function() {
             $('#nav-mark').click();
         });
+
+        // throw (mark as read & open next)
+        $(document).bind('keydown', 't', function() {
+            $('.entry.selected.unread .entry-unread').click();
+            selfoss.shortcuts.nextprev('next', true);
+            return false;
+        });
+
+        // throw (mark as read & open previous)
+        $(document).bind('keydown', 'Shift+t', function() {
+            $('.entry.selected.unread .entry-unread').click();
+            selfoss.shortcuts.nextprev('prev', true);
+            return false;
+        });
     },
     
     


### PR DESCRIPTION
This patch add two new shortcuts that allow to browse the entries quicker:
`t` (throw) to mark the current entry as read and open the next one.
`shift+t` to mark the current entry as read and open the previous one.

This functionnality is inspired by Google Reader where pressing space does the same thing.

I choosed not to allow those shortcuts to switch an entry back to the unread state, since think it does not makes any sense to "mark as unread and open the next/previous one".
