### PR TITLE
Middle click on the title to open the entry in an new window

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -420,14 +420,21 @@ input {
 
     .entry-title {
         cursor:pointer;
-        color:#999999;
         padding-top:7px;
         padding-bottom:7px;
     }
+
+    .entry-title,
+    .entry-title a {
+        color:#999999;
+        font-weight:normal;
+        text-decoration: none;
+    }
     
-        .entry.unread  .entry-title {
-            color:#333333;
-        }
+    .entry.unread .entry-title,
+    .entry.unread .entry-title a {
+        color:#333333;
+    }
     
     .entry-tags-tag {
         -moz-border-radius:4px;
@@ -1201,10 +1208,14 @@ body.publicmode.notloggedin .entry-unread {
         #fullscreen-entry .entry {
             padding-top:50px;
         }
+        
+        #fullscreen-entry .entry-title,
+        #fullscreen-entry .entry-title a {
+            color:#333333;
+        }
     
         #fullscreen-entry .entry-title {
             padding-top:40px;
-            color:#333333;
             font-size:1.3em;
         }
         

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -7,7 +7,8 @@ selfoss.events.entries = function(e) {
 
     // show/hide entry
     var target = selfoss.isMobile() ? '.entry' : '.entry-title';
-    $(target).click(function() {
+    $(target).click(function(e) {
+        if(e.which !== 1) return;
         var parent = ((target == '.entry') ? $(this) : $(this).parent());
         
         if(selfoss.isSmartphone()==false) {
@@ -93,7 +94,33 @@ selfoss.events.entries = function(e) {
             }
         } 
     });
-
+    
+    // middle click to open in new window
+    $('.entry-title a').mousedown(function(e) {
+        if((e.which != 1) && (e.which != 2)) return;
+        e.preventDefault();
+	    
+        if(e.which == 2) {
+            $(this).data('doMiddleClick', true);
+        }
+    }).mouseup(function(e) {
+        if((e.which != 1) && (e.which != 2)) return;
+        var link = $(this);
+        
+        if((e.which == 2) && link.data('doMiddleClick')) {
+            var entry = link.parents('.entry');
+            selfoss.events.entriesToolbar(entry);
+            entry.find('.entry-unread.active').click();
+            link.removeData('doMiddleClick');
+        } else {
+            e.preventDefault();
+        }
+    }).click(function(e) {
+        if(e.which == 1) {
+            e.preventDefault();
+        }
+    });
+    
     // no source click
     if(selfoss.isSmartphone())
         $('.entry-source, .entry-icon').unbind('click').click(function(e) {e.preventDefault(); return false });

--- a/public/js/selfoss-events-entriestoolbar.js
+++ b/public/js/selfoss-events-entriestoolbar.js
@@ -6,7 +6,7 @@ selfoss.events.entriesToolbar = function(parent) {
         parent = $('#content');
     
     // prevent close on links
-    parent.find('a').unbind('click').click(function(e) {
+    parent.find('.entry-content a').unbind('click').click(function(e) {
         window.open($(this).attr('href'));
         e.preventDefault();
         return false;

--- a/templates/item.phtml
+++ b/templates/item.phtml
@@ -35,7 +35,7 @@
     </a>
     
     <!-- title -->
-    <h2 class="entry-title"><?PHP echo $title; ?></h2>
+    <h2 class="entry-title"><a href="<?PHP echo trim(\F3::get('anonymizer')) . $this->item['link']; ?>"><?PHP echo $title; ?></a></h2>
     
     <span class="entry-tags">
         <?PHP foreach($this->item['tags'] as $tag => $color) : ?>


### PR DESCRIPTION
Tested with all major desktop and mobile browsers. ~~Tested with all major desktop browsers. **Please test this on mobile browsers!** (Currently I don't have a appropriate device at hand)~~

**Some notes about the implementation:**
Actually JavaScript neither opens the window nor follows the link. The user clicks on an regular `<a href="">`. We just prevent the browser from following the link on a regular left click. This is done with `preventDefault()` within an `click` event.

Because Firefox never triggers the `click` event on middle click, we must use the `mousedown` and `mouseup` events. Unfortunately Firefox even doesn't trigger the `mouseup` event by default. To work around that, we must call `preventDefault()` within the `mousedown` event. Now we can mark the entry read within the `mouseup` event. Finally, we use `.data()` to prevent fragmentary clicks.
