### PR TITLE
inline and resize emojis to fit into text flow

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1376,3 +1376,6 @@ body.publicmode.notloggedin .entry-unread {
 .fancybox-overlay {
     background: url('images/fancybox_overlay.png');
 }
+
+/* emojis */
+img[src^='http://s.w.org/images/core/emoji']{display:inline;height: 1em;margin: 0;}


### PR DESCRIPTION
According to gained knowledge in #671 this makes wordpress smilies integrate into continuous text more smoothly