### PR TITLE
Set Default value for updatetime on MYSQL

### DIFF
--- a/daos/mysql/Database.php
+++ b/daos/mysql/Database.php
@@ -56,7 +56,7 @@ class Database {
                         source INT NOT NULL ,
                         uid VARCHAR(255) NOT NULL,
                         link TEXT NOT NULL,
-                        updatetime DATETIME NOT NULL,
+                        updatetime DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                         author VARCHAR(255),
                         INDEX (source)
                     ) ENGINE = InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Mysql Database didn't have default value for table **Item** field **updatetime** and this is required for the correct functionality of the application.