### PR TITLE
Optimize SQL request to look for icon usage

### DIFF
--- a/daos/mysql/Items.php
+++ b/daos/mysql/Items.php
@@ -329,11 +329,11 @@ class Items extends Database {
      * @param string $icon file
      */
     public function hasIcon($icon) {
-        $res = \F3::get('db')->exec('SELECT count(*) AS amount
-                   FROM '.\F3::get('db_prefix').'items 
-                   WHERE icon=:icon',
+        $res = \F3::get('db')->exec('SELECT id
+                   FROM items
+                   WHERE icon=:icon limit 1',
                   array(':icon' => $icon));
-        return $res[0]['amount']>0;
+        return sizeof($res)>0;
     }
     
     /**


### PR DESCRIPTION
Having a quite huge instance (>250k items, >500 sources), cleaning unused icons run for ages.
Example today:

    10-27-15 16:20:01 ---
    [...]
    10-27-15 16:27:53 Debug cleanup orphaned and old items
    10-27-15 16:27:56 Debug cleanup orphaned and old items finished
    [...]
    10-27-15 16:27:56 Debug delete orphaned thumbnails
    10-27-15 16:28:00 Debug delete orphaned thumbnails finished
    [...]
    10-27-15 16:28:00 Debug delete orphaned icons
    10-27-15 16:47:30 Debug delete orphaned icons finished
    [...]
    10-27-15 16:47:30 Debug optimize database
    10-27-15 16:49:43 Debug optimize database finished

As you can see, deleting orphaned icons runs for 20 minutes. This is due to the SQL request which performs a count, means that it'll scan the whole item's table.

If you just want to know wether a given icon is still used or not, you'd better use a simple seletc id with limit 1 so that the SQL engine stops the query after having found the icon.

It's still not fully optimal since for a really orphaned icon, the whole table will be scanned, but it's a quite good optimization:

    10-27-15 18:20:01 Debug ---
    [...]
    10-27-15 18:27:18 Debug cleanup orphaned and old items
    10-27-15 18:27:26 Debug cleanup orphaned and old items finished
    [...]
    10-27-15 18:27:26 Debug delete orphaned thumbnails
    10-27-15 18:27:30 Debug delete orphaned thumbnails finished
    [...]
    10-27-15 18:27:30 Debug delete orphaned icons
    10-27-15 18:30:54 Debug delete orphaned icons finished
    [...]
    10-27-15 18:30:54 Debug optimize database
    10-27-15 18:30:56 Debug optimize database finished
