### PR TITLE
Share an item on public mode and not logged in

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,4 +1,3 @@
-
 /* base */
 
 html {
@@ -806,7 +805,7 @@ body.publicmode.notloggedin .entry-unread {
 @media screen and (min-width: 1024px) {
 
     body.publicmode.notloggedin  .entry-toolbar {
-        display:none !important;
+        display:none;
     }
 
 }


### PR DESCRIPTION
To be able to share an item on public mode and not logged in, i suggest to remove `!important` on L 808 from css/style.css

My users want to be able to share items but I they have not acces to the configuration side to add/modify/delete feeds sources.
