### PR TITLE
Fix icons not showing up in sources view

### DIFF
--- a/daos/mysql/Items.php
+++ b/daos/mysql/Items.php
@@ -367,7 +367,7 @@ class Items extends Database {
         if(is_numeric($sourceid)===false)
             return false;
         
-        $res = \F3::get('db')->exec('SELECT icon FROM '.\F3::get('db_prefix').'items WHERE source=:sourceid AND icon!=0 AND icon!="" ORDER BY ID DESC LIMIT 0,1',
+        $res = \F3::get('db')->exec('SELECT icon FROM '.\F3::get('db_prefix').'items WHERE source=:sourceid AND icon!="" ORDER BY ID DESC LIMIT 0,1',
                     array(':sourceid' => $sourceid));
         if(count($res)==1)
             return $res[0]['icon'];


### PR DESCRIPTION
MySQL compared the first character of the icon field to the integer 0 and any icon field that didn't start with a number greater than 0 was not returned.
