### PR TITLE
Fix bug on Rss controller which not mark all item

### DIFF
--- a/controllers/Rss.php
+++ b/controllers/Rss.php
@@ -74,15 +74,16 @@ class Rss extends BaseController {
 
             $feedWriter->addItem($newItem);
             $lastid = $item['id'];
+         
+            // mark as read
+            if(\F3::get('rss_mark_as_read')==1 && $lastid!=-1)
+                $itemDao->mark($lastid);
         }
         
         if($newestEntryDate===false)
             $newestEntryDate = date(\DATE_ATOM , time());
         $feedWriter->setChannelElement('updated', $newestEntryDate);
-        
-        // mark as read
-        if(\F3::get('rss_mark_as_read')==1 && $lastid!=-1)
-            $itemDao->mark($lastid);
+
         
         $feedWriter->genarateFeed();
     }


### PR DESCRIPTION
When refreshing rss feed on client-app just one item (the last) is marked as read. The amrk as read instruction was written after the foreach loop, I re intregate it in the foreach.
