### PR TITLE
Fix the "Creating default object from empty value"

### DIFF
--- a/controllers/Tags.php
+++ b/controllers/Tags.php
@@ -58,6 +58,8 @@ class Tags extends BaseController {
     public function renderTags($tags) {
         $html = "";
         $itemsDao = new \daos\Items();
+        if (!$this->view)
+            return;
         foreach($tags as $tag) {
             $this->view->tag = $tag['tag'];
             $this->view->color = $tag['color'];


### PR DESCRIPTION
Fix the 500 Error "Creating default object from empty value".

I can't setup tags in my setup without this fix. 
