### PR TITLE
Add support for private (@) and hidden (#) tags

### DIFF
--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -49,7 +49,16 @@ class Index extends BaseController {
         $this->view->statsAll = $stats['total'];
         $this->view->statsUnread = $stats['unread'];
         $this->view->statsStarred = $stats['starred'];
-        
+
+        if ($tagsDao->hasTag("#")) {
+		foreach ($tags as $tag) {
+			if (strcmp($tag["tag"], "#") !== 0) {
+				continue;
+			}
+			$this->view->statsUnread -= $tag["unread"];
+		}
+	}
+
         // prepare tags display list
         $tagsController = new \controllers\Tags();
         $this->view->tags = $tagsController->renderTags($tags);

--- a/controllers/Items.php
+++ b/controllers/Items.php
@@ -146,6 +146,18 @@ class Items extends BaseController {
 
         $itemsDao = new \daos\Items();
         $stats = $itemsDao->stats();
+	$stats['unread'] -= $itemsDao->numberOfUnreadForTag("#");
+
+	$tagsDao = new \daos\Tags();
+	$tags = $tagsDao->getWithUnread();
+        if ($tagsDao->hasTag("#")) {
+            foreach ($tags as $tag) {
+                if (strcmp($tag["tag"], "#") !== 0) {
+                    continue;
+                }
+                $stats['unread'] -= $tag["unread"];
+            }
+        }
 
         if( array_key_exists('tags', $_GET) && $_GET['tags'] == 'true' ) {
             $tagsDao = new \daos\Tags();

--- a/daos/Items.php
+++ b/daos/Items.php
@@ -80,6 +80,28 @@ class Items extends Database {
             $options
         );
         
-        return $this->backend->get($options);
+        $items = $this->backend->get($options);
+
+        // remove private posts with private tags
+        if(!\F3::get('auth')->showPrivateTags()) {
+            foreach($items as $idx => $item) {
+                if (strpos($item['tags'], "@") !== false) {
+                    unset($items[$idx]);
+                }
+            }
+            $items = array_values($items);
+        }
+
+        // remove posts with hidden tags
+        if(!isset($options['tag']) || strlen($options['tag']) === 0) {
+            foreach($items as $idx => $item) {
+                if (strpos($item['tags'], "#") !== false) {
+                    unset($items[$idx]);
+                }
+            }
+            $items = array_values($items);
+        }
+
+        return $items;
     }
 }

--- a/daos/Sources.php
+++ b/daos/Sources.php
@@ -47,6 +47,20 @@ class Sources extends Database {
             \F3::get('logger')->log('Unimplemented method for ' . \F3::get('db_type') . ': ' . $name, \ERROR);
     }
     
+    public function get() {
+        $sources = $this->backend->get();
+        // remove items with private tags
+        if(!\F3::get('auth')->showPrivateTags()) {
+            foreach($sources as $idx => $source) {
+                if (strpos($source['tags'], "@") !== false) {
+                    unset($sources[$idx]);
+                }
+            }
+            $sources = array_values($sources);
+        }
+        
+        return $sources;
+    }
     
     /**
      * validate new data for a given source

--- a/daos/Tags.php
+++ b/daos/Tags.php
@@ -30,7 +30,21 @@ class Tags extends Database {
         $this->backend = new $class();
         parent::__construct();
     }
-    
+
+    public function get() {
+        $tags = $this->backend->get();
+        // remove items with private tags
+        if(!\F3::get('auth')->showPrivateTags()) {
+            foreach($tags as $idx => $tag) {
+                if (strpos($tag['tag'], "@") !== false) {
+                    unset($tags[$idx]);
+                }
+            }
+            $tags = array_values($tags);
+        }
+
+        return $tags;
+    }
     
     /**
      * pass any method call to the backend.

--- a/defaults.ini
+++ b/defaults.ini
@@ -35,4 +35,3 @@ unread_order=
 load_images_on_mobile=0
 auto_hide_read_on_mobile=0
 env_prefix=selfoss_
-

--- a/helpers/Authentication.php
+++ b/helpers/Authentication.php
@@ -124,6 +124,16 @@ class Authentication {
         return $this->loggedin;
     }
     
+
+    /**
+     * showPrivateTags
+     *
+     * @return bool
+     */
+    public function showPrivateTags() {
+       return $this->isLoggedin();
+     }
+
     
     /**
      * logout


### PR DESCRIPTION
Hello,

I had these patches in my version of selfoss since quite a while, and I wanted to suggest it to you.
It add the ability 

1/ to have private tags (with a @ in the tag name). Items (and sources) with such tags won't be visible in the feed if the user is not logged in.

2/ to have "not important" tags (with a # in the tag name), whose items won't be visible in the "all tags" feed, but only when you click directly on the tag or source.

Currently the # and @ symbols are hardcoded, but I can update the code to allow the configuration in defaults.ini (or even disabling it with an empty value).