### PR TITLE
Auto collapse

### DIFF
--- a/_docs/website/index.html
+++ b/_docs/website/index.html
@@ -265,6 +265,10 @@ db_port=3306</code>
                         <td class="documentation-first-column">auto_mark_as_read</td>
                         <td>set this to 1 for automatically marking items as read after open/read them.</td>
                     </tr>
+		    <tr>
+                        <td class="documentation-first-column">auto_collapse</td>
+                        <td>set this to 1 for automatically collapsing items when another one is opened.</td>
+                    </tr>
                     <tr>
                         <td class="documentation-first-column">auto_stream_more</td>
                         <td>set this to 0 to disable autoloading of more items when you scroll down. With 1, a click on a button is required instead.</td>

--- a/defaults.ini
+++ b/defaults.ini
@@ -24,6 +24,7 @@ rss_mark_as_read=0
 homepage=newest
 language=0
 auto_mark_as_read=0
+auto_collapse=0
 auto_stream_more=1
 anonymizer=
 use_system_font=

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -84,7 +84,7 @@ selfoss.events.entries = function(e) {
                 parent.find('.entry-toolbar').hide();
                 content.hide();
             } else {
-                if($('#config').data('auto-collapse')=="1"){
+                if($('#config').data('auto_collapse')=="1"){
                     $('.entry-content, .entry-toolbar').hide();
                 }
                 content.show();

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -84,6 +84,9 @@ selfoss.events.entries = function(e) {
                 parent.find('.entry-toolbar').hide();
                 content.hide();
             } else {
+                if($('#config').data('auto-collapse')=="1"){
+                    $('.entry-content, .entry-toolbar').hide();
+                }
                 content.show();
                 selfoss.events.entriesToolbar(parent);
                 parent.find('.entry-toolbar').show();

--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -70,6 +70,7 @@
         data-wallabag="<?PHP echo \F3::get('wallabag'); ?>"
         data-wordpress="<?PHP echo \F3::get('wordpress'); ?>"
         data-auto_mark_as_read="<?PHP echo \F3::get('auto_mark_as_read'); ?>"
+        data-auto_collapse="<?PHP echo \F3::get('auto_collapse'); ?>"
         data-auto_stream_more="<?PHP echo \F3::get('auto_stream_more'); ?>"
         data-load_images_on_mobile="<?PHP echo \F3::get('load_images_on_mobile'); ?>"
         data-items_perpage="<?PHP echo \F3::get('items_perpage'); ?>"


### PR DESCRIPTION
Added a new feature auto_collapse.
It can be used by setting `auto_collapse=1` in the config.ini file. By default the value is set to 0 and the feature is deactivated.
When activated the open items will collapse automatically when another item is opened, thereby making the interface even more clutter free and easy to browse.