### PR TITLE
Fix for #420 Twitter spouts does not work: Twitter API v1 is inactive

### DIFF
--- a/libs/twitteroauth/twitteroauth.php
+++ b/libs/twitteroauth/twitteroauth.php
@@ -18,7 +18,7 @@ class TwitterOAuth {
   /* Contains the last API call. */
   public $url;
   /* Set up the API root URL. */
-  public $host = "https://api.twitter.com/1/";
+  public $host = "https://api.twitter.com/1.1/";
   /* Set timeout default. */
   public $timeout = 30;
   /* Set connect timeout. */


### PR DESCRIPTION
Twitter api protocol updated to 1.1.
