### PR TITLE
API REST : /login should return true if auth is disable

### DIFF
--- a/helpers/Authentication.php
+++ b/helpers/Authentication.php
@@ -105,9 +105,11 @@ class Authentication {
                 $this->loggedin = true;
                 $_SESSION['loggedin'] = true;
                 return true;
+            } else {
+                return false;
             }
         }
-        return false;
+        return true;	
     }
     
     


### PR DESCRIPTION
I'm developing an Android app which uses the REST API. In order to check whether the configuration entered by the user is correct, I use the "/login" method.
When authentication is enabled, if it returns `{success: true}`, the configuration is right, if it returns `{success: false}` the username and password don't match, else, the url is wrong.
When authentication is disabled, it returns `false`. So we can't know if the user forgot to set its username and password or if the config is right.
That's why I think that this method should always return `true` if authentication is disabled.
