### PR TITLE
Add version number to all.js and all.css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /data/logs/*.log
 /data/sqlite/*.db
 /public/all.*
+/public/all-v*.*
 user.css
 /_bin/*.*
 /_docs/website/forum

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ UPDATE
 2. (IMPORTANT: don't delete the "data" folder) delete all old files and folders excluding the folder "data"
 3. upload all new files and folders excluding the data folder (IMPORTANT: also upload the invisible .htaccess files)
 4. Rename your folder /data/icons into /data/favicons
-5. Delete the files /public/all.css and /public/all.js
+5. Delete the files /public/all-v*.css and /public/all-v*.js
 6. Clean your browser cache
 7. insert your current database connection and your individual configuration in config.ini. Important: we change the config.ini and add new options in newer versions. You have to update the config.ini too.
 8. The database will be updated automatically (ensure that your database has enought rights for creating triggers)

--- a/_docs/website/index.html
+++ b/_docs/website/index.html
@@ -157,7 +157,7 @@ db_port=3306</code>
                     <li><b>IMPORTANT: don't delete the "data" folder</b>. Delete all old files and folders excluding the folder "data".</li>
                     <li>Upload all new files and folders excluding the data folder (IMPORTANT: also upload the invisible .htaccess files).</li>
                     <li>Rename your folder /data/icons into /data/favicons</li>
-                    <li>Delete the files /public/all.css and /public/all.js</li>
+                    <li>Delete the files /public/all-v<var>*</var>.css and /public/all-v<var>*</var>.js</li>
                     <li>Clean your browser cache.</li>
                 </ol>
                 

--- a/helpers/View.php
+++ b/helpers/View.php
@@ -116,13 +116,34 @@ class View {
     
     
     /**
+     * returns global JavaScript file name (all.js)
+     *
+     * @return string all.js file name
+     */
+    public static function getGlobalJsFileName() {
+        return 'all-v' . \F3::get('version') . '.js';
+    }
+    
+    
+    /**
+     * returns global CSS file name (all.css)
+     *
+     * @return string all.css file name
+     */
+    public static function getGlobalCssFileName() {
+        return 'all-v' . \F3::get('version') . '.css';
+    }
+    
+    
+    
+    /**
      * generate minified css and js
      *
      * @return void
      */
     public function genMinifiedJsAndCss() {
         // minify js
-        $targetJs = \F3::get('BASEDIR').'/public/all.js';
+        $targetJs = \F3::get('BASEDIR').'/public/'.self::getGlobalJsFileName();
         if(!file_exists($targetJs) || \F3::get('DEBUG')!=0) {
             $js = "";
             foreach(\F3::get('js') as $file)
@@ -131,7 +152,7 @@ class View {
         }
     
         // minify css
-        $targetCss = \F3::get('BASEDIR').'/public/all.css';
+        $targetCss = \F3::get('BASEDIR').'/public/'.self::getGlobalCssFileName();
         if(!file_exists($targetCss) || \F3::get('DEBUG')!=0) {
             $css = "";
             foreach(\F3::get('css') as $file)

--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -32,7 +32,7 @@
     <?PHP if(\F3::get('use_system_font')!=true) : ?>
         <link rel="stylesheet" href="css/fonts.css" />
     <?PHP endif; ?>
-    <link rel="stylesheet" href="all.css" />
+    <link rel="stylesheet" href="<?PHP echo \helpers\View::getGlobalCssFileName(); ?>" />
 
 </head>
 <body class="
@@ -139,6 +139,6 @@
     <!-- fullscreen popup -->
     <div id="fullscreen-entry"></div>
     
-    <script src="all.js"></script>
+    <script src="<?PHP echo \helpers\View::getGlobalJsFileName(); ?>"></script>
 </body>
 </html>

--- a/templates/login.phtml
+++ b/templates/login.phtml
@@ -26,7 +26,7 @@
     <?PHP if(\F3::get('use_system_font')!=true) : ?>
         <link rel="stylesheet" href="css/fonts.css" />
     <?PHP endif; ?>
-    <link rel="stylesheet" href="all.css" />
+    <link rel="stylesheet" href="<?PHP echo \helpers\View::getGlobalCssFileName(); ?>" />
 
 </head>
 <body>
@@ -57,6 +57,6 @@
     </form>
     <?PHP endif; ?>
     
-    <script src="all.js"></script>
+    <script src="<?PHP echo \helpers\View::getGlobalJsFileName(); ?>"></script>
 </body>
 </html>

--- a/templates/opml.phtml
+++ b/templates/opml.phtml
@@ -20,7 +20,7 @@
         <link rel="apple-touch-icon" href="apple-touch-icon.png">
 
         <!-- all css definitions -->
-        <link rel="stylesheet" href="all.css">
+        <link rel="stylesheet" href="<?PHP echo \helpers\View::getGlobalCssFileName(); ?>">
     </head>
     <body id="opmlbody">
         <form method="post" enctype="multipart/form-data">
@@ -40,7 +40,7 @@
             <li class="button"><label>&nbsp;</label><input type="submit" value="Deliver my OPML!" /></li>
             </ul>
         </form>
-        <script src="all.js"></script>
+        <script src="<?PHP echo \helpers\View::getGlobalJsFileName(); ?>"></script>
         <script type="text/javascript">
             $('form').submit(function() {
                 $('input[type=submit]').prop('disabled', true).val('Importing...');


### PR DESCRIPTION
This patch adds the selfoss version to the all.js and all.css file names. This should avoid browser cache problems if the user switch to a new version.

Only the gruntfile.js must still changed. But I have no idea, how it must changed.
