### PR TITLE
None is not an accepted value for logger_value

### DIFF
--- a/helpers/Logger.php
+++ b/helpers/Logger.php
@@ -42,7 +42,8 @@ class Logger {
         INFO    => "Info",
         NOTICE  => "Notice",
         WARNING => "Warning",
-        ERROR   => "Error"
+        ERROR   => "Error",
+	NONE	=> "None"
     );
     
     


### PR DESCRIPTION
logger_level cannot be set to none without create an internal server error.
According to the official documentation, NONE should be an acceptable value.
