### PR TITLE
The processing of the parameter of the session cookie is updated.

### DIFF
--- a/helpers/Authentication.php
+++ b/helpers/Authentication.php
@@ -32,13 +32,22 @@ class Authentication {
     public function __construct() {
         
         // check for SSL proxy and special cookie options
-    	if(isset($_SERVER['HTTP_X_FORWARDED_SERVER'])) {
-  			// set cookie details (http://php.net/manual/en/function.setcookie.php)
-  			// expire, path, domain, secure, httponly
-        	session_set_cookie_params((3600*24*30), '/'.$_SERVER['SERVER_NAME'].preg_replace('/\/[^\/]+$/','',$_SERVER['PHP_SELF']).'/', $_SERVER['HTTP_X_FORWARDED_SERVER'], "true", "true");
-  		} else {
-        // session cookie will be valid for one month
-        session_set_cookie_params((3600*24*30), "/");
+        if(isset($_SERVER['HTTP_X_FORWARDED_SERVER'])
+           &&isset($_SERVER['HTTP_X_FORWARDED_HOST'])
+           &&($_SERVER['HTTP_X_FORWARDED_SERVER']===$_SERVER['HTTP_X_FORWARDED_HOST'])) {
+            // set cookie details (http://php.net/manual/en/function.setcookie.php)
+            // expire, path, domain, secure, httponly
+            session_set_cookie_params(
+                (3600*24*30), 
+                '/'.$_SERVER['SERVER_NAME'].preg_replace('/\/[^\/]+$/','',$_SERVER['PHP_SELF']).'/', 
+                $_SERVER['HTTP_X_FORWARDED_SERVER'], 
+                (isset($_SERVER['HTTPS'])&&"off"!==$_SERVER['HTTPS'])?"true":"false", 
+                "true");
+        } else {
+            // session cookie will be valid for one month. path is script dir.
+            session_set_cookie_params(
+                (3600*24*30), 
+                dirname($_SERVER['SCRIPT_NAME'])==='/'?'/':dirname($_SERVER['SCRIPT_NAME']).'/');
         }
         
         session_name();


### PR DESCRIPTION
Hi.

In current code (helpers/Authentication.php), cookie is not set in my environment (reverse proxy is used).

I think that it is not necessarily SSL proxy even if "$_SERVER['HTTP_X_FORWARDED_SERVER']" is set.
(For example, reverse proxy and load balancer, and so on.)
Moreover, path and domain do not necessarily change.

Therefore, I changed the condition. 
The person who is using SSL proxy verifies this code, I am glad. 

After that, the range of cookie was narrowed below the directory of selfoss. 
Selfoss of each directory can be arranged if it does so. (ex: UserDir) 

Best regards.
