### PR TITLE
Add more robust RSS feed date parsing

### DIFF
--- a/spouts/rss/feed.php
+++ b/spouts/rss/feed.php
@@ -277,9 +277,27 @@ class feed extends \spouts\spout {
      */
     public function getDate() {
         if($this->items!==false && $this->valid())
-            $date = @current($this->items)->get_date('Y-m-d H:i:s');
-        if(strlen($date)==0)
+            $date = @current($this->items)->get_date('');
+
+        $match = false;
+        $dateFormats = array(
+            "Y-m-d H:i:s",
+            "d/m/Y H:i:s"
+        );
+
+        foreach ($dateFormats as $dateFormat) {
+            $dt = \DateTime::createFromFormat($dateFormat, $date);
+
+            if ($dt !== false && !array_sum($dt->getLastErrors())) {
+                $match = true;
+                $date = $dt->format('Y-m-d H:i:s');
+                break;
+            }
+        }
+
+        if(!$match) 
             $date = date('Y-m-d H:i:s');
+        
         return $date;
     }
     


### PR DESCRIPTION
Added the ability to specify different formats for parsing RSS feed publish dates. Some of the RSS feeds have screwy formats.

This should be backwards compatible with the existing parser....I tested it and it seemed to work perfectly.
