### PR TITLE
"$HTTP_RAW_POST_DATA is deprecated" error

### DIFF
--- a/public/js/selfoss-events-entriestoolbar.js
+++ b/public/js/selfoss-events-entriestoolbar.js
@@ -90,6 +90,7 @@ selfoss.events.entriesToolbar = function(parent) {
             
             $.ajax({
                 url: $('base').attr('href') + (starr ? 'starr/' : 'unstarr/') + id,
+                data: { ajax: true },
                 type: 'POST',
                 error: function(jqXHR, textStatus, errorThrown) {
                     // rollback ui changes


### PR DESCRIPTION
As of PHP 5.6, `$HTTP_RAW_POST_DATA` is deprecated. Sending a POST request without Content-Type populates `$HTTP_RAW_POST_DATA`, which triggers an `E_DEPRECATED`.

It makes the Star / Unstar button fail:

Request:
```
POST /selfoss/starr/26110 HTTP/1.1
Host: ...
Connection: keep-alive
Content-Length: 0
Accept: */*
Origin: ...
X-Requested-With: XMLHttpRequest
User-Agent: Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2398.0 Safari/537.36
DNT: 1
Referer: ...
Accept-Encoding: gzip, deflate
Accept-Language: fr,en-US;q=0.8,en;q=0.6
Cookie: PHPSESSID=...
```

Response headers:
```
HTTP/1.1 500 Internal Server Error
Server: nginx/1.6.0
Date: Tue, 19 May 2015 07:40:49 GMT
Content-Type: text/html; charset=UTF-8
Transfer-Encoding: chunked
Connection: keep-alive
X-Powered-By: PHP/5.6.8

{"status":"Internal Server Error","code":500,"text":"Fatal error: Automatically populating $HTTP_RAW_POST_DATA is deprecated and will be removed in a future version. To avoid this warning set 'always_populate_raw_post_data' to '-1' in php.ini and use the php:\/\/input stream instead.","trace":[]}
```

A `data` key was added with `{ ajax: true }`, in order to be consistent with the second AJAX call in selfoss-events-entriestoolbar.js (line 182). Adding `contentType: 'application/x-www-form-urlencoded; charset=UTF-8'` would work too.