### PR TITLE
Multi-language support of search and error fix.

### DIFF
--- a/public/js/selfoss-events-search.js
+++ b/public/js/selfoss-events-search.js
@@ -13,6 +13,8 @@ selfoss.events.search = function() {
     };
 
     var joinTerm = function(words) {
+        if(!words || words.length <= 0)
+            return "";
         for(var i = 0; i < words.length; i++) {
             if(words[i].indexOf(" ") >= 0)
                 words[i] = '"'  + words[i] + '"';
@@ -23,6 +25,7 @@ selfoss.events.search = function() {
     var executeSearch = function(term) {
         // show words in top of the page
         var words = splitTerm(term);
+        term = joinTerm(words);
         $('#search-list').html('');
         var itemId = 0;
         $.each(words, function(index, item) {


### PR DESCRIPTION
[1] Multi-language support of search.

'\w' doesn't match for the multi language.
( '\w' is [A-Za-z0-9_]. )

[2] The error by inputting double quotation as search term was fixed.

If search term  that include a double quotation mark is used, an error occurs.
Exsample search term:  
t "
" " "
etc.

So, I corrected.

Regards,
arbk
