### PR TITLE
Wider touch area

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1051,10 +1051,10 @@ body.publicmode.notloggedin .entry-unread {
             width:29px;
             height:29px;
             left:100%;
-            top:10px;
-            margin-left:-48px;
-            background:url(images/nav-mobile-settings.png) no-repeat;
+            margin-left:-66px;
+            background:url(images/nav-mobile-settings.png) no-repeat center;
             background-size:29px 29px;
+            padding:11px 21px 11px 15px;
         }
         
     #nav {


### PR DESCRIPTION
Wider touch area for the settings icon, in mobile view.

Touch area before:
![before](https://f.cloud.github.com/assets/5294234/1045441/0e49217c-1025-11e3-97fb-8dca793bd726.jpg)

Touch area after:
![after](https://f.cloud.github.com/assets/5294234/1045443/18efdf76-1025-11e3-84ba-41dda6a9b1d7.jpg)
