### PR TITLE
Allow configuration of html <title>

### DIFF
--- a/defaults.ini
+++ b/defaults.ini
@@ -17,6 +17,7 @@ username=
 password=
 salt=lkjl1289
 public=
+html_title=selfoss
 rss_title=selfoss feed
 rss_max_items=300
 rss_mark_as_read=0

--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -31,7 +31,11 @@ var selfoss = {
      * last stats update
      */
     lastStatsUpdate: Date.now(),
-
+    
+    /**
+     * the html title configured
+     */
+    htmlTitle: 'selfoss',
 
     /**
      * initialize application
@@ -49,7 +53,10 @@ var selfoss = {
             
             // initialize type by homepage config param
             selfoss.filter.type = $('#nav-filter li.active').attr('id').replace('nav-filter-', '');
-            
+
+            // read the html title configured
+            selfoss.htmlTitle = $('#config').data('html_title')
+
             // init shares
             selfoss.shares.init();
 
@@ -264,10 +271,10 @@ var selfoss = {
         // title
         if(unread>0) {
             $('span.unread-count').addClass('unread');
-            $(document).attr('title', 'selfoss ('+unread+')');
+            $(document).attr('title', selfoss.htmlTitle+' ('+unread+')');
         } else {
             $('span.unread-count').removeClass('unread');
-            $(document).attr('title', 'selfoss');
+            $(document).attr('title', selfoss.htmlTitle);
         }
     },
 

--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -4,7 +4,7 @@
 
     <meta charset="utf-8">
 
-    <title>selfoss<?PHP echo $this->statsUnread>0 ? ' ('.$this->statsUnread.')' : ''; ?></title>
+    <title><?PHP echo trim(\F3::get('html_title')); echo $this->statsUnread>0 ? ' ('.$this->statsUnread.')' : ''; ?></title>
     
     <meta name="description" content="selfoss" />
     <meta name="author" content="Tobias Zeising" />

--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -72,7 +72,8 @@
         data-auto_stream_more="<?PHP echo \F3::get('auto_stream_more'); ?>"
         data-load_images_on_mobile="<?PHP echo \F3::get('load_images_on_mobile'); ?>"
         data-items_perpage="<?PHP echo \F3::get('items_perpage'); ?>"
-        data-auto_hide_read_on_mobile="<?PHP echo \F3::get('auto_hide_read_on_mobile'); ?>"></span>
+        data-auto_hide_read_on_mobile="<?PHP echo \F3::get('auto_hide_read_on_mobile'); ?>"
+        data-html_title="<?PHP echo trim(\F3::get('html_title')); ?>"></span>
 
     <!-- menue open for smartphone -->
     <div id="nav-mobile">

--- a/templates/login.phtml
+++ b/templates/login.phtml
@@ -4,7 +4,7 @@
 
     <meta charset="utf-8">
 
-    <title>selfoss</title>
+    <title><?PHP echo trim(\F3::get('html_title')); ?></title>
     
     <meta name="description" content="selfoss" />
     <meta name="author" content="Tobias Zeising" />

--- a/templates/opml.phtml
+++ b/templates/opml.phtml
@@ -4,7 +4,7 @@
 
         <meta charset="utf-8">
 
-        <title>selfoss</title>
+        <title><?PHP echo trim(\F3::get('html_title')); ?></title>
         
         <meta name="description" content="selfoss">
         <meta name="author" content="Tobias Zeising">


### PR DESCRIPTION
When running multiple installations of selfoss all installations show the same HTML title. I've added a configuration that defaults to 'selfoss' but can be overriden by the user so one is able to differentiate between different installations depending on the title.