### PR TITLE
Sanitize tag list and title when adding/editing a source

### DIFF
--- a/daos/mysql/Sources.php
+++ b/daos/mysql/Sources.php
@@ -22,9 +22,12 @@ class Sources extends Database {
      * @param mixed $params depends from spout
      */
     public function add($title, $tags, $spout, $params) {
+        // sanitize tag list
+        $tags = implode(',', preg_split('/\s*,\s*/', trim($tags), -1, PREG_SPLIT_NO_EMPTY));
+
         \F3::get('db')->exec('INSERT INTO sources (title, tags, spout, params) VALUES (:title, :tags, :spout, :params)',
                     array(
-                        ':title'  => $title,
+                        ':title'  => trim($title),
                         ':tags'   => $tags,
                         ':spout'  => $spout,
                         ':params' => htmlentities(json_encode($params))
@@ -46,9 +49,12 @@ class Sources extends Database {
      * @param mixed $params the new params
      */
     public function edit($id, $title, $tags, $spout, $params) {
+        // sanitize tag list
+        $tags = implode(',', preg_split('/\s*,\s*/', trim($tags), -1, PREG_SPLIT_NO_EMPTY));
+
         \F3::get('db')->exec('UPDATE sources SET title=:title, tags=:tags, spout=:spout, params=:params WHERE id=:id',
                     array(
-                        ':title'  => $title,
+                        ':title'  => trim($title),
                         ':tags'  => $tags,
                         ':spout'  => $spout,
                         ':params' => htmlentities(json_encode($params)),

--- a/daos/pgsql/Sources.php
+++ b/daos/pgsql/Sources.php
@@ -22,9 +22,12 @@ class Sources extends \daos\mysql\Sources {
      * @param mixed $params depends from spout
      */
     public function add($title, $tags, $spout, $params) {
+        // sanitize tag list
+        $tags = implode(',', preg_split('/\s*,\s*/', trim($tags), -1, PREG_SPLIT_NO_EMPTY));
+
         $res = \F3::get('db')->exec('INSERT INTO sources (title, tags, spout, params) VALUES (:title, :tags, :spout, :params) RETURNING id',
                     array(
-                        ':title'  => $title,
+                        ':title'  => trim($title),
                         ':tags'  => $tags,
                         ':spout'  => $spout,
                         ':params' => htmlentities(json_encode($params))

--- a/daos/sqlite/Sources.php
+++ b/daos/sqlite/Sources.php
@@ -23,9 +23,12 @@ class Sources extends \daos\mysql\Sources {
      * @param mixed $params depends from spout
      */
     public function add($title, $tags, $spout, $params) {
+        // sanitize tag list
+        $tags = implode(',', preg_split('/\s*,\s*/', trim($tags), -1, PREG_SPLIT_NO_EMPTY));
+
         \F3::get('db')->exec('INSERT INTO sources (title, tags, spout, params) VALUES (:title, :tags, :spout, :params)',
                     array(
-                        ':title'  => $title,
+                        ':title'  => trim($title),
                         ':tags'  => $tags,
                         ':spout'  => $spout,
                         ':params' => htmlentities(json_encode($params))


### PR DESCRIPTION
I was getting slightly annoyed with having to use trim() and strlen() all over the place, so this cleans up the tag list into a nice, trimmed list when inserting or updating a source in the database.

Snippets like these:

```
foreach ($tags as $tag) {
    $tag = trim($tag);
     if (strlen($tag) > 0) {
         ...
```

would become redundant. (Well, except for tags that have been added to the database before this change, until the source is edited again...)
