### PR TITLE
fix tag names not case sensitive in mysql (fix #480)

### DIFF
--- a/daos/mysql/Items.php
+++ b/daos/mysql/Items.php
@@ -213,7 +213,7 @@ class Items extends Database {
         if(isset($options['tag']) && strlen($options['tag'])>0) {
             $params[':tag'] = array( "%,".$options['tag'].",%" , \PDO::PARAM_STR );
             if ( \F3::get( 'db_type' ) == 'mysql' ) {
-              $where .= " AND ( CONCAT( ',' , sources.tags , ',' ) LIKE :tag ) ";
+              $where .= " AND ( CONCAT( ',' , sources.tags , ',' ) LIKE _utf8 :tag COLLATE utf8_bin ) ";
             } else {
               $where .= " AND ( (',' || sources.tags || ',') LIKE :tag ) ";
             }
@@ -425,7 +425,7 @@ class Items extends Database {
         $select = 'SELECT count(*) AS amount FROM '.\F3::get('db_prefix').'items AS items, '.\F3::get('db_prefix').'sources AS sources';
         $where = ' WHERE items.source=sources.id AND unread=1';
         if ( \F3::get( 'db_type' ) == 'mysql' ) {
-            $where .= " AND ( CONCAT( ',' , sources.tags , ',' ) LIKE :tag ) ";
+            $where .= " AND ( CONCAT( ',' , sources.tags , ',' ) LIKE _utf8 :tag COLLATE utf8_bin ) ";
         } else {
             $where .= " AND ( (',' || sources.tags || ',') LIKE :tag ) ";
         }

--- a/daos/mysql/Tags.php
+++ b/daos/mysql/Tags.php
@@ -112,7 +112,12 @@ class Tags extends Database {
      * @return boolean true if color is used by an tag
      */
     public function hasTag($tag) {
-        $res = \F3::get('db')->exec('SELECT COUNT(*) AS amount FROM '.\F3::get('db_prefix').'tags WHERE tag=:tag',
+        if ( \F3::get( 'db_type' ) == 'mysql' ) {
+            $where = 'WHERE tag = _utf8 :tag COLLATE utf8_bin';
+        } else {
+            $where = 'WHERE tag=:tag';
+        }
+        $res = \F3::get('db')->exec('SELECT COUNT(*) AS amount FROM '.\F3::get('db_prefix').'tags '.$where,
                     array(':tag' => $tag));
         return $res[0]['amount']>0;
     }


### PR DESCRIPTION
This was because string comparison in mysql with utf8 is not case sensitive
by default.

mysql> SELECT COUNT(*) AS amount FROM tags WHERE tag='Général';
+--------+
| amount |
+--------+
|      1 |
+--------+
1 row in set (0.01 sec)

mysql> SELECT COUNT(*) AS amount FROM tags WHERE tag='général';
+--------+
| amount |
+--------+
|      1 |
+--------+
1 row in set (0.00 sec)
