### PR TITLE
Fixed Mobile checking function (isTablet checking was not robust enough for me)

### DIFF
--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -84,7 +84,7 @@ var selfoss = {
      * @return true if device resolution smaller equals 1024
      */
     isMobile: function() {
-        return selfoss.isTablet() || selfoss.isSmartphone();
+        return (/iPhone|iPod|iPad|Android|BlackBerry/).test(navigator.userAgent);
     },
     
     


### PR DESCRIPTION
I am not completely sure that what I am suggesting is what was intended by the author, but still.

In the original code testing for `isTablet` was based on the width of the window – and in fact in my case I got it true even on the desktop, where I was using half of my screen width for the browser :)  (Somehow it worked ok on hires iPad, to my surprise).

I suggest to check for `isMobile` as

```
return (/iPhone|iPod|iPad|Android|BlackBerry/).test(navigator.userAgent);
```

instead of based on the window width. (`isTablet` is left in the code, but it is not really used at the moment)
