### PR TITLE
allow target attribute

### DIFF
--- a/helpers/ContentLoader.php
+++ b/helpers/ContentLoader.php
@@ -251,7 +251,7 @@ class ContentLoader {
         return htmLawed(
             htmlspecialchars_decode($value),
             array(
-                "deny_attribute" => '* -href -title',
+                "deny_attribute" => '* -href -title -target',
                 "elements"       => 'a,br,ins,del,b,i,strong,em,tt,sub,sup,s,code'
             )
         );


### PR DESCRIPTION
Allowing the target attribute within sanitizeField enables hyperlinks in titles to be opened in a new browser tab. This is especially useful for links within tweets.