### PR TITLE
Settings cannot be opened

### DIFF
--- a/daos/mysql/Sources.php
+++ b/daos/mysql/Sources.php
@@ -200,9 +200,9 @@ class Sources extends Database {
             FROM '.\F3::get('db_prefix').'sources AS sources
             LEFT OUTER JOIN
                 (SELECT items.source, icon
-                 FROM '.\F3::get('db_prefix').'items,
+                 FROM '.\F3::get('db_prefix').'items AS items,
                       (SELECT source, MAX(id) as maxid
-                       FROM '.\F3::get('db_prefix').'items
+                       FROM '.\F3::get('db_prefix').'items AS items
                        WHERE icon IS NOT NULL AND icon != \'\'
                        GROUP BY items.source) AS icons
                  WHERE items.id=icons.maxid AND items.source=icons.source


### PR DESCRIPTION
After upgrading from 2.12 to 2.14, Settings screen cannot be opened, showing a red alert with message "Load list error: error Internal Server Error". If tables are using a custom prefix, "AS items" are needed on SQL statements.