### PR TITLE
&bullet; doesn't work in IE

### DIFF
--- a/templates/item.phtml
+++ b/templates/item.phtml
@@ -38,7 +38,7 @@
     
     <!-- datetime -->
     <div class="entry-datetime">
-        &bullet; <?PHP echo $date; ?>
+        &bull; <?PHP echo $date; ?>
     </div>
     
     <!-- thumbnail -->


### PR DESCRIPTION
The &bullet; seems not to work with the Internet Explorer:
http://stackoverflow.com/questions/11762622/bullet-doesnt-work-in-ie

Testet with IE9 under Windows 7.
