### PR TITLE
fix: remove source from navigation bar after deleting source

### DIFF
--- a/public/js/selfoss-events-sources.js
+++ b/public/js/selfoss-events-sources.js
@@ -120,8 +120,9 @@ selfoss.events.sources = function() {
                     $(this).remove();
                 });
                 
-                // reload tags
+                // reload tags and remove source from navigation
                 selfoss.reloadTags();
+                $('#nav-sources li#'+parent.attr('id')).remove();
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 parent.find('.source-edit-delete').removeClass('loading');


### PR DESCRIPTION
When deleting a source, the tags get reloaded, but the deleted source isn't removed from the navigation bar.
