### PR TITLE
Allow tag filtering to not include partial matches

### DIFF
--- a/daos/mysql/Items.php
+++ b/daos/mysql/Items.php
@@ -178,8 +178,9 @@ class Items extends Database {
         
         // tag filter
         if(isset($options['tag']) && strlen($options['tag'])>0) {
-            $params[':tag'] = array("%".$options['tag']."%", \PDO::PARAM_STR);
-            $where .= ' AND (sources.tags LIKE :tag) ';
+            $params[':tag'] = array("%,".$options['tag'].",%", \PDO::PARAM_STR);
+            $where .= " AND (','|| sources.tags || ',' LIKE :tag) ";
+
         }
         
         // set limit


### PR DESCRIPTION
When clicking on a tag (e.g. `foo`), that previously included partially matching tags (e.g. `football`). This fix corrects this.
