### PR TITLE
Replace &bullet; with &bull; in source.phtml

### DIFF
--- a/templates/source.phtml
+++ b/templates/source.phtml
@@ -11,7 +11,7 @@
     
     <div class="source-title"><?PHP echo isset($this->source) ? $this->source['title'] : \F3::get('lang_source_new') ; ?></div>
     
-    <div class="source-edit-delete"><span class="source-showparams"><?PHP echo \F3::get('lang_source_edit')?></span> &bullet; <span class="source-delete"><?PHP echo \F3::get('lang_source_delete')?></span></div>
+    <div class="source-edit-delete"><span class="source-showparams"><?PHP echo \F3::get('lang_source_edit')?></span> &bull; <span class="source-delete"><?PHP echo \F3::get('lang_source_delete')?></span></div>
 
     <!-- edit -->
     <ul class="source-edit-form">
@@ -57,7 +57,7 @@
         
         <!-- save/delete -->
         <li class="source-action">
-            <span class="source-save"><?PHP echo \F3::get('lang_source_save')?></span> &bullet; <span class="source-cancel"><?PHP echo \F3::get('lang_source_cancel')?></span>
+            <span class="source-save"><?PHP echo \F3::get('lang_source_save')?></span> &bull; <span class="source-cancel"><?PHP echo \F3::get('lang_source_cancel')?></span>
         </li>
     </ul>
 


### PR DESCRIPTION
My IE 9 shows the word &bullet; when I manage my sources. The correct entity is &bull;. :)
