### PR TITLE
Add option 'auto_hide_read_on_mobile' support.

### DIFF
--- a/defaults.ini
+++ b/defaults.ini
@@ -29,3 +29,4 @@ readability=
 share=gtfprde
 allow_public_update_access=
 unread_order=
+auto_hide_read_on_mobile=

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -20,6 +20,7 @@ selfoss.events.entries = function(e) {
             return;
         
         var autoMarkAsRead = $('#config').data('auto_mark_as_read')=="1" && parent.hasClass('unread');
+        var mobileHideOnClose = $('#config').data('mobile_hide_on_close')=="1" && parent.hasClass('unread');
         
         // anonymize
         selfoss.anonymize(parent.find('.entry-content'));
@@ -58,6 +59,9 @@ selfoss.events.entries = function(e) {
             fullscreen.find('.entry, .entry-close').click(function(e) {
                 if(e.target.tagName.toLowerCase()=="a")
                     return;
+                if(mobileHideOnClose && ($('#entrr'+parent.attr('id').substr(5)).hasClass('unread')==false)) {
+                    $('#'+parent.attr('id')).hide();
+                }
                 content.show();
                 location.hash = "";
                 $(window).scrollTop(scrollTop);

--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -53,7 +53,8 @@
     <!-- other settings -->
     <span id="config"
         data-anonymizer="<?PHP echo trim(\F3::get('anonymizer')); ?>"
-        data-auto_mark_as_read="<?PHP echo \F3::get('auto_mark_as_read'); ?>">
+        data-auto_mark_as_read="<?PHP echo \F3::get('auto_mark_as_read'); ?>"
+        data-auto_hide_read_on_mobile="<?PHP echo \F3::get('auto_hide_read_on_mobile'); ?>">
 
     <!-- menue open for smartphone -->
     <div id="nav-mobile">


### PR DESCRIPTION
# Summary:

Allows to hide read item when closing fullscreen view.
This makes reading RSS on mobile easier and has been sucessfully tested on smartphone Galaxy Nexus and on tablet Nexus 7 & TF101 with Firefox for Android and default Android web browser.
# Technically:

Read items are hidden when closing fullscreen view only if:
- option `auto_hide_read_on_mobile` is enabled
- item's state is unread (ie. when item does not have class `unread`).

Default value for `auto_hide_read_on_mobile` is disabled.
