### PR TITLE
"Newest items" change to "all articles" 

### DIFF
--- a/public/lang/en.ini
+++ b/public/lang/en.ini
@@ -1,5 +1,5 @@
 lang_markread=mark as read
-lang_newest=newest
+lang_newest=all articles
 lang_unread=unread
 lang_starred=starred
 lang_tags=Tags


### PR DESCRIPTION
Hi !

I just don't get the "newest items" title.

It's not newest articles as opposed to older/other articles.

This link only have all articles selected.

Does this change make any sense to you ?

Thanks,
GLLM
