### PR TITLE
Multi-language support of search.

### DIFF
--- a/public/js/selfoss-events-search.js
+++ b/public/js/selfoss-events-search.js
@@ -22,6 +22,7 @@ selfoss.events.search = function() {
 
     var executeSearch = function(term) {
         // show words in top of the page
+    	if(term=="\"") term="";
         var words = splitTerm(term);
         $('#search-list').html('');
         var itemId = 0;


### PR DESCRIPTION
'\w' doesn't match for the multi language. 
( '\w' is [A-Za-z0-9_]. )
So, I corrected. 

Regards,
arbk
