### PR TITLE
Prevents an error fetching favicons.

### DIFF
--- a/helpers/Image.php
+++ b/helpers/Image.php
@@ -162,8 +162,9 @@ class Image {
         if($result==0)
             $result = preg_match('/<link [^>]*rel=("|\')icon\1.*>/Ui', $html, $match1);
         if($result>0) {
-            preg_match('/href=("|\')(.*)\1/Ui', $match1[0], $match2);
-            return $match2[2];
+            $result = preg_match('/href=("|\')?(.+)\1?/Ui', $match1[0], $match2);
+            if($result>0)
+                return $match2[2];
         }
         
         return false;


### PR DESCRIPTION
When encountering a favicon `<link>` where the `href` is not enclosed
in quotes, the selfoss `ContentLoader` would fail and exit early.

For example, `<link rel="shortcut icon" href=img/favicon.ico>` would cause
the error `Undefined offset 2` in `helpers/Image.php`.  Making the regex
a bit more liberal and also checking the results of the final `preg_match`
fix this.

This fixes the issue I asked about in http://selfoss.aditu.de/forum/index.php?id=936.
This is also the corrected followup to the incorrectly-based PR in https://github.com/SSilence/selfoss/pull/572. 
