### PR TITLE
Decode HTML entities before passing title or content to htmLawed

### DIFF
--- a/helpers/ContentLoader.php
+++ b/helpers/ContentLoader.php
@@ -106,7 +106,7 @@ class ContentLoader {
             
             // sanitize content html
             $content = htmLawed(
-                $item->getContent(), 
+                html_entity_decode($item->getContent()),
                 array(
                     "safe"           => 1,
                     "deny_attribute" => '* -alt -title -src -href',
@@ -116,7 +116,7 @@ class ContentLoader {
                     "elements"       => 'div,p,ul,li,a,img,dl,dt,h1,h2,h3,h4,h5,h6,ol,br,table,tr,td,blockquote,pre,ins,del,th,thead,tbody,b,i,strong,em,tt'
                 )
             );
-            $title = htmLawed($item->getTitle(), array("deny_attribute" => "*", "elements" => "-*"));
+            $title = htmLawed(html_entity_decode($item->getTitle()), array("deny_attribute" => "*", "elements" => "-*"));
             \F3::get('logger')->log('item content sanitized', \DEBUG);
             
             $icon = $item->getIcon();


### PR DESCRIPTION
Yet another quick fix for an issue I've noticed with some feeds. Some HTML tags weren't being removed properly from the title or content.

Some websites encode the title or content of their feeds with HTML entities (for example the Wired feed). HtmLawed doesn't recognize tags that are already entity encoded, so we have to decode them first in order for htmLawed to neutralize/remove all tags correctly.
