### PR TITLE
New webclient helper

### DIFF
--- a/helpers/ContentLoader.php
+++ b/helpers/ContentLoader.php
@@ -163,6 +163,7 @@ class ContentLoader {
             try {
                 $icon = $item->getIcon();
             } catch(\exception $e) {
+                \F3::get('logger')->log('icon: error ' . $e->getMessage(), \DEBUG);
                 return;
             }
 

--- a/helpers/Image.php
+++ b/helpers/Image.php
@@ -38,7 +38,13 @@ class Image {
         $urlElements = parse_url($url);
 
         // search on base page for <link rel="shortcut icon" url...
-        $html = @file_get_contents($url);
+        $html = null;
+        try {
+            $html = \helpers\WebClient::request($url);
+        }catch( \exception $e ) {
+            \F3::get('logger')->log("icon: failed to get html page: ".$e->getMessage(), \DEBUG);
+        }
+
         $shortcutIcon = $this->parseShortcutIcon($html);
         if($shortcutIcon!==false) {
             if(substr($shortcutIcon,0,4)!='http') {
@@ -82,9 +88,13 @@ class Image {
      */
     public function loadImage($url, $extension='png', $width=false, $height=false) {
         // load image
-        $data = @file_get_contents($url);
-        if($data===false)
+        try{
+            $data = \helpers\WebClient::request($url);
+        }
+        catch ( \exception $e ) {
+            \F3::get('logger')->log("failed to retrieve image $url," . $e->getMessage(), \ERROR);
             return false;
+        }
         
         // get image type
         $tmp = \F3::get('cache') . '/' . md5($url);

--- a/helpers/WebClient.php
+++ b/helpers/WebClient.php
@@ -1,0 +1,59 @@
+<?PHP
+namespace helpers;
+
+/**
+ * Helper class for web request
+ *
+ * @package    helpers
+ * @copyright  Copyright (c) Tobias Zeising (http://www.aditu.de)
+ * @license    GPLv3 (http://www.gnu.org/licenses/gpl-3.0.html)
+ * @author     Alexandre Rossi <alexandre.rossi@gmail.com>
+ */
+class WebClient {
+    /**
+     * get the user agent to use for web based spouts
+     *
+     * @return the user agent string for this spout
+     */
+    public static function getUserAgent($agentInfo=null){
+        $userAgent = 'Selfoss/'.\F3::get('version');
+
+        if( is_null($agentInfo) )
+            $agentInfo = array();
+
+        $agentInfo[] = '+http://selfoss.aditu.de';
+
+        return $userAgent.' ('.implode('; ', $agentInfo).')';
+    }
+    
+    
+    /**
+     * Retrieve content from url
+     *
+     * @param string $subagent Extra user agent info to use in the request
+     * @return request data
+     */
+    public static function request($url, $agentInfo=null) {
+        $options  = array(
+            'user_agent' => self::getUserAgent($agentInfo),
+            'ignore_errors' => true,
+            'timeout' => 60
+        );
+        $request = \Web::instance()->request($url, $options);
+
+        // parse last (in case of redirects) HTTP status
+        $http_status = null;
+        foreach( $request['headers'] as $header ) {
+            if( substr($header, 0, 5) == 'HTTP/' ) {
+                $tokens = explode(' ', $header);
+                if( isset($tokens[1]) )
+                    $http_status = $tokens[1];
+            }
+        }
+
+        if( $http_status != '200' ) {
+            throw new \exception(substr($request['body'], 0, 512));
+        }
+        return $request['body'];
+    }
+}

--- a/libs/f3/web.php
+++ b/libs/f3/web.php
@@ -256,8 +256,6 @@ class Web extends Prefab {
 		curl_setopt($curl,CURLOPT_CUSTOMREQUEST,$options['method']);
 		if (isset($options['header']))
 			curl_setopt($curl,CURLOPT_HTTPHEADER,$options['header']);
-		if (isset($options['user_agent']))
-			curl_setopt($curl,CURLOPT_USERAGENT,$options['user_agent']);
 		if (isset($options['content']))
 			curl_setopt($curl,CURLOPT_POSTFIELDS,$options['content']);
 		curl_setopt($curl,CURLOPT_ENCODING,'gzip,deflate');
@@ -470,7 +468,9 @@ class Web extends Prefab {
 		$this->subst($options['header'],
 			array(
 				'Accept-Encoding: gzip,deflate',
-				'User-Agent: Mozilla/5.0 (compatible; '.php_uname('s').')',
+				'User-Agent: '.(isset($options['user_agent'])?
+					$options['user_agent']:
+					'Mozilla/5.0 (compatible; '.php_uname('s').')'),
 				'Connection: close'
 			)
 		);

--- a/spouts/github/commits.php
+++ b/spouts/github/commits.php
@@ -285,24 +285,17 @@ class commits extends \spouts\spout {
      * @return object JSON object
      */
     public function getJsonContent($url) {
-        $options  = array('http' => array(
-            'user_agent' => $this->getUserAgent(),
-            'ignore_errors' => true,
-            'timeout' => 60
-        ));
-
-        $request = \Web::instance()->request($url, $options);
-
-        if( $request['headers'][0] != 'HTTP/1.1 200 OK' ) {
-            throw new \exception('github spout error ' . $request['headers'][0] . ': ' . substr($request['body'], 0, 512));
+        $content = null;
+        try {
+            $content = \helpers\WebClient::request($url);
+        }catch( \exception $e ) {
+            throw new \exception('github spout error ' . $e->getMessage());
         }
-
-        $content = $request['body'];
 
         $json = @json_decode($content);
         
         if (empty($json)) {
-            throw new \exception('github spout error ' . $request['headers'][0] . ': empy json');
+            throw new \exception('github spout error: empy json');
         }
         
         return $json;

--- a/spouts/rss/feed.php
+++ b/spouts/rss/feed.php
@@ -153,7 +153,7 @@ class feed extends \spouts\spout {
         @$this->feed->set_cache_duration(1800);
         @$this->feed->set_feed_url(htmlspecialchars_decode($params['url']));
         @$this->feed->set_autodiscovery_level( SIMPLEPIE_LOCATOR_AUTODISCOVERY | SIMPLEPIE_LOCATOR_LOCAL_EXTENSION | SIMPLEPIE_LOCATOR_LOCAL_BODY);
-        $this->feed->set_useragent($this->getUserAgent(array('SimplePie/'.SIMPLEPIE_VERSION)));
+        $this->feed->set_useragent(\helpers\WebClient::getUserAgent(array('SimplePie/'.SIMPLEPIE_VERSION)));
          
         // fetch items
         @$this->feed->init();

--- a/spouts/spout.php
+++ b/spouts/spout.php
@@ -59,24 +59,6 @@ abstract class spout implements \Iterator {
 
 
     /**
-     * get the user agent to use for web based spouts
-     *
-     * @return the user agent string for this spout
-     */
-    protected function getUserAgent($agentInfo=null){
-        $userAgent = 'Selfoss/'.\F3::get('version');
-
-        if( is_null($agentInfo) )
-            $agentInfo = array();
-
-        $agentInfo[] = $this->name.' spout';
-        $agentInfo[] = '+http://selfoss.aditu.de';
-
-        return $userAgent.' ('.implode('; ', $agentInfo).')';
-    }
-    
-    
-    /**
      * loads content for given source
      *
      * @return void


### PR DESCRIPTION
This helper can replace all custom curl calls in spouts. It uses f3 internals, so it can use sockets, curl or file_get_contents(), and it logs and throws errors as exceptions.