### PR TITLE
Check unread count before submitting mark-all-as-read request, prevent JS error msg

### DIFF
--- a/public/js/selfoss-events.js
+++ b/public/js/selfoss-events.js
@@ -191,6 +191,10 @@ selfoss.events = {
                 $('.entry.unread').each(function(index, item) {
                     ids.push( $(item).attr('id').substr(5) );
                 });
+
+		if(ids.length === 0){
+		    return;
+		}
                 
                 $.ajax({
                     url: $('base').attr('href') + 'mark',


### PR DESCRIPTION
If all messages are already read and you click "mark as read" you get a JS error dialog because of a PHP error which occurs when there are zero IDs in the POST request. 

This pull request simply returns from the function without making the AJAX call if there are no IDs in the request. 
