### PR TITLE
Shortcut to open Searchbar and Image Positioning Fix

### DIFF
--- a/public/js/selfoss-events-search.js
+++ b/public/js/selfoss-events-search.js
@@ -26,10 +26,11 @@ selfoss.events.search = function() {
     $('#search-button').unbind('click').click(function () {
         if($('#search').hasClass('active')==false) {
             $('#search').addClass('active');
-            $('#search-term').focus();
+            $('#search-term').focus().select();
             return;
         }
         executeSearch($('#search-term').val());
+		$('#search-term').blur();
     });
     
     // navigation search button for mobile navigation
@@ -39,9 +40,11 @@ selfoss.events.search = function() {
     });
     
     // keypress enter in search inputfield
-    $('#search-term').unbind('keypress').keypress(function(e) {
+    $('#search-term').unbind('keyup').keyup(function(e) {
         if(e.which == 13)
             $('#search-button').click();
+		if(e.keyCode == 27)
+			$('#search-remove').click();
     });
     
     // search term list in top of the page
@@ -61,6 +64,7 @@ selfoss.events.search = function() {
     $('#search-remove').unbind('click').click(function () {
         if(selfoss.filter.search=='') {
             $('#search').removeClass('active');
+		    $('#search-term').blur();
             return;
         }
         

--- a/public/js/selfoss-shortcuts.js
+++ b/public/js/selfoss-shortcuts.js
@@ -102,6 +102,13 @@ selfoss.shortcuts = {
             e.preventDefault();
             return false;
         });
+
+		// Share on G+
+		$(document).bind('keydown', 'g', function() {
+			var w = window.open('https://plus.google.com/share?url='+ $('.entry.selected .entry-source').attr('href'), 
+				'google_share', "status=0,toolbar=0,location=0,width=500,height=450,scrollbars=1,menubar=0");
+			return true;
+		});
         
         // 'Ctrl+m': mark all as read
         $(document).bind('keydown', 'ctrl+m', function(e) {
@@ -124,6 +131,11 @@ selfoss.shortcuts = {
             e.preventDefault();
             return false;
         });
+
+		// open search
+		$(document).bind('keyup', '/', function() {
+			$('#search-button').click();
+		});
     },
     
     
@@ -177,9 +189,11 @@ selfoss.shortcuts = {
         // open?
         if(open) {
             var content = current.find('.entry-content');
+            var connext = current.next().find('.entry-content');
             // load images not on mobile devices
             if(selfoss.isMobile()==false)
                 content.lazyLoadImages();
+                connext.lazyLoadImages();
             // anonymize
             selfoss.anonymize(content);
             content.show();


### PR DESCRIPTION
Added "/" for opening the Searchbar and <ESC> for closing it again.
(And "g" for Google+, which is personal preference and a "can be included". But I prefer the popup over a new tab.)

Also fixes a bug in which fast keyboard navigation displays the next open Feed in the middle with a big picture truncated, because it wasnt loaded fast enough to detect height. Simply added preloading next Feed.
