### PR TITLE
Added Rewrite Rule for ACME well known location.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -2,6 +2,9 @@
 RewriteEngine On
 #RewriteBase /selfoss
 
+# rule for ACME
+RewriteRule .well-known/(.*) - [L]
+
 # rule for favicons
 RewriteRule !data/favicons/(.*)$ - [C]
 RewriteRule favicons/(.*)$ data/favicons/$1 [L]


### PR DESCRIPTION
This folder is used by letsencrypt to prove ownership of domain.

Adding the exception to the ``.htaccess`` file allows the letsencrypt server to fetch a generated filed in this folder.

For more information, see https://letsencrypt.org/