### PR TITLE
Optimise Expires section and Compression

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -37,45 +37,90 @@ RewriteRule (.*) public/$1 [L]
 
 # Default expires header if none specified (stay in browser cache for 7 days)
 <IfModule mod_expires.c>
-    ExpiresActive On
-    ExpiresDefault A604800
 
-    ExpiresByType application/javascript "access plus 2 hours"
-    ExpiresByType application/x-javascript "access plus 2 hours"
-    ExpiresByType text/javascript "access plus 2 hours"
-    ExpiresByType text/x-javascript "access plus 2 hours"
-    ExpiresByType text/css "access plus 2 hours"
-    ExpiresByType image/gif "access plus 2 hours"
-    ExpiresByType image/jpg "access plus 2 hours"
-    ExpiresByType image/png "access plus 2 hours"
-    ExpiresByType image/x-icon "access plus 2 hours"
+    ExpiresActive on
+    ExpiresDefault                                      "access plus 1 week"
+
+  # CSS
+    ExpiresByType text/css                              "access plus 1 year"
+
+  # Data interchange
+    ExpiresByType application/json                      "access plus 0 seconds"
+    ExpiresByType application/xml                       "access plus 0 seconds"
+    ExpiresByType text/xml                              "access plus 0 seconds"
+
+  # Favicon (cannot be renamed!)
+    ExpiresByType image/x-icon                          "access plus 1 week"
+
+  # HTML components (HTCs)
+    ExpiresByType text/x-component                      "access plus 1 month"
+
+  # HTML
+    ExpiresByType text/html                             "access plus 0 seconds"
+
+  # JavaScript
+    ExpiresByType application/javascript                "access plus 1 year"
+
+  # Manifest files
+    ExpiresByType application/x-web-app-manifest+json   "access plus 0 seconds"
+    ExpiresByType text/cache-manifest                   "access plus 0 seconds"
+
+  # Media
+    ExpiresByType audio/ogg                             "access plus 1 month"
+    ExpiresByType image/gif                             "access plus 1 month"
+    ExpiresByType image/jpeg                            "access plus 1 month"
+    ExpiresByType image/png                             "access plus 1 month"
+    ExpiresByType video/mp4                             "access plus 1 month"
+    ExpiresByType video/ogg                             "access plus 1 month"
+    ExpiresByType video/webm                            "access plus 1 month"
+
+  # Web feeds
+    ExpiresByType application/atom+xml                  "access plus 1 hour"
+    ExpiresByType application/rss+xml                   "access plus 1 hour"
+
+  # Web fonts
+    ExpiresByType application/font-woff                 "access plus 1 month"
+    ExpiresByType application/vnd.ms-fontobject         "access plus 1 month"
+    ExpiresByType application/x-font-ttf                "access plus 1 month"
+    ExpiresByType font/opentype                         "access plus 1 month"
+    ExpiresByType image/svg+xml                         "access plus 1 month"
+
 </IfModule>
 
-# set compression
-<IfModule mod_header.c>
-    <IfModule mod_deflate.c>
-        # Insert filter
-        SetOutputFilter DEFLATE
 
-        # Netscape 4.x has some problems...
-        BrowserMatch ^Mozilla/4 gzip-only-text/html
+<IfModule mod_deflate.c>
 
-        # Netscape 4.06-4.08 have some more problems
-        BrowserMatch ^Mozilla/4\.0[678] no-gzip
-
-        # MSIE masquerades as Netscape, but it is fine
-        # BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
-
-        # NOTE: Due to a bug in mod_setenvif up to Apache 2.0.48
-        # the above regex won't work. You can use the following
-        # workaround to get the desired effect:
-        BrowserMatch \bMSI[E] !no-gzip !gzip-only-text/html
-
-        # Don't compress images
-        SetEnvIfNoCase Request_URI \
-        \.(?:gif|jpe?g|png)$ no-gzip dont-vary
-
-        # Make sure proxies don't deliver the wrong content
-        Header append Vary User-Agent env=!dont-vary
+    # Force compression for mangled headers.
+    # http://developer.yahoo.com/blogs/ydn/posts/2010/12/pushing-beyond-gzipping
+    <IfModule mod_setenvif.c>
+        <IfModule mod_headers.c>
+            SetEnvIfNoCase ^(Accept-EncodXng|X-cept-Encoding|X{15}|~{15}|-{15})$ ^((gzip|deflate)\s*,?\s*)+|[X~-]{4,13}$ HAVE_Accept-Encoding
+            RequestHeader append Accept-Encoding "gzip,deflate" env=HAVE_Accept-Encoding
+        </IfModule>
     </IfModule>
+
+    # Compress all output labeled with one of the following MIME-types
+    # (for Apache versions below 2.3.7, you don't need to enable `mod_filter`
+    #  and can remove the `<IfModule mod_filter.c>` and `</IfModule>` lines
+    #  as `AddOutputFilterByType` is still in the core directives).
+    <IfModule mod_filter.c>
+        AddOutputFilterByType DEFLATE application/atom+xml \
+                                      application/javascript \
+                                      application/json \
+                                      application/rss+xml \
+                                      application/vnd.ms-fontobject \
+                                      application/x-font-ttf \
+                                      application/x-web-app-manifest+json \
+                                      application/xhtml+xml \
+                                      application/xml \
+                                      font/opentype \
+                                      image/svg+xml \
+                                      image/x-icon \
+                                      text/css \
+                                      text/html \
+                                      text/plain \
+                                      text/x-component \
+                                      text/xml
+    </IfModule>
+
 </IfModule>


### PR DESCRIPTION
I've merged the "Compression" and "Expires headers" sections from [html5boilerplate's .htaccess](https://github.com/h5bp/html5-boilerplate/blob/master/.htaccess) into selfoss/.htaccess

Compression was not working on the earlier version on a few servers, notably Hostgator's shared server setup. Web fonts also had a relatively short expiration time. The html5boilerplate code resolves both these issues.
