### PR TITLE
Prevents an error fetching favicons.

### DIFF
--- a/defaults.ini
+++ b/defaults.ini
@@ -32,3 +32,5 @@ wallabag=
 allow_public_update_access=
 unread_order=
 load_images_on_mobile=0
+android_web_app=1
+ios_web_app=1

--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -1,30 +1,34 @@
-<!doctype html>  
+<!doctype html>
 <head>
-    <base href="<?PHP echo $this->base; ?>" /> 
+    <base href="<?PHP echo $this->base; ?>" />
 
     <meta charset="utf-8">
 
     <title>selfoss<?PHP echo $this->statsUnread>0 ? ' ('.$this->statsUnread.')' : ''; ?></title>
-    
+
     <meta name="description" content="selfoss" />
     <meta name="author" content="Tobias Zeising" />
     <meta name="version" content="<?PHP echo \F3::get('version'); ?>" />
 
     <!--  Mobile viewport optimized: j.mp/bplateviewport -->
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1" />
-    
+
     <!--  Add support for fullscreen Webapp on iPhone 5 -->
     <meta name="viewport" content="initial-scale=1, user-scalable=no, maximum-scale=1" media="(device-height: 568px)" />
-    
+
     <!-- app 'behaviour' when adding link to iDevice springboard -->
+    <?PHP if(\F3::get('ios_web_app')==1) : ?>
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    
+    <?PHP endif; ?>
+
     <!-- app 'behaviour' when adding link to Android Home  -->
+    <?PHP if(\F3::get('android_web_app')==1) : ?>
     <meta name="mobile-web-app-capable" content="yes" />
+    <?PHP endif; ?>
 
     <!--  RSS Feed -->
     <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="feed" />
-    
+
     <link rel="shortcut icon" href="favicon.ico" />
     <link rel="apple-touch-icon" href="apple-touch-icon.png" />
 
@@ -37,12 +41,12 @@
 </head>
 <body class="
     <?PHP echo $this->publicMode===true ? "publicmode" : ""; ?>
-    <?PHP echo $this->loggedin===true ? "loggedin" : "notloggedin"; ?> 
+    <?PHP echo $this->loggedin===true ? "loggedin" : "notloggedin"; ?>
     <?PHP echo \F3::get('auto_mark_as_read')==1 ? "auto_mark_as_read" : ""; ?>
 ">
-    
+
     <div id="error"></div>
-    
+
     <!-- language settings for jQuery -->
     <span id="lang"
         data-mark="<?PHP echo \F3::get('lang_mark'); ?>"
@@ -67,19 +71,19 @@
         <div id="nav-mobile-logo"></div>
         <div id="nav-mobile-settings"></div>
     </div>
-    
+
     <!-- navigation -->
     <div id="nav">
         <div id="nav-logo"></div>
         <div id="nav-mark"><?PHP echo \F3::get('lang_markread')?></div>
-        
+
         <?PHP $active = (\F3::get('homepage')) ? \F3::get('homepage') : 'newest' ?>
         <ul id="nav-filter">
             <li id="nav-filter-newest" class="nav-filter-newest<?PHP if($active=='newest') : ?> active<?PHP endif; ?>"><?PHP echo \F3::get('lang_newest')?> <span><?PHP echo $this->statsAll; ?></span></li>
             <li id="nav-filter-unread" class="nav-filter-unread<?PHP if($active=='unread') : ?> active<?PHP endif; ?>"><?PHP echo \F3::get('lang_unread')?> <span <?PHP echo $this->statsUnread>0 ? 'class="unread"' : ''; ?>><?PHP echo $this->statsUnread; ?></span></li>
             <li id="nav-filter-starred" class="nav-filter-starred<?PHP if($active=='starred') : ?> active<?PHP endif; ?>"><?PHP echo \F3::get('lang_starred') ?> <span><?PHP echo $this->statsStarred; ?></span></li>
         </ul>
-        
+
         <hr>
 
         <div id="nav-tags-wrapper">
@@ -93,33 +97,33 @@
             <?PHP echo $this->sources; ?>
         </ul>
         </div>
-        
+
         <hr>
-        
+
         <!-- navigation search input just for smartphone version -->
         <div id="nav-search">
             <input type="text" id="nav-search-term" /> <input type="button" id="nav-search-button" value="<?PHP echo \F3::get('lang_searchbutton')?>" />
             <hr>
         </div>
-        
+
         <?PHP if($this->loggedin===true && \F3::get('auth')->enabled()===false) : ?>
         <div id="nav-refresh" title="<?PHP echo trim(\F3::get('lang_refreshbutton')); ?>" class="nologin"></div>
         <div id="nav-settings" title="<?PHP echo trim(\F3::get('lang_settingsbutton')); ?>" class="nologin"></div>
         <?PHP endif; ?>
-        
+
         <?PHP if($this->loggedin===true && \F3::get('auth')->enabled()===true) : ?>
         <div id="nav-refresh" title="<?PHP echo trim(\F3::get('lang_refreshbutton')); ?>"></div>
         <div id="nav-settings" title="<?PHP echo trim(\F3::get('lang_settingsbutton')); ?>"></div>
         <div id="nav-logout" title="<?PHP echo trim(\F3::get('lang_logoutbutton')); ?>"></div>
         <?PHP endif; ?>
-        
+
         <?PHP if($this->loggedin===false) : ?>
         <div id="nav-login" title="<?PHP echo trim(\F3::get('lang_loginbutton')); ?>"></div>
         <?PHP endif; ?>
-        
+
         <a id="nav-copyright" href="http://selfoss.aditu.de" target="_blank">selfoss <?PHP echo \F3::get('version'); ?></a>
     </div>
-    
+
     <!-- search -->
     <div id="search">
         <input type="text" id="search-term" />
@@ -127,18 +131,18 @@
         <div id="search-button"></div>
         <div id="search-shownav"></div>
     </div>
-    
+
     <ul id="search-list">
     </ul>
-    
+
     <!-- content -->
     <div id="content">
         <?PHP echo $this->content; ?>
     </div>
-    
+
     <!-- fullscreen popup -->
     <div id="fullscreen-entry"></div>
-    
+
     <script src="all.js"></script>
 </body>
 </html>


### PR DESCRIPTION
When encountering a favicon `<link>` where the `href` is not enclosed
in quotes, the selfoss `ContentLoader` would fail and exit early.

For example, `<link rel="shortcut icon" href=img/favicon.ico>` would cause
the error `Undefined offset 2` in `helpers/Image.php`.  Making the regex
a bit more liberal and also checking the results of the final `preg_match`
fix this.

This fixes the issue I asked about in http://selfoss.aditu.de/forum/index.php?id=936.
