### PR TITLE
"$HTTP_RAW_POST_DATA is deprecated" error when deleting a source

### DIFF
--- a/public/js/selfoss-events-sources.js
+++ b/public/js/selfoss-events-sources.js
@@ -119,6 +119,7 @@ selfoss.events.sources = function() {
         // delete on server
         $.ajax({
             url: $('base').attr('href')+'source/delete/'+id,
+            data: { ajax: true },
             type: 'POST',
             success: function() {
                 parent.fadeOut('fast', function() {


### PR DESCRIPTION
Same as #664, but when deleting a source.
Fixes the second part of #643.