### PR TITLE
Added the ability to select individual sources for display

### DIFF
--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -34,6 +34,10 @@ class Index extends BaseController {
         $tagsDao = new \daos\Tags();
         $tags = $tagsDao->get();
         
+        // load sources
+        $sourcesDao = new \daos\Sources();
+        $sources = $sourcesDao->get();
+        
         // get search param
         if(isset($options['search']) && strlen($options['search'])>0)
             $this->view->search = $options['search'];
@@ -61,6 +65,10 @@ class Index extends BaseController {
         // load tags
         $tagsController = new \controllers\Tags();
         $this->view->tags = $tagsController->renderTags($tags);
+        
+        // prepare sources display list
+        $sourcesController = new \controllers\Sources();
+        $this->view->sources = $sourcesController->renderSources($sources);
         
         // show as full html page
         $this->view->publicMode = \F3::get('auth')->isLoggedin()!==true && \F3::get('public')==1;

--- a/controllers/Sources.php
+++ b/controllers/Sources.php
@@ -149,4 +149,23 @@ class Sources extends BaseController {
             )
         );
     }
+
+    /**
+     * return all Sources suitable for navigation panel
+     *
+     * @return htmltext
+     */
+    public function renderSources($sources) {
+        $html = "";
+        $itemsDao = new \daos\Items();
+        foreach($sources as $source) {
+            $this->view->source = $source['title'];
+            $this->view->sourceid = $source['id'];
+	    $this->view->unread = $itemsDao->numberOfUnreadForSource($source['id']);
+            $html .= $this->view->render('templates/source-nav.phtml');
+        }
+        
+        return $html;
+    }
+
 }

--- a/daos/mysql/Items.php
+++ b/daos/mysql/Items.php
@@ -185,6 +185,11 @@ class Items extends Database {
               $where .= " AND ( (',' || sources.tags || ',') LIKE :tag ) ";
             }
         }
+	// source filter
+        elseif(isset($options['source']) && strlen($options['source'])>0) {
+	  $params[':source'] = array($options['source'], \PDO::PARAM_INT);
+	  $where .= " AND items.source=:source ";
+        }
         
         // set limit
         if(!is_numeric($options['items']) || $options['items']>200)
@@ -369,7 +374,7 @@ class Items extends Database {
 
     
     /**
-     * returns the amount of entries in database per tag
+     * returns the amount of unread entries in database per tag
      *
      * @return int amount of entries in database per tag
      */
@@ -383,6 +388,18 @@ class Items extends Database {
         }
         $res = \F3::get('db')->exec( $select . $where,
             array(':tag' => "%,".$tag.",%"));
+        return $res[0]['amount'];
+    }
+
+    /**
+     * returns the amount of unread entries in database per source
+     *
+     * @return int amount of entries in database per tag
+     */
+    public function numberOfUnreadForSource($sourceid) {
+        $res = \F3::get('db')->exec(
+	    'SELECT count(*) AS amount FROM items WHERE source=:source AND unread=1',
+            array(':source' => $sourceid));
         return $res[0]['amount'];
     }
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -94,6 +94,7 @@ input {
         }
     
     #nav h2 {
+        cursor:pointer;
         color:#494949;
         text-transform:uppercase;
         font:18px/27px 'OpenSansBold', Arial, sans-serif;
@@ -141,6 +142,41 @@ input {
         }
         
         #nav-tags .unread {
+            font-size:0.9em;
+            vertical-align:sub;
+            color: #777;
+        }
+    
+    #nav-sources-wrapper  {
+        overflow:hidden;
+    }
+    
+        #nav-sources li {
+            position:relative;
+            font: 18px/27px 'OpenSansLight', Arial, sans-serif;
+            color:#b9b9b9;
+            cursor:pointer;
+/*            padding:5px; */
+            padding-left:25px;
+            padding-right:30px;
+            font-size:0.7em;
+            
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            -o-text-overflow: ellipsis;
+        }
+        
+        #nav-sources li.active {
+            background:#272325;
+            color:#d7d7d7;
+        }
+        
+        #nav-sources .unread {
+	    position:absolute;
+	    left:100%;
+	    top:0px;
+	    margin-left: -30px;
             font-size:0.9em;
             vertical-align:sub;
             color: #777;

--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -17,6 +17,7 @@ var selfoss = {
         search: '',
         type: 'newest',
         tag: '',
+        source: '',
         ajax: true
     },
 

--- a/public/js/selfoss-events.js
+++ b/public/js/selfoss-events.js
@@ -142,8 +142,10 @@ selfoss.events = {
         // tag
         $('#nav-tags > li').unbind('click').click(function () {
             $('#nav-tags > li').removeClass('active');
+            $('#nav-sources > li').removeClass('active');
             $(this).addClass('active');
             
+            selfoss.filter.source = '';
             selfoss.filter.tag = '';
             if($(this).hasClass('nav-tags-all')==false)
                 selfoss.filter.tag = $(this).find('span').html();
@@ -154,6 +156,28 @@ selfoss.events = {
             if(selfoss.isSmartphone())
                 $('#nav-mobile-settings').click();
         });
+	$('#nav-tags-title').unbind('click').click(function () {
+	    var s = $('#nav-tags').toggle("slow");
+	});
+
+        // source
+        $('#nav-sources > li').unbind('click').click(function () {
+            $('#nav-tags > li').removeClass('active');
+            $('#nav-sources > li').removeClass('active');
+            $(this).addClass('active');
+            
+            selfoss.filter.tag = '';
+            selfoss.filter.source = $(this).attr('id').substr(6);
+                
+            selfoss.filter.offset = 0;
+            selfoss.reloadList();
+            
+            if(selfoss.isSmartphone())
+                $('#nav-mobile-settings').click();
+        });
+	$('#nav-sources-title').unbind('click').click(function () {
+	    var s = $('#nav-sources').toggle("slow");
+	});
         
         // show hide navigation for mobile version
         $('#nav-mobile-settings').unbind('click').click(function () {
@@ -569,6 +593,8 @@ selfoss.events = {
                         unreadstats++;
                     }
                     $('.nav-filter-unread span').html(unreadstats);
+
+		    // TODO -- update unread count on souruces (save sourceid in item)
 
                     // Iterate over elements tags
                     $('#entry'+id+' .entry-tags-tag').each( function(index) {

--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -45,13 +45,16 @@
         </ul>
         
         <hr>
-        
-        <h2>Tags</h2>
+
         <div id="nav-tags-wrapper">
+        <h2 id="nav-tags-title">Tags</h2>
             <ul id="nav-tags">
                 <li class="active nav-tags-all">all tags</li>
                 <?PHP echo $this->tags; ?>
             </ul>
+        <h2 id="nav-sources-title">Sources</h2>
+            <ul id="nav-sources">
+                <?PHP echo $this->sources; ?>
         </div>
         
         <hr>

--- a/templates/source-nav.phtml
+++ b/templates/source-nav.phtml
@@ -1,0 +1,4 @@
+<li id="source<?PHP echo $this->sourceid; ?>">
+    <span class="nav-source"><?PHP echo $this->source; ?></span>
+    <div class="unread"><?PHP if ($this->unread>0) echo $this->unread; ?></div>
+</li>


### PR DESCRIPTION
I added the possibility to select individual sources for display.

The list of sources appears below the tags list in the navigation panel.  It is also possible to hide the list of sources (or tags) by clicking at the title 'Sources' (or 'Tags').
###### Possible further improvements:
- I guess, it would be also nice to add some symbol (+ or -) to the Tags/Sources h2 element to show, that the list it hidden/expanded.
- I really think, that 'padding: 5px' should be removed from '#nav-tags li' style, but I am not changing this in the pull request -- let Tobias decide this.
- The mobile setup is not really tested in any way.
- There is a bug -- if the Tag name is long, the unread count for the Tag will be squashed (fixed for sources unread counts only)
