### PR TITLE
Fixed: blog's target link 

### DIFF
--- a/_docs/website/index.html
+++ b/_docs/website/index.html
@@ -518,7 +518,7 @@ db_port=3306</code>
             |
             <a href="http://www.aditu.de">About me</a>
             |
-            <a href="http://blog.aditu.de">Blog</a>
+            <a href="http://www.aditu.de//#filter=.blog">Blog</a>
             |
             logo by <a href="http://blog.artcore-illustrations.de/aicons/">ArtCore</a>
         </p>


### PR DESCRIPTION
Old link target was being resolved to www.aditu.de instead of to the blog section.
