### PR TITLE
Re-initialize entry events on screen width change

### DIFF
--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -3,9 +3,11 @@
  */
 selfoss.events.entries = function(e) {
 
+    $('.entry, .entry-title').unbind('click');
+
     // show/hide entry
     var target = selfoss.isMobile() ? '.entry' : '.entry-title';
-    $(target).unbind('click').click(function() {
+    $(target).click(function() {
         var parent = ((target == '.entry') ? $(this) : $(this).parent());
         
         if(selfoss.isSmartphone()==false) {

--- a/public/js/selfoss-events.js
+++ b/public/js/selfoss-events.js
@@ -10,7 +10,11 @@ selfoss.events = {
         selfoss.events.navigation();
         selfoss.events.entries();
         selfoss.events.search();
-        
+
+        // re-init on media query change
+        var mq = window.matchMedia("(min-width: 641px) and (max-width: 1024px)");
+        mq.addListener(selfoss.events.entries);
+
         // window resize
         $("#nav-tags-wrapper").mCustomScrollbar({
             advanced:{


### PR DESCRIPTION
This fixes some small inconsistencies that happen when the browser window is resized.
For example, when you open Selfoss in a window that is >1024px wide, items expand only when clicking on the title. But when you open Selfoss in a window that is <1024px wide and then resize it to >1024px, clicking anywhere on the item expands it.
