### PR TITLE
Add session keep alive

### DIFF
--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -170,6 +170,20 @@ class Index extends BaseController {
     
     
     /**
+     * keep session alive by actually doing nothing...
+     * json
+     *
+     * @return void
+     */
+    public function keepAlive() {
+        $this->view->jsonSuccess(array(
+            'publicMode' => ((\F3::get('auth')->isLoggedin() !== true) && (\F3::get('public') == 1)),
+            'loggedin' => (\F3::get('auth')->isLoggedin() === true)
+        ));
+    }
+    
+    
+    /**
      * update feeds
      * text
      *

--- a/index.php
+++ b/index.php
@@ -46,24 +46,25 @@ $f3->set('css', $css);
 // define routes
 
 // all users
-$f3->route('GET /',           'controllers\Index->home');     // html
-$f3->route('POST /',          'controllers\Index->home');     // html
-$f3->route('GET /password',   'controllers\Index->password'); // html
-$f3->route('POST /password',  'controllers\Index->password'); // html
-$f3->route('GET /login',      'controllers\Index->login');    // json
-$f3->route('GET /logout',     'controllers\Index->logout');   // json
-$f3->route('GET /update',     'controllers\Index->update');   // text
-$f3->route('GET /badge',      'controllers\Index->badge');    // xml
-$f3->route('GET /win8notifs', 'controllers\Index->win8Notifications');    // xml
+$f3->route('GET /',           'controllers\Index->home');                     // html
+$f3->route('POST /',          'controllers\Index->home');                     // html
+$f3->route('GET /password',   'controllers\Index->password');                 // html
+$f3->route('POST /password',  'controllers\Index->password');                 // html
+$f3->route('GET /login',      'controllers\Index->login');                    // json
+$f3->route('GET /logout',     'controllers\Index->logout');                   // json
+$f3->route('GET /keepAlive',  'controllers\Index->keepAlive');                // json
+$f3->route('GET /update',     'controllers\Index->update');                   // text
+$f3->route('GET /badge',      'controllers\Index->badge');                    // xml
+$f3->route('GET /win8notifs', 'controllers\Index->win8Notifications');        // xml
 
 // only for loggedin users or on public mode
-$f3->route('GET /rss',           'controllers\Rss->rss');           // rss
-$f3->route('GET /feed',          'controllers\Rss->rss');           // rss
-$f3->route('GET /items',         'controllers\Items->listItems');   // json
-$f3->route('GET /tags',          'controllers\Tags->listTags');     // json
-$f3->route('GET /tagslist',      'controllers\Tags->tagslist');     // html
-$f3->route('GET /stats',         'controllers\Items->stats');       // json
-$f3->route('GET /sources/stats', 'controllers\Sources->stats');     // json
+$f3->route('GET /rss',           'controllers\Rss->rss');                     // rss
+$f3->route('GET /feed',          'controllers\Rss->rss');                     // rss
+$f3->route('GET /items',         'controllers\Items->listItems');             // json
+$f3->route('GET /tags',          'controllers\Tags->listTags');               // json
+$f3->route('GET /tagslist',      'controllers\Tags->tagslist');               // html
+$f3->route('GET /stats',         'controllers\Items->stats');                 // json
+$f3->route('GET /sources/stats', 'controllers\Sources->stats');               // json
 
 // only loggedin users
 $f3->route('POST /mark/@item',          'controllers\Items->mark');           // json

--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -20,11 +20,16 @@ var selfoss = {
         source: '',
         ajax: true
     },
-
+    
     /**
      * instance of the currently running XHR that is used to reload the items list
      */
     activeAjaxReq: null,
+    
+    /**
+     * interval ID of session keep alive
+     */
+    keepAliveIntervalID: null,
     
     /**
      * initialize application
@@ -36,7 +41,10 @@ var selfoss = {
                 $('#username').focus();
                 return;
             }
-        
+            
+            // init session keep alive
+            selfoss.keepAliveIntervalID = setInterval(selfoss.keepAlive, 590000);
+            
             // set items per page
             selfoss.filter.itemsPerPage = $('#config').data('items_perpage');
             
@@ -48,6 +56,30 @@ var selfoss = {
             
             // init shortcut handler
             selfoss.shortcuts.init();
+        });
+    },
+    
+    
+    /**
+     * keep session alive by sending periodic ajax requests
+     *
+     * @return void
+     */
+    keepAlive: function() {
+        $.ajax({
+            url: $('base').attr('href') + 'keepAlive',
+            type: 'GET',
+            dataType: 'json',
+            success: function(data, textStatus, jqXHR) {
+                // neither logged in nor in public mode
+                // redirect to login page
+                if (!data.publicMode && !data.loggedin) {
+                    location.reload();
+                }
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                clearInterval(selfoss.keepAliveIntervalID);
+            }
         });
     },
     


### PR DESCRIPTION
Send periodic AJAX requests to keep the session alive. About every 10 minutes a request is sent, which actually does nothing, but prevents PHP from garbage collecting the session file. When the user is neither logged in nor Selfoss is in public mode, the users session expired and can't be re-initialized automatically, as it would be possible in public mode. If this is the case, reload the page, which will present the login form.