### PR TITLE
reddit2 spout: fix link to return http

### DIFF
--- a/spouts/reddit/reddit2.php
+++ b/spouts/reddit/reddit2.php
@@ -314,7 +314,7 @@ class reddit2 extends \spouts\spout {
      */
     public function getLink() {
         if ( $this->items!==false && $this->valid() )
-            return "//reddit.com" . @current( $this->items )->data->permalink;
+            return "http://reddit.com" . @current( $this->items )->data->permalink;
         return false;
     }
 


### PR DESCRIPTION
The reddit2 spout returns the item link like: "//reddit.com/....".

This makes the following unusable:
- Share with pocket/readability/...
- Open with anonymizer

These changes to include 'http:' fix that.
