### PR TITLE
Don't leave behind sp-container divs when refreshing the tags

### DIFF
--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -206,6 +206,7 @@ var selfoss = {
      */
     refreshTags: function(tags) {
         var currentTag = $('#nav-tags li').index($('#nav-tags .active'));
+        $('.color').spectrum('destroy');
         $('#nav-tags li:not(:first)').remove();
         $('#nav-tags').append(tags);
         if(currentTag>=0)


### PR DESCRIPTION
Previously, every time refreshTags was called, sp-container divs were being left behind in the DOM. We need to clean those up with spectrum('destroy') before removing the list items in #nav-tags.
