### PR TITLE
Fix pgsql VACUUM ANALYZE syntax error

### DIFF
--- a/daos/pgsql/Database.php
+++ b/daos/pgsql/Database.php
@@ -150,6 +150,6 @@ class Database {
         $tables = array();
         foreach($result as $table)
             foreach($table as $key=>$value)
-                @\F3::get('db')->exec("VACUUM ANALYZE :table", array(':table' => $value));
+                @\F3::get('db')->exec("VACUUM ANALYZE " . $value);
     }
 }


### PR DESCRIPTION
Hi there - first off, thanks for SelfOSS!  Still getting used to it but it's really nice to have a self-hosted RSS solution.

I noticed an error every five minutes or so in my postgres logs that I tracked down to daos/pgsql/Database.php.  It's a syntax error in the VACUUM ANALYZE statement:

```
2014-03-30 00:45:18 UTC ERROR:  syntax error at or near "$1" at character 16
2014-03-30 00:45:18 UTC STATEMENT:  VACUUM ANALYZE $1
```

It turns out that pgsql doesn't let you use bound parameters to represent table names - the commit message explains it in greater detail.

An alternative implementation might be to just execute a list of VACUUM ANALYZE statements for the known set of tables (items, sources, version, tags); but I wasn't sure if you were dynamically getting the list of tables to help with maintenance.  Another simpler alternative would be an unqualified VACUUM ANALYZE, which would just vacuum all the tables the db user has access to.

I'm not a Postgres expert so I opted for the solution that fixed the error while changing behavior as little as possible - if you'd like me to investigate any of the alternatives, let me know and I'll give it a shot.

Thanks!
-Ben
