### PR TITLE
Clean up orphaned items (fixes #291)

### DIFF
--- a/daos/Items.php
+++ b/daos/Items.php
@@ -48,15 +48,17 @@ class Items extends Database {
     
     
     /**
-     * cleanup old items
+     * cleanup orphaned and old items
      *
      * @return void
-     * @param int $days delete all items older than this value
+     * @param int $days delete all items older than this value [optional]
      */
     public function cleanup($days) {
-        $minDate = new \DateTime();
-        $minDate->sub(new \DateInterval('P'.$days.'D'));
-        
+        $minDate = NULL;
+        if ($days !== "") {
+            $minDate = new \DateTime();
+            $minDate->sub(new \DateInterval('P'.$days.'D'));
+        }
         $this->backend->cleanup($minDate);
     }
     

--- a/daos/mysql/Items.php
+++ b/daos/mysql/Items.php
@@ -144,13 +144,17 @@ class Items extends Database {
     
     
     /**
-     * cleanup old items
+     * cleanup orphaned and old items
      *
      * @return void
-     * @param DateTime $date date to delete all items older than this value
+     * @param DateTime $date date to delete all items older than this value [optional]
      */
-    public function cleanup(\DateTime $date) {
-        \F3::get('db')->exec('DELETE FROM items WHERE starred=0 AND datetime<:date',
+    public function cleanup(\DateTime $date = NULL) {
+        \F3::get('db')->exec('DELETE FROM items WHERE id IN (
+                                SELECT items.id FROM items LEFT JOIN sources
+                                ON items.source=sources.id WHERE sources.id IS NULL)');
+        if ($date !== NULL)
+            \F3::get('db')->exec('DELETE FROM items WHERE starred=0 AND datetime<:date',
                     array(':date' => $date->format('Y-m-d').' 00:00:00'));
     }
     

--- a/daos/pgsql/Items.php
+++ b/daos/pgsql/Items.php
@@ -198,13 +198,17 @@ class Items extends \daos\mysql\Items {
     }
 
     /**
-     * cleanup old items
+     * cleanup orphaned and old items
      *
      * @return void
-     * @param DateTime $date date to delete all items older than this value
+     * @param DateTime $date date to delete all items older than this value [optional]
      */
-    public function cleanup(\DateTime $date) {
-        \F3::get('db')->exec('DELETE FROM items WHERE starred=false AND datetime<:date',
+    public function cleanup(\DateTime $date = NULL) {
+        \F3::get('db')->exec('DELETE FROM items WHERE id IN (
+                                SELECT items.id FROM items LEFT JOIN sources
+                                ON items.source=sources.id WHERE sources.id IS NULL)');
+        if ($date !== NULL)
+            \F3::get('db')->exec('DELETE FROM items WHERE starred=false AND datetime<:date',
                     array(':date' => $date->format('Y-m-d').' 00:00:00'));
     }
 }

--- a/helpers/ContentLoader.php
+++ b/helpers/ContentLoader.php
@@ -197,13 +197,11 @@ class ContentLoader {
      * @return void
      */
     public function cleanup() {
-        // cleanup old items
-        if(\F3::get('items_lifetime')) {
-            \F3::get('logger')->log('cleanup old items', \DEBUG);
-            $itemsDao = new \daos\Items();
-            $itemsDao->cleanup(\F3::get('items_lifetime'));
-            \F3::get('logger')->log('cleanup old items finished', \DEBUG);
-        }
+        // cleanup orphaned and old items
+        \F3::get('logger')->log('cleanup orphaned and old items', \DEBUG);
+        $itemsDao = new \daos\Items();
+        $itemsDao->cleanup(\F3::get('items_lifetime'));
+        \F3::get('logger')->log('cleanup orphaned and old items finished', \DEBUG);
         
         // delete orphaned thumbnails
         \F3::get('logger')->log('delete orphaned thumbnails', \DEBUG);


### PR DESCRIPTION
These changes extend the cleanup function of the items daos to also remove any items whose source field doesn't have a corresponding entry in the sources table.

From my testing, #291 occurs when deleting a source while update.php is running and fetching items for that source.
So, one (unreliable) option would have been to check if the source still exists every time an item is inserted, or to clean up afterwards and delete all items that don't have a corresponding source.
I think that cleaning up afterwards is the better way to handle this, as it takes care of other cases I might have missed where items could be orphaned and it also removes orphaned items that have already been inserted into the db.
