### PR TITLE
content images float left

### DIFF
--- a/helpers/ContentLoader.php
+++ b/helpers/ContentLoader.php
@@ -176,7 +176,7 @@ class ContentLoader {
                 "keep_bad"       => 0,
                 "comment"        => 1,
                 "cdata"          => 1,
-                "elements"       => 'div,p,ul,li,a,img,dl,dt,h1,h2,h3,h4,h5,h6,ol,br,table,tr,td,blockquote,pre,ins,del,th,thead,tbody,b,i,strong,em,tt'
+                "elements"       => 'div,p,ul,li,a,img,dl,dt,dd,h1,h2,h3,h4,h5,h6,ol,br,table,tr,td,blockquote,pre,ins,del,th,thead,tbody,b,i,strong,em,tt'
             )
         );
     }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -488,6 +488,13 @@ input {
 			clear: left;
 		}
 
+		.entry-content dt {
+			font-weight: bold;
+		}
+		.entry-content dd {
+			text-indent: 1.3em;
+		}
+
     .entry-icon,
     .entry-icon img {
         margin-top:3px;


### PR DESCRIPTION
with this patch, images in content area are no longer treated as character but float left around the content within the same paragraph. upcoming paragraphs as well as lists, blockquotes and pre-elements clear this floating, so they won't get interfered by the floating image, if the content inside the paragraph is too short to fully wrap it.
the wrapping class needs to have hidden overflow, so that images do not float into upcoming entries.
