### PR TITLE
Fix ajax loading of more items when using Postgres

### DIFF
--- a/daos/mysql/Items.php
+++ b/daos/mysql/Items.php
@@ -18,7 +18,7 @@ class Items extends Database {
      * results or not
      * @var bool
      */
-    private $hasMore = false;
+    protected $hasMore = false;
 
     
     /**


### PR DESCRIPTION
Currently, loading more items is broken when using Postgres because the inheriting Postgres DAO class can't set the private $hasMore property. Fixed with this quick one-liner.
