### PR TITLE
do not format long articles in columns

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -507,7 +507,7 @@ input {
             font-style: italic;
         }
 
-        .entry-content.entry-content-short {
+        .entry-content.entry-content-nocolumns {
             -moz-column-count: 1;
             -webkit-column-count: 1;
             column-count: 1;

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -95,6 +95,11 @@ selfoss.events.entries = function(e) {
 
                 // setup fancyBox image viewer
                 selfoss.setupFancyBox(content, parent.attr('id').substr(5));
+
+                // turn of column view if entry is too long
+                if(content.height() > $(window).height() ) {
+                    content.addClass('entry-content-nocolumns');
+                }
             }
             
             // load images not on mobile devices

--- a/templates/item.phtml
+++ b/templates/item.phtml
@@ -72,7 +72,7 @@
     <?PHP endif; ?>
     
     <!-- content -->
-    <div class="entry-content <?PHP if(strlen(strip_tags($content))<500) : ?>entry-content-short<?PHP endif; ?>">
+    <div class="entry-content <?PHP if(strlen(strip_tags($content))<500) : ?>entry-content-nocolumns<?PHP endif; ?>">
         <?PHP echo $content; ?>
         
         <ul class="entry-smartphone-share">


### PR DESCRIPTION
Because in order to read them when they are longer than the vertical view pane,
you need to scroll up and down and again up and down and one last time up
and down to read the three columns. It is preferable in that case not to
format in columns.

(this is #559 in a better way and with more explaination)
