### PR TITLE
Use defined F3 variable instead of static one

### DIFF
--- a/helpers/Image.php
+++ b/helpers/Image.php
@@ -77,7 +77,7 @@ class Image {
             return false;
         
         // get image type
-        $tmp = 'data/cache/' . md5($url);
+        $tmp = \F3::get('cache') . '/' . md5($url);
         file_put_contents($tmp, $data);
         $imgInfo = @getimagesize($tmp); 
         if(strtolower($imgInfo['mime'])=='image/vnd.microsoft.icon')


### PR DESCRIPTION
`helpers/Image.php` use static filename to store images.
Filename is build from `data/cache`when index.php & update.php define a specific variable `cache`for that purpose.
This fix aims to avoid misbehaviours.
