### PR TITLE
Fix duplicate items with MySQL

### DIFF
--- a/daos/mysql/Items.php
+++ b/daos/mysql/Items.php
@@ -148,7 +148,7 @@ class Items extends Database {
     public function findAll($itemsInFeed) {
         $itemsFound = array();
         array_walk($itemsInFeed, function( &$value ) { $value = \F3::get('db')->quote($value); });
-        $query = "SELECT uid AS uid FROM items WHERE uid IN (". implode(',', $itemsInFeed) .")";
+        $query = 'SELECT uid AS uid FROM '.\F3::get('db_prefix').'items WHERE uid IN ('. implode(',', $itemsInFeed) .')';
         $res = \F3::get('db')->query($query);
         if ($res) {
             $all = $res->fetchAll();


### PR DESCRIPTION
Bug reported https://github.com/SSilence/selfoss/issues/470

Caused by https://github.com/ssilence/selfoss/commit/5a49b98ba0c88a62c33165ed562dc029955806f1
missing the table prefix in findAll query
