### PR TITLE
Fix curl 60 errors on HTTPS rss feeds

### DIFF
--- a/libs/SimplePie.php
+++ b/libs/SimplePie.php
@@ -6849,6 +6849,7 @@ class SimplePie_File
 				curl_setopt($fp, CURLOPT_REFERER, $url);
 				curl_setopt($fp, CURLOPT_USERAGENT, $useragent);
 				curl_setopt($fp, CURLOPT_HTTPHEADER, $headers2);
+				curl_setopt($fp, CURLOPT_SSL_VERIFYPEER, FALSE);
 				if (!ini_get('open_basedir') && !ini_get('safe_mode') && version_compare(SimplePie_Misc::get_curl_version(), '7.15.2', '>='))
 				{
 					curl_setopt($fp, CURLOPT_FOLLOWLOCATION, 1);


### PR DESCRIPTION
prevents curl 60 errors on https rss feeds

Example Error:
`2014-03-26 23:12:02error loading feed content: cURL error 60: SSL certificate problem: unable to get local issuer certificate`
