### PR TITLE
Fix: Tags and Sources in Sidebar not clickable after adding/saving source

### DIFF
--- a/public/js/selfoss-events-navigation.js
+++ b/public/js/selfoss-events-navigation.js
@@ -51,7 +51,8 @@ selfoss.events.navigation = function() {
     });
     
     // tag
-    $('#nav-tags > li').unbind('click').click(function () {
+    $('#nav-tags').on('click', 'li', function () {
+        $(this).unbind('click');
         $('#nav-tags > li').removeClass('active');
         $('#nav-sources > li').removeClass('active');
         $(this).addClass('active');
@@ -74,7 +75,8 @@ selfoss.events.navigation = function() {
     });
     
     // source
-    $('#nav-sources > li').unbind('click').click(function () {
+    $('#nav-sources').on('click', 'li', function () {
+        $(this).unbind('click')
         $('#nav-tags > li').removeClass('active');
         $('#nav-sources > li').removeClass('active');
         $(this).addClass('active');


### PR DESCRIPTION
After a Source is saved all Sidebar "Links" are deleted and reimplemented (to refresh them?). unfortunatly the `nav-tags > li` click-event is only set on startup.
Solution:
Changed the jQuery event to `.on()` which adds events if elements are created on runtime.
Performance is not worse than individual adding every `li` http://www.brentsowers.com/2012/03/jquery-on-performance.html
