### PR TITLE
Fix the reload shortcut

### DIFF
--- a/public/js/selfoss-shortcuts.js
+++ b/public/js/selfoss-shortcuts.js
@@ -119,9 +119,8 @@ selfoss.shortcuts = {
         
         // 'r': Reload the current view
         $(document).bind('keydown', 'r', function(e) {
-            selfoss.reloadList();
             e.preventDefault();
-            return false;
+            $('#nav-filter-unread').click();
         });
         
         // 'Ctrl+m': mark all as read


### PR DESCRIPTION
The previous way to reload the unread article list was broken when we hit the latest element of the list.
