### PR TITLE
Make the home page configurable

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -18,3 +18,4 @@ rss_title=selfoss feed
 rss_max_items=300
 rss_mark_as_read=0
 readability_key=
+homepage=

--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -33,7 +33,16 @@ class Index extends BaseController {
         // get search param
         if(isset($options['search']) && strlen($options['search'])>0)
             $this->view->search = $options['search'];
-        
+
+        // if type is not provided, does the user have a preferred
+        // start type?
+        if(!isset($options['type']) && \F3::get('homepage')) {
+            $options['type'] = \F3::get('homepage');
+            $this->view->startFilter = $options['type'];
+        } else {
+            $this->view->startFilter = 'newest';
+        } 
+
         // load items
         $itemsHtml = $this->loadItems($options, $tags);
         $this->view->content = $itemsHtml;

--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -38,9 +38,9 @@
         <div id="nav-mark">mark as read</div>
         
         <ul id="nav-filter">
-            <li class="nav-filter-newest active">newest <span><?PHP echo $this->statsAll; ?></span></li>
-            <li class="nav-filter-unread">unread <span><?PHP echo $this->statsUnread; ?></span></li>
-            <li class="nav-filter-starred">starred <span><?PHP echo $this->statsStarred; ?></span></li>
+            <li class="nav-filter-newest<?PHP if ($this->startFilter == 'newest') { echo ' active'; } ?>">newest <span><?PHP echo $this->statsAll; ?></span></li>
+            <li class="nav-filter-unread<?PHP if ($this->startFilter == 'unread') { echo ' active'; } ?>">unread <span><?PHP echo $this->statsUnread; ?></span></li>
+            <li class="nav-filter-starred<?PHP if ($this->startFilter == 'starred') { echo ' active'; } ?>">starred <span><?PHP echo $this->statsStarred; ?></span></li>
         </ul>
         
         <hr>


### PR DESCRIPTION
This change adds a new configuration option, "homepage", that allows selecting which page/filter/type to load by default. The default value for this option is "newest", which is selfoss's current behaviour, i.e. load the newest items by default. It can also take, however, the values "unread" or "starred", so the user can choose their preferred home page.
