### PR TITLE
Allowing the hoster to disable the Android/iOS web app `<meta>` tags.

### DIFF
--- a/defaults.ini
+++ b/defaults.ini
@@ -32,5 +32,4 @@ wallabag=
 allow_public_update_access=
 unread_order=
 load_images_on_mobile=0
-android_web_app=1
-ios_web_app=1
+support_mobile_web_app=1

--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -16,13 +16,10 @@
     <!--  Add support for fullscreen Webapp on iPhone 5 -->
     <meta name="viewport" content="initial-scale=1, user-scalable=no, maximum-scale=1" media="(device-height: 568px)" />
 
+    <?PHP if(\F3::get('support_mobile_web_app')==1) : ?>
     <!-- app 'behaviour' when adding link to iDevice springboard -->
-    <?PHP if(\F3::get('ios_web_app')==1) : ?>
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <?PHP endif; ?>
-
     <!-- app 'behaviour' when adding link to Android Home  -->
-    <?PHP if(\F3::get('android_web_app')==1) : ?>
     <meta name="mobile-web-app-capable" content="yes" />
     <?PHP endif; ?>
 


### PR DESCRIPTION
I'd like to give users the option to configure whether their hosted selfoss includes the `<meta>` tags that enable web app support, while retaining them as the default behavior.  This has been a major annoyance for me, as I primarily read on Android with Chrome; however, this is _not_ really a bug in selfoss, but rather in Android Chrome.

Because selfoss was inserting the `<meta name="mobile-web-app-capable" content="yes">` tags, Chrome's "Add to Homescreen" behavior treated it as a full-screen web app.  This would typically be excellent, but on recent versions of Android Chrome, after opening a few articles to read the full content, I receive the error "Unsupported number of Chrome instances" and have to exit both the full-screen selfoss web app and my other running Chrome instance before I am able to continue reading.
