### PR TITLE
change UTF-8 decoding

### DIFF
--- a/controllers/Rss.php
+++ b/controllers/Rss.php
@@ -96,7 +96,8 @@ class Rss extends BaseController {
             $contents[$o] = $this->unicode_entity_replace($contents[$o]);
             $swap .= $contents[$o];
         }
-        return mb_convert_encoding($swap,"UTF-8"); //not really necessary, but why not.
+        return html_entity_decode($swap, ENT_NOQUOTES, 'UTF-8'); //convert HTML-entities like &#8211; to UTF-8
+        
     }
 
     private function unicode_string_to_array( $string ) { //adjwilli


### PR DESCRIPTION
I saw a lot of HTML-entities like & #8211; in the RSS-Feed so I changed mb_convert_encoding to html_entity_decode with parameter "UTF-8". This brings much better results.
