### PR TITLE
Fix : Some icons weren't fetched

### DIFF
--- a/helpers/Image.php
+++ b/helpers/Image.php
@@ -47,7 +47,7 @@ class Image {
                 elseif (substr($shortcutIcon, 0, 1)=='/')
                     $shortcutIcon = $urlElements['scheme'] . '://' . $urlElements['host'] . $shortcutIcon;
                 else
-                    $shortcutIcon = $url . $shortcutIcon;
+                    $shortcutIcon = $url . '/' . $shortcutIcon;
             }
 
             $faviconAsPng = $this->loadImage($shortcutIcon, $width, $height);


### PR DESCRIPTION
I realized that the icons weren't fetched for quite a lot of feeds I read. I added a few lines of codes to correct that. I didn't add a lot of stuff :
- I added a search pattern for the icon link : `<link rel="icon" ... />`
- I added a slash between the link and the favicon path (before that, if the link was `http://www.domain.tld/dir` and the favicon path was `favicon.ico`, the resulting icon url would be `http://www.domain.tld/dirfavicon.ico`)
