### PR TITLE
Config from env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ config.ini
 .project
 node_modules
 _wiki
+.env

--- a/_docs/website/index.html
+++ b/_docs/website/index.html
@@ -308,6 +308,10 @@ db_port=3306</code>
                         <td class="documentation-first-column">auto_hide_read_on_mobile</td>
                         <td>hide read articles on mobile devices</td>
                     </tr>
+                    <tr>
+                        <td class="documentation-first-column">env_prefix</td>
+                        <td>only consider ENV variables that start with this prefix as additional config variables. Defaults to "SELFOSS_".</td>
+                    </tr>
                 </table>
             </div>
             

--- a/common.php
+++ b/common.php
@@ -16,6 +16,14 @@ $f3->config('defaults.ini');
 if(file_exists('config.ini'))
     $f3->config('config.ini');
 
+// overwrite config with ENV variables
+foreach($f3->get('ENV') as $key => $value) {
+    $env_prefix = $f3->get('env_prefix');
+    if(strncasecmp($key,$env_prefix,strlen($env_prefix)) == 0) {
+        $f3->set(strtolower(substr($key,strlen($env_prefix))),$value);
+    }
+}
+
 // init logger
 $f3->set(
     'logger',

--- a/common.php
+++ b/common.php
@@ -17,8 +17,8 @@ if(file_exists('config.ini'))
     $f3->config('config.ini');
 
 // overwrite config with ENV variables
+$env_prefix = $f3->get('env_prefix');
 foreach($f3->get('ENV') as $key => $value) {
-    $env_prefix = $f3->get('env_prefix');
     if(strncasecmp($key,$env_prefix,strlen($env_prefix)) == 0) {
         $f3->set(strtolower(substr($key,strlen($env_prefix))),$value);
     }

--- a/defaults.ini
+++ b/defaults.ini
@@ -33,3 +33,5 @@ allow_public_update_access=
 unread_order=
 load_images_on_mobile=0
 auto_hide_read_on_mobile=0
+env_prefix=selfoss_
+


### PR DESCRIPTION
I am preparing to run selfoss in a PaaS like Heroku. For that it must be possible to configure the app - at least partially - through ENV variables.

Even if I would bundle it up using Docker with configuration files, one would have to build a new Docker image upon mine to have his/her own config. (E.g. to change the salt, the username/password, the db credentials and so on)

That's why I implemented an easy way to set selfoss config variables though ENV variables. To prevent accidental conflicts the variables, by default, must be prefixed with a configurable prefix. I have pre-defined that prefix in defaults.ini to be "SELFOSS_". (The prefix check is case insensitive and the variable will be converted to lower case before adding it to f3.)

It would be nice to see this change integrated into the main stream.