### PR TITLE
Change of datatype of content for MySQL

### DIFF
--- a/daos/mysql/Database.php
+++ b/daos/mysql/Database.php
@@ -48,7 +48,7 @@ class Database {
                         id INT NOT NULL AUTO_INCREMENT PRIMARY KEY ,
                         datetime DATETIME NOT NULL ,
                         title TEXT NOT NULL ,
-                        content TEXT NOT NULL ,
+                        content LONGTEXT NOT NULL ,
                         thumbnail TEXT ,
                         icon TEXT ,
                         unread BOOL NOT NULL ,


### PR DESCRIPTION
I am using 2.3 with MySQL. I usually got an exception when updating feeds. I observed that MySQL has a limitation of the length of the type TEXT (64K). It may be too small for some of the pages. When I converted it to LONGTEXT, it worked fine.

I am glad to hear any suggestions.
