### PR TITLE
Use translated string for 'edit' after saving a source

### DIFF
--- a/public/js/selfoss-events-sources.js
+++ b/public/js/selfoss-events-sources.js
@@ -69,7 +69,7 @@ selfoss.events.sources = function() {
                 // show saved text
                 parent.find('.source-showparams').addClass('saved').html($('#lang').data('source_saved'));
                 window.setTimeout(function() {
-                    parent.find('.source-showparams').removeClass('saved').html('edit');
+                    parent.find('.source-showparams').removeClass('saved').html($('#lang').data('source_edit'));
                 }, 10000);
                 
                 // hide input form

--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -42,7 +42,8 @@
         data-star="<?PHP echo \F3::get('lang_star'); ?>"
         data-unstar="<?PHP echo \F3::get('lang_unstar'); ?>"
         data-source_warn="<?PHP echo \F3::get('lang_source_warn'); ?>"
-        data-source_saved="<?PHP echo \F3::get('lang_source_saved'); ?>">
+        data-source_saved="<?PHP echo \F3::get('lang_source_saved'); ?>"
+        data-source_edit="<?PHP echo \F3::get('lang_source_edit'); ?>">
 
     <!-- other settings -->
     <span id="config"


### PR DESCRIPTION
After saving a source, the text on its edit link was replaced by `edit`, instead of `$('#lang').data('source_edit')`.
