### PR TITLE
Add support for fullscreen Webapp on iPhone 5

### DIFF
--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -13,6 +13,9 @@
     <!--  Mobile viewport optimized: j.mp/bplateviewport -->
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1" />
     
+    <!--  Add support for fullscreen Webapp on iPhone 5 -->
+    <meta name="viewport" content="initial-scale=1, user-scalable=no, maximum-scale=1" media="(device-height: 568px)" />
+    
     <!-- app 'behaviour' when adding link to iDevice springboard -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
 

--- a/templates/login.phtml
+++ b/templates/login.phtml
@@ -12,6 +12,9 @@
     <!--  Mobile viewport optimized: j.mp/bplateviewport -->
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1" />
     
+    <!--  Add support for fullscreen Webapp on iPhone 5 -->
+    <meta name="viewport" content="initial-scale=1, user-scalable=no, maximum-scale=1" media="(device-height: 568px)" />
+    
     <!-- app 'behaviour' when adding link to iDevice springboard -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
 

--- a/templates/opml.phtml
+++ b/templates/opml.phtml
@@ -11,6 +11,9 @@
 
         <!--  Mobile viewport optimized: j.mp/bplateviewport -->
         <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+        
+        <!--  Add support for fullscreen Webapp on iPhone 5 -->
+    	<meta name="viewport" content="initial-scale=1, user-scalable=no, maximum-scale=1" media="(device-height: 568px)" />
 
         <!-- Place favicon.ico & apple-touch-icon.png in the root of your domain and delete these references -->
         <link rel="shortcut icon" href="favicon.ico">


### PR DESCRIPTION
Refers to Issue #409 where the Webapp on an iPhone 5 started from
Springboard starts letterboxed.
