### PR TITLE
Yet another fix for #300 and friends

### DIFF
--- a/helpers/ContentLoader.php
+++ b/helpers/ContentLoader.php
@@ -106,7 +106,7 @@ class ContentLoader {
             
             // sanitize content html
             $content = htmLawed(
-                html_entity_decode($item->getContent(), ENT_COMPAT, 'UTF-8'),
+                htmlspecialchars_decode($item->getContent()),
                 array(
                     "safe"           => 1,
                     "deny_attribute" => '* -alt -title -src -href',
@@ -116,7 +116,7 @@ class ContentLoader {
                     "elements"       => 'div,p,ul,li,a,img,dl,dt,h1,h2,h3,h4,h5,h6,ol,br,table,tr,td,blockquote,pre,ins,del,th,thead,tbody,b,i,strong,em,tt'
                 )
             );
-            $title = html_entity_decode($item->getTitle(), ENT_COMPAT, 'UTF-8');
+            $title = htmlspecialchars_decode($item->getTitle());
             $title = htmLawed($title, array("deny_attribute" => "*", "elements" => "-*"));
             \F3::get('logger')->log('item content sanitized', \DEBUG);
             


### PR DESCRIPTION
This should finally fix #300 and related issues, but give it a try first before merging, just to be sure.

Using html_entity_decode when storing the item title/content obviously caused too much UTF-8 related breakage, htmlspecialchars_decode should be safer and does the job just as well without touching the encoding.
