### PR TITLE
Check age of last post to redurce download frequency

### DIFF
--- a/daos/mysql/Items.php
+++ b/daos/mysql/Items.php
@@ -161,6 +161,10 @@ class Items extends Database {
         $params = array();
         $where = '';
         
+        // given source
+        if(isset($options['source']))
+            $where .= ' AND source=' . $options['source'] . ' ';
+
         // only starred
         if(isset($options['type']) && $options['type']=='starred')
             $where .= ' AND starred=1 ';

--- a/helpers/ContentLoader.php
+++ b/helpers/ContentLoader.php
@@ -22,9 +22,14 @@ class ContentLoader {
         // include readability
         if(!function_exists('readability'))
             require('libs/readability.php');
+        $this->age = 0;
     }
     
     
+    public function setage($age) {
+        $this->age = $age;
+    }
+
     /**
      * updates all sources
      *
@@ -33,7 +38,17 @@ class ContentLoader {
     public function update() {
         $sourcesDao = new \daos\Sources();
         foreach($sourcesDao->get() as $source) {
-            $this->fetch($source);
+            if ($this->age == 0) {
+                $this->fetch($source);
+                continue;
+            }
+            $itemDao = new \daos\Items();
+            foreach ($itemDao->get(array('source' => $source['id'])) as $item) {
+                if ($item['datetime'] > date('Y-m-d H:i:s',time()-$this->age)) {
+                    $this->fetch($source);
+                    break;
+                }
+            }
         }
         $this->cleanup();
     }

--- a/update.php
+++ b/update.php
@@ -19,4 +19,5 @@ $f3->set(
 );
 
 $loader = new \helpers\ContentLoader();
+$loader->setage($argv[1]);
 $loader->update();


### PR DESCRIPTION
Adds an argument to update.php, the time period, in seconds, that the feed has to have been active in for downloading.

Feeds that aren't updated frequency probably shouldn't be checked every time.  This patch allows me to set multiple cron jobs at different frequencies specifying different ages.  The hourly job checks everything that's been updated in the last day, daily checks feeds updated in the last week, and a weekly job checks them all.
