### PR TITLE
within common.php set f3->('ASSETS', ..) with the full URL of the assets...

### DIFF
--- a/common.php
+++ b/common.php
@@ -8,6 +8,17 @@ $f3->set('AUTOLOAD',__dir__.'/;libs/f3/;libs/;libs/WideImage/;daos/;libs/twitter
 $f3->set('cache',__dir__.'/data/cache');
 $f3->set('BASEDIR',__dir__);
 $f3->set('LOCALES',__dir__.'/public/lang/');
+//If the website is loaded through HTTPS we set the full URL (which does not natively work when using apache2 as back-end and nginx as front-end).
+$assets = "http";
+  if( (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) && $_SERVER['HTTP_X_FORWARDED_PROTO']=="https" ||
+      (isset($_SERVER['HTTP_HTTPS'])) && $_SERVER['HTTP_HTTPS']=="https")
+  {
+    $assets .= "s";
+  } else {
+    $assets .= "";
+  }
+  $assets .= "://".$_SERVER['HTTP_HOST'].'/';
+$f3->set('ASSETS', $assets);
 
 // read defaults
 $f3->config('defaults.ini');

--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -23,24 +23,23 @@
     <meta name="mobile-web-app-capable" content="yes" />
 
     <!--  RSS Feed -->
-    <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="feed" />
+    <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="<?PHP echo \F3::get('ASSETS') ?>feed" />
     
-    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="shortcut icon" href="<?PHP echo \F3::get('ASSETS') ?>favicon.ico" />
     <link rel="apple-touch-icon" href="apple-touch-icon.png" />
 
     <!-- all css definitions -->
     <?PHP if(\F3::get('use_system_font')!=true) : ?>
-        <link rel="stylesheet" href="css/fonts.css" />
+        <link rel="stylesheet" href="<?PHP echo \F3::get('ASSETS') ?>css/fonts.css" />
     <?PHP endif; ?>
-    <link rel="stylesheet" href="<?PHP echo \helpers\View::getGlobalCssFileName(); ?>" />
+    <link rel="stylesheet" href="<?PHP echo \F3::get('ASSETS').\helpers\View::getGlobalCssFileName(); ?>" />
 
 </head>
 <body class="
     <?PHP echo $this->publicMode===true ? "publicmode" : ""; ?>
     <?PHP echo $this->loggedin===true ? "loggedin" : "notloggedin"; ?> 
     <?PHP echo \F3::get('auto_mark_as_read')==1 ? "auto_mark_as_read" : ""; ?>
-">
-    
+">    
     <div id="error"></div>
     
     <!-- language settings for jQuery -->
@@ -140,6 +139,6 @@
     <!-- fullscreen popup -->
     <div id="fullscreen-entry"></div>
     
-    <script src="<?PHP echo \helpers\View::getGlobalJsFileName(); ?>"></script>
+    <script src="<?PHP echo \F3::get('ASSETS').\helpers\View::getGlobalJsFileName(); ?>"></script>
 </body>
 </html>

--- a/templates/login.phtml
+++ b/templates/login.phtml
@@ -19,18 +19,17 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
 
     <!-- Place favicon.ico & apple-touch-icon.png in the root of your domain and delete these references -->
-    <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="apple-touch-icon" href="apple-touch-icon.png" />
+    <link rel="shortcut icon" href="<?PHP echo \F3::get('ASSETS') ?>favicon.ico" />
+    <link rel="apple-touch-icon" href="<?PHP echo \F3::get('ASSETS') ?>apple-touch-icon.png" />
 
     <!-- all css definitions -->
     <?PHP if(\F3::get('use_system_font')!=true) : ?>
-        <link rel="stylesheet" href="css/fonts.css" />
+        <link rel="stylesheet" href="<?PHP echo \F3::get('ASSETS') ?>css/fonts.css" />
     <?PHP endif; ?>
-    <link rel="stylesheet" href="<?PHP echo \helpers\View::getGlobalCssFileName(); ?>" />
+    <link rel="stylesheet" href="<?PHP echo <?PHP echo \F3::get('ASSETS') ?>.\helpers\View::getGlobalCssFileName(); ?>" />
 
 </head>
 <body>
-
     <?PHP if(!isset($this->password)) : ?>
     <form action="<?PHP echo $this->base; ?>?login=1" method="post">
     <ul id="login">
@@ -57,6 +56,6 @@
     </form>
     <?PHP endif; ?>
     
-    <script src="<?PHP echo \helpers\View::getGlobalJsFileName(); ?>"></script>
+    <script src="<?PHP echo \F3::get('ASSETS').\helpers\View::getGlobalJsFileName(); ?>"></script>
 </body>
 </html>


### PR DESCRIPTION
According to some use-cases with apache2/nginx proposes client resource through http instead of https. This includes all `href` and `src` ressources. Chromium, by default, block (security reasons) this ressources.

Note that I don't know if the proposed patch is the cleanest way of doing this, but it works (as far as I tested it).

Feel free to demand any changes to make it proper I would be glad to help more !
