### PR TITLE
Use the date specified by the items as the date of the last entry

### DIFF
--- a/daos/mysql/Sources.php
+++ b/daos/mysql/Sources.php
@@ -134,7 +134,7 @@ class Sources extends Database {
      * @return mixed all sources
      */
     public function getByLastUpdate() {
-        $ret = \F3::get('db')->exec('SELECT id, title, tags, spout, params, filter, error, lastupdate FROM '.\F3::get('db_prefix').'sources ORDER BY lastupdate ASC');
+        $ret = \F3::get('db')->exec('SELECT id, title, tags, spout, params, filter, error, lastupdate, lastentry FROM '.\F3::get('db_prefix').'sources ORDER BY lastupdate ASC');
         $spoutLoader = new \helpers\SpoutLoader();
         for($i=0;$i<count($ret);$i++)
             $ret[$i]['spout_obj'] = $spoutLoader->get( $ret[$i]['spout'] );

--- a/daos/mysql/Sources.php
+++ b/daos/mysql/Sources.php
@@ -108,20 +108,20 @@ class Sources extends Database {
      *
      * @return void
      * @param int $id the source id
-     * @param boolean newPostAdded true or false depending on whether a post was added
+     * @param int $lastEntry timestamp of the newest item or NULL when no items were added
      */
-    public function saveLastUpdate($id, $newPostAdded) {
+    public function saveLastUpdate($id, $lastEntry) {
         \F3::get('db')->exec('UPDATE '.\F3::get('db_prefix').'sources SET lastupdate=:lastupdate WHERE id=:id',
                     array(
                         ':id'         => $id,
                         ':lastupdate' => time()
                     ));
         
-        if ($newPostAdded == TRUE) {
+        if ($lastEntry !== null) {
         	\F3::get('db')->exec('UPDATE '.\F3::get('db_prefix').'sources SET lastentry=:lastentry WHERE id=:id',
         			array(
         					':id'         => $id,
-        					':lastentry' => time()
+        					':lastentry' => $lastEntry
         			));
         }
         


### PR DESCRIPTION
Instead of assuming that the date of the last entry is the same as the date of the last update that added new items (what could be horribly wrong...), we can use the date specified by the newest item itself.

As suggested by @niol (https://github.com/SSilence/selfoss/pull/679#issuecomment-116114194); see https://github.com/SSilence/selfoss/pull/679#discussion_r33422101