### PR TITLE
Sqlite's "optimize()" was implemented.

### DIFF
--- a/daos/sqlite/Database.php
+++ b/daos/sqlite/Database.php
@@ -139,5 +139,8 @@ class Database {
      * @return  void
      */
     public function optimize() {
+        @\F3::get('db')->exec('
+            VACUUM;
+        ');
     }
 }


### PR DESCRIPTION
VACUUM is executed in optimize(). 
To prevent the DB file of Sqlite from enlarging. 
