### PR TITLE
F3 would not launch when "magic_quotes_gpc" is not set.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -21,6 +21,11 @@ RewriteRule !public - [C]
 RewriteRule !index.php - [C]
 RewriteRule (.*) public/$1 [L]
 
+# set magic_quotes_gpc as f3 wouldn't start otherwise
+<IfModule mod_php5.c>
+    php_value magic_quotes_gpc "1"
+</IfModule>
+
 # deny requests for config files
 <FilesMatch ".(ini)$">
     Order allow,deny


### PR DESCRIPTION
Although magic_quotes_gpc was removed from recent PHP versions, f3 would not start without this property set. This patch fixes setups where this property is not set.

And because it is deprecated or removed, it does not matter if we overwrite it accidentally.