### PR TITLE
Miscellaneous small CSS tweaks

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -370,11 +370,10 @@ input {
 
     .entry-icon,
     .entry-title,
-    .entry-tags,
     .entry-tags-tag {
         display:inline;
         font-weight:normal;
-        margin-right:5px;
+        margin-left:5px;
         cursor:pointer;
     }
 
@@ -384,7 +383,22 @@ input {
         padding-top:7px;
         padding-bottom:7px;
     }
-    
+
+    .entry-source,
+    .entry-separator,
+    .entry-datetime,
+    .entry-tags {
+        float: right;
+        margin-right: 5px;
+        height: 25px;
+    }
+    /* clearfix */
+    .entry:after {
+        content: " ";
+        display: block;
+        clear: both;
+    }
+
         .entry.unread  .entry-title {
             color:#333333;
         }
@@ -401,6 +415,7 @@ input {
     
     .entry-content {
         display:none;
+        clear: both;
         -moz-column-count: 3;
         -moz-column-gap: 2em;
         -moz-column-rule: 1px solid rgba(204, 204, 204, 0.4);
@@ -411,7 +426,7 @@ input {
         column-gap: 2em;
         column-rule: 1px solid rgba(204, 204, 204, 0.4);
         font-size:0.95em;
-        margin-top:20px;
+        padding-top:20px;
         line-height: 1.7em;
     }
     
@@ -459,6 +474,7 @@ input {
     }
     
     .entry-source,
+    .entry-separator,
     .entry-datetime {
         display:inline;
         color:#aaa;
@@ -863,7 +879,13 @@ body.publicmode.notloggedin .entry-unread {
         -webkit-column-count: 1;
         column-count: 1;
     }
-    
+
+    .entry-icon,
+    .entry-tags {
+        margin-left: 0;
+        margin-right: 0;
+    }
+
     .entry.selected.unread,
     .entry.unread {
         border-right:5px solid #5f9490;
@@ -1008,6 +1030,7 @@ body.publicmode.notloggedin .entry-unread {
         }
         
         .entry-source,
+        .entry-separator,
         .entry-datetime {
             color:#3d6d69;
         }

--- a/templates/item.phtml
+++ b/templates/item.phtml
@@ -26,26 +26,28 @@
     
     <!-- title -->
     <h2 class="entry-title"><?PHP echo $title; ?></h2>
-    
-    <div class="entry-tags">
+
+    <span class="entry-tags">
         <?PHP foreach($this->item['tags'] as $tag => $color) : ?>
-            <div class="entry-tags-tag" style="background-color:<?PHP echo $color; ?>"><?PHP echo $tag; ?></div>
+            <span class="entry-tags-tag" style="background-color:<?PHP echo $color; ?>"><?PHP echo $tag; ?></span>
         <?PHP endforeach; ?>
-    </div>
-    
+    </span>
+
     <!-- source -->
     <a href="<?PHP echo trim(\F3::get('anonymizer')) . $this->item['link']; ?>" class="entry-source entry-source<?PHP echo $this->item['source']; ?>" target="_blank"><?PHP echo $sourcetitle ?></a>
-    
+
+    <span class="entry-separator">&bull;</span>
+
     <!-- datetime -->
-    <div class="entry-datetime">
-        &bullet; <?PHP echo $date; ?>
-    </div>
-    
+    <span class="entry-datetime">
+        <?PHP echo $date; ?>
+    </span>
+
     <!-- thumbnail -->
     <?PHP if(isset($this->item['thumbnail']) && strlen(trim($this->item['thumbnail']))>0) : ?>
-    <div class="entry-thumbnail">
+    <span class="entry-thumbnail">
         <a href="<?PHP echo $this->item['link']; ?>"><img src="<?PHP echo 'thumbnails/'.$this->item['thumbnail']; ?>" alt="<?PHP echo $this->item['title']; ?>" /></a>
-    </div>
+    </span>
     <?PHP endif; ?>
     
     <!-- content -->


### PR DESCRIPTION
Feel free to cherry-pick the commits you like.

With commit 10aed1f, the scrollbar won't show on >1024px screens anymore when clicking on a filter or when pressing r to refresh the page.

Commit 4e7c3ad limits the maximal width of items with short text. Previously, short items would span the whole screen, which is hard to read.

Commit 7b61f68 prevents tags from wrapping. Wrapping inside a tag just looks ugly.

Commit 2bde6b1 aligns tags, source and timestamps to the right and is probably the most "controversial" change, but I think it improves the look of the items list:

![selfoss-screenshot-01](https://f.cloud.github.com/assets/929479/320041/3ad1ea6c-9910-11e2-825f-18d0cd6a00a9.png)
![selfoss-screenshot-02](https://f.cloud.github.com/assets/929479/320042/3e3adefc-9910-11e2-9219-d78ecafe8146.png)
