### PR TITLE
reddit2 spout: add empty validation on username&password to fix unable t...

### DIFF
--- a/spouts/reddit/reddit2.php
+++ b/spouts/reddit/reddit2.php
@@ -67,12 +67,14 @@ class reddit2 extends \spouts\spout {
             "type"       => "text",
             "default"    => "",
             "required"   => false,
+            "validation" => ""
         ),
         "password" => array(
             "title"      => "Password",
             "type"       => "password",
             "default"    => "",
             "required"   => false,
+            "validation" => ""
         )
     );
 


### PR DESCRIPTION
I was unable to add a reddit2 source, the error I got was "Undefined index: validation".
These changes (empty validation because the fields are not required) fixes that.
