### PR TITLE
Add option to sort unread items by oldest

### DIFF
--- a/daos/mysql/Items.php
+++ b/daos/mysql/Items.php
@@ -160,15 +160,19 @@ class Items extends Database {
     public function get($options = array()) {
         $params = array();
         $where = '';
-        
+        $order = 'DESC';
+
         // only starred
         if(isset($options['type']) && $options['type']=='starred')
             $where .= ' AND starred=1 ';
             
         // only unread
-        else if(isset($options['type']) && $options['type']=='unread')
+        else if(isset($options['type']) && $options['type']=='unread') {
             $where .= ' AND unread=1 ';
-        
+            if (\F3::get('reverse_unread_order')==1)
+                $order = 'ASC';
+        }
+
         // search
         if(isset($options['search']) && strlen($options['search'])>0) {
             $search = str_replace(" ", "%", trim($options['search']));
@@ -207,7 +211,7 @@ class Items extends Database {
                     items.id, datetime, items.title AS title, content, unread, starred, source, thumbnail, icon, uid, link, sources.title as sourcetitle, sources.tags as tags
                    FROM items, sources 
                    WHERE items.source=sources.id '.$where.' 
-                   ORDER BY items.datetime DESC 
+                   ORDER BY items.datetime '.$order.' 
                    LIMIT ' . $options['offset'] . ', ' . $options['items'], $params);
     }
     

--- a/daos/pgsql/Items.php
+++ b/daos/pgsql/Items.php
@@ -21,15 +21,19 @@ class Items extends \daos\mysql\Items {
     public function get($options = array()) {
         $params = array();
         $where = '';
-        
+        $order = 'DESC';
+
         // only starred
         if(isset($options['type']) && $options['type']=='starred')
             $where .= ' AND starred=true ';
             
         // only unread
-        else if(isset($options['type']) && $options['type']=='unread')
+        else if(isset($options['type']) && $options['type']=='unread') {
             $where .= ' AND unread=true ';
-        
+            if (\F3::get('reverse_unread_order')==1)
+                $order = 'ASC';
+        }
+
         // search
         if(isset($options['search']) && strlen($options['search'])>0) {
             $search = str_replace(" ", "%", trim($options['search']));
@@ -64,7 +68,7 @@ class Items extends \daos\mysql\Items {
                     items.id, datetime, items.title AS title, content, unread, starred, source, thumbnail, icon, uid, link, sources.title as sourcetitle, sources.tags as tags
                    FROM items, sources 
                    WHERE items.source=sources.id '.$where.' 
-                   ORDER BY items.datetime DESC 
+                   ORDER BY items.datetime '.$order.' 
                    LIMIT ' . $options['items'] . ' OFFSET ' . $options['offset'], $params);
     }
     

--- a/defaults.ini
+++ b/defaults.ini
@@ -21,3 +21,4 @@ rss_max_items=300
 rss_mark_as_read=0
 homepage=newest
 auto_mark_as_read=0
+reverse_unread_order=0


### PR DESCRIPTION
This adds a config option 'reverse_unread_order', which allows sorting of unread items from oldest to newest instead of the default (new to old).

Sorting items this way in Google Reader always made much more sense to me when you're catching up on unread items (especially for stuff like twitter timelines).
