### PR TITLE
save the last update time of a source

### DIFF
--- a/daos/mysql/Database.php
+++ b/daos/mysql/Database.php
@@ -69,7 +69,8 @@ class Database {
                         tags TEXT,
                         spout TEXT NOT NULL ,
                         params TEXT NOT NULL ,
-                        error TEXT 
+                        error TEXT,
+                        lastupdate INT
                     ) ENGINE = MYISAM DEFAULT CHARSET=utf8;
                 ');
                 $isNewestSourcesTable = true;
@@ -84,7 +85,7 @@ class Database {
                 ');
                 
                 \F3::get('db')->exec('
-                    INSERT INTO version (version) VALUES (2);
+                    INSERT INTO version (version) VALUES (3);
                 ');
                 
                 \F3::get('db')->exec('
@@ -97,6 +98,19 @@ class Database {
                 if($isNewestSourcesTable===false) {
                     \F3::get('db')->exec('
                         ALTER TABLE sources ADD tags TEXT;
+                    ');
+                }
+            }
+            else{
+                $version = @\F3::get('db')->exec('SELECT version FROM version ORDER BY version DESC LIMIT 0, 1');
+                $version = $version[0]['version'];
+                
+                if($version == "2"){
+                    \F3::get('db')->exec('
+                        ALTER TABLE sources ADD lastupdate INT;
+                    ');
+                    \F3::get('db')->exec('
+                        INSERT INTO version (version) VALUES (3);
                     ');
                 }
             }

--- a/daos/mysql/Sources.php
+++ b/daos/mysql/Sources.php
@@ -87,6 +87,35 @@ class Sources extends Database {
                         ':error' => $error
                     ));
     }
+
+
+    /**
+     * sets the last updated timestamp
+     *
+     * @return void
+     * @param int $id the source id
+     */
+    public function saveLastUpdate($id) {
+        \F3::get('db')->exec('UPDATE sources SET lastupdate=:lastupdate WHERE id=:id',
+                    array(
+                        ':id'         => $id,
+                        ':lastupdate' => time()
+                    ));
+    }
+
+
+    /**
+     * returns all sources
+     *
+     * @return mixed all sources
+     */
+    public function getByLastUpdate() {
+        $ret = \F3::get('db')->exec('SELECT id, title, tags, spout, params, error FROM sources ORDER BY lastupdate ASC');
+        $spoutLoader = new \helpers\SpoutLoader();
+        for($i=0;$i<count($ret);$i++)
+            $ret[$i]['spout_obj'] = $spoutLoader->get( $ret[$i]['spout'] );
+        return $ret;
+    }
     
     
     /**

--- a/daos/pgsql/Database.php
+++ b/daos/pgsql/Database.php
@@ -82,7 +82,8 @@ class Database {
                         tags        TEXT,
                         spout       TEXT NOT NULL,
                         params      TEXT NOT NULL,
-                        error       TEXT 
+                        error       TEXT,
+                        lastupdate  INTEGER
                     );
                 ');
                 $isNewestSourcesTable = true;
@@ -97,7 +98,7 @@ class Database {
                 ');
                 
                 \F3::get('db')->exec('
-                    INSERT INTO version (version) VALUES (2);
+                    INSERT INTO version (version) VALUES (3);
                 ');
                 
                 \F3::get('db')->exec('
@@ -110,6 +111,19 @@ class Database {
                 if($isNewestSourcesTable===false) {
                     \F3::get('db')->exec('
                         ALTER TABLE sources ADD COLUMN tags TEXT;
+                    ');
+                }
+            }
+            else{
+                $version = @\F3::get('db')->exec('SELECT version FROM version ORDER BY version DESC LIMIT 0, 1');
+                $version = $version[0]['version'];
+
+                if($version == "2"){
+                    \F3::get('db')->exec('
+                        ALTER TABLE sources ADD lastupdate INT;
+                    ');
+                    \F3::get('db')->exec('
+                        INSERT INTO version (version) VALUES (3);
                     ');
                 }
             }

--- a/daos/sqlite/Database.php
+++ b/daos/sqlite/Database.php
@@ -81,7 +81,8 @@ class Database {
                         tags        TEXT,
                         spout       TEXT NOT NULL,
                         params      TEXT NOT NULL,
-                        error       TEXT 
+                        error       TEXT,
+                        lastupdate  INTEGER
                     );
                 ');
                 $isNewestSourcesTable = true;
@@ -96,7 +97,7 @@ class Database {
                 ');
                 
                 \F3::get('db')->exec('
-                    INSERT INTO version (version) VALUES (2);
+                    INSERT INTO version (version) VALUES (3);
                 ');
                 
                 \F3::get('db')->exec('
@@ -109,6 +110,19 @@ class Database {
                 if($isNewestSourcesTable===false) {
                     \F3::get('db')->exec('
                         ALTER TABLE sources ADD tags TEXT;
+                    ');
+                }
+            }
+            else{
+                $version = @\F3::get('db')->exec('SELECT version FROM version ORDER BY version DESC LIMIT 0, 1');
+                $version = $version[0]['version'];
+
+                if($version == "2"){
+                    \F3::get('db')->exec('
+                        ALTER TABLE sources ADD lastupdate INT;
+                    ');
+                    \F3::get('db')->exec('
+                        INSERT INTO version (version) VALUES (3);
                     ');
                 }
             }

--- a/helpers/ContentLoader.php
+++ b/helpers/ContentLoader.php
@@ -29,7 +29,7 @@ class ContentLoader {
      */
     public function update() {
         $sourcesDao = new \daos\Sources();
-        foreach($sourcesDao->get() as $source) {
+        foreach($sourcesDao->getByLastUpdate() as $source) {
             $this->fetch($source);
         }
         $this->cleanup();
@@ -180,12 +180,14 @@ class ContentLoader {
         // destroy feed object (prevent memory issues)
         \F3::get('logger')->log('destroy spout object', \DEBUG);
         $spout->destroy();
-        
+
+        $sourceDao = new \daos\Sources();
         // remove previous error
         if(strlen(trim($source['error']))!=0) {
-            $sourceDao = new \daos\Sources();
             $sourceDao->error($source['id'], '');
         }
+        // save last update
+        $sourceDao->saveLastUpdate($source['id']);
     }
     
     


### PR DESCRIPTION
In my config there are to many sources and the update.php will always lead to a 500 server error, not being able to update the sources at the bottom. This change will also lead to 500 server errors, but will sequential update all source which are not up to date because they are sorted differently.
