### PR TITLE
When front-end nginx (through https:443) forward to apache2 (through htt...

### DIFF
--- a/helpers/View.php
+++ b/helpers/View.php
@@ -48,14 +48,19 @@ class View {
             $subdir = $lastSlash!==false ? substr($_SERVER['SCRIPT_NAME'], 0, $lastSlash) : '';
             
             $protocol = 'http';
-            if (isset($_SERVER["HTTPS"]) && ($_SERVER["HTTPS"]=="on" || $_SERVER["HTTPS"]==1))
+            if (isset($_SERVER["HTTPS"]) && ($_SERVER["HTTPS"]=="on" || $_SERVER["HTTPS"]==1) ||
+               (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) && $_SERVER['HTTP_X_FORWARDED_PROTO']=="https" ||
+               (isset($_SERVER['HTTP_HTTPS'])) && $_SERVER['HTTP_HTTPS']=="https")
                 $protocol = 'https';
             
             $port = '';
             if (($protocol == 'http' && $_SERVER["SERVER_PORT"]!="80") ||
                 ($protocol == 'https' && $_SERVER["SERVER_PORT"]!="443"))
                 $port = ':' . $_SERVER["SERVER_PORT"];
-            
+            //Override the port if nginx is the front end and the traffic is being forwarded
+            if (isset($_SERVER["HTTP_X_FORWARDED_PORT"]))
+                $port = ':' . $_SERVER["HTTP_X_FORWARDED_PORT"];
+
             $base = $protocol . '://' . $_SERVER["SERVER_NAME"] . $port . $subdir . '/';
         }
         


### PR DESCRIPTION
According to some use-cases with apache2/nginx proposes client resource through http instead of https. This includes all `href` and `src` ressources. Web browser, by default, block (security reasons) theses ressources.

As [asked](https://github.com/SSilence/selfoss/pull/582#issuecomment-58396733) I put the changes (lighter btw) at the right place.

Note that nginx front-end users need to location as this:

```
      location / {
         proxy_set_header X-Nginx-Scheme $scheme;
          proxy_set_header X-Forwarded-Port $server_port;
          proxy_pass   http://<whatever IP you need>:<whatever port you need>/;
          include      /etc/nginx/proxy.conf;
      }
```

I think it good to pull now :) :bug: (otherwise, just ask)
