### PR TITLE
Fixed OPML import for other formats

### DIFF
--- a/controllers/Opml.php
+++ b/controllers/Opml.php
@@ -99,9 +99,9 @@ class Opml extends BaseController {
         
         // parse every outline item
         foreach($xml->outline as $outline){
-            if((string)$outline['type']) {
+            if((string)$outline['type'] || !(string)$outline['xmlUrl']) {
                 //support folders in opml
-                if($outline['type']=='folder') {
+                if($outline['type']=='folder' || !(string)$outline['xmlUrl']) {
                     $ret = $this->processGroup($outline,$tags);
                     $errors = array_merge($errors,$ret);
                 } else {
@@ -132,6 +132,9 @@ class Opml extends BaseController {
         
         // description
         $title = (string)$xml['text'];
+        if ($title == null) {
+            $title = (string)$xml['title'];
+        }
         
         // RSS URL
         $data['url'] = (string)$xml['xmlUrl'];


### PR DESCRIPTION
Some OPML exports don't match the specifications. For example, [Netvibes](http://www.netvibes.com) exports OPML files without "type" or "text" attributes.
My changes allow the importer to still detect if an outline is a category or a feed entry, and it can still get the feed title even if there is no "text" attribute.
