### PR TITLE
Fix login auth loop due to cookie not being set over HTTP

### DIFF
--- a/helpers/Authentication.php
+++ b/helpers/Authentication.php
@@ -28,7 +28,7 @@ class Authentication {
     
         // session cookie will be valid for one month.
         $cookie_expire = 3600*24*30;
-        $cookie_secure = isset($_SERVER['HTTPS']) && "off"!==$_SERVER['HTTPS'];
+        $cookie_secure = isset($_SERVER['HTTPS']) && !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS']!=="off";
         $cookie_httponly = true;
 
         // check for SSL proxy and special cookie options


### PR DESCRIPTION
Under certain conditions the server may set `$_SERVER['HTTPS']` but it will be empty ([this is expected](http://php.net/manual/en/reserved.variables.server.php)) and it would be `"off"` only in some cases.

Because of this, the cookie isn't set and the user experiences a login loop with no error whatsoever, as previously commented on issue #581 and [on the selfoss support forum](http://selfoss.aditu.de/forum/index.php?id=530).

This pull request fixes the issue checking if `$_SERVER['HTTPS']` is empty.