### PR TITLE
Added an indicator of "below the fold" unread entries

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -381,6 +381,36 @@ body * {
         cursor:pointer;
     }
     
+/* unread count below the fold */
+
+#floating-unread {
+    display: none;
+    width: 40px;
+    position: fixed;
+    left: 185px;
+    bottom: 5px;
+    text-align: center;
+}
+
+#floating-unread .floating-unread-count {
+    display: inline;
+    min-width: 8px;
+    padding: 0 5px 0 5px;
+    background-color: #E74C3C;
+    border-radius: 30px;
+    font-size: 0.6em;
+    color: white;
+}
+
+#floating-unread .bottom-triangle {
+    position: relative;
+    bottom: 3px;
+    margin: 0 15px;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid #E74C3C;
+}
+
 /* content */
 
 #content {
@@ -1053,6 +1083,10 @@ body.publicmode.notloggedin .entry-unread {
         margin-left:157px;
     }
     
+    #floating-unread {
+        display: none !important;
+    }
+
     .entry-toolbar {
         margin-left:-7px;
     }

--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -190,6 +190,9 @@ var selfoss = {
                 }
                 if(selfoss.filter.sourcesNav)
                     selfoss.refreshSources(data.sources, currentSource);
+
+                // update the floating unread count
+                selfoss.events.updateUnreadBelowTheFold();
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 if (textStatus == "parsererror")
@@ -284,6 +287,24 @@ var selfoss = {
         } else {
             $('span.unread-count').removeClass('unread');
             $(document).attr('title', selfoss.htmlTitle);
+        }
+    },
+
+
+    /**
+     * refresh unread below the fold stats.
+     *
+     * @return void
+     * @param new unread stats (might be null when unknown)
+     */
+    refreshUnreadBelowTheFold: function(unread) {
+        var $floatingUnread = $('#floating-unread');
+        if (unread != null && unread <= 0) {
+            $floatingUnread.hide();
+        } else {
+            var $countBelow = $floatingUnread.find('.floating-unread-count');
+            $countBelow.html(unread == null ? '?' : unread);
+            $floatingUnread.show();
         }
     },
 

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -101,12 +101,19 @@ selfoss.events.entries = function(e) {
 
                 // scroll to article header
                 parent.get(0).scrollIntoView();
+
+                // update the floating unread count after every image load
+                // since they might resize the entry container
+                content.find('img').load(selfoss.events.updateUnreadBelowTheFold);
             }
             
             // load images not on mobile devices
             if(selfoss.isMobile()==false || $('#config').data('load_images_on_mobile')=="1") {
                 content.lazyLoadImages();
             }
+
+            // update the floating unread count
+            selfoss.events.updateUnreadBelowTheFold();
         } 
     });
 
@@ -125,6 +132,11 @@ selfoss.events.entries = function(e) {
            && $('.stream-more').position().top < $(window).height() + $(window).scrollTop() 
            && $('.stream-more').hasClass('loading')==false)
             $('.stream-more').click();
+
+        if ($('#floating-unread').is(':visible')) {
+            // update the floating unread count
+            selfoss.events.updateUnreadBelowTheFold();
+        }
     });
     
     $('.mark-these-read').unbind('click').click(selfoss.markVisibleRead);

--- a/public/js/selfoss-events-navigation.js
+++ b/public/js/selfoss-events-navigation.js
@@ -197,6 +197,8 @@ selfoss.events.navigation = function() {
             
             if(selfoss.isSmartphone())
                 $('#nav-mobile-settings').click();
+
+            $('#floating-unread').hide();
         });
         
         

--- a/public/js/selfoss-events.js
+++ b/public/js/selfoss-events.js
@@ -26,6 +26,7 @@ selfoss.events = {
         });
         $(window).bind("resize", selfoss.events.resize);
         selfoss.events.resize();
+        selfoss.events.updateUnreadBelowTheFold();
         
         // hash change event
         window.onhashchange = selfoss.events.hashChange;
@@ -103,5 +104,92 @@ selfoss.events = {
             $('#nav-tags-wrapper').height("auto");
             $("#nav-tags-wrapper").mCustomScrollbar("disable",selfoss.isSmartphone());
         }
+        if ($('#floating-unread').is(':visible')) {
+            selfoss.events.updateUnreadBelowTheFold();
+        }
+    },
+
+
+    /**
+     * updates the "unread below the fold" count
+     */
+    updateUnreadBelowTheFold: function() {
+        if (!selfoss.isTablet()) {
+            var $floatingUnread = $('#floating-unread');
+            if ($floatingUnread.length) {
+                var unreadStats = selfoss.events.countUnreadBelowTheFold();
+
+                selfoss.refreshUnreadBelowTheFold(unreadStats);
+            }
+        }
+    },
+
+
+    /**
+     * counts the number of unread entries below the fold
+     *
+     * @return int number of unread entries below the fold, null when unknown
+     */
+    countUnreadBelowTheFold: function() {
+        var foldPos = $(window).scrollTop() + $(window).height();
+        var contentBottom = $('#content').outerHeight() + $('#content').offset().top;
+
+        var unreadStats = selfoss.events.countCurrentUnread();
+
+        $starredFilter = $('#nav-filter-starred');
+        $searchTerms = $('#search-list li');
+        if ($starredFilter.hasClass('active') || $searchTerms.length > 0) {
+            // disabled for starred filter and when search is active
+            // since we don't known the number of unread entries in the current view
+            if (contentBottom <= foldPos) {
+                // everything is visible, no unread entries below the fold
+                unreadStats = 0;
+            } else {
+                // not everything is visible, unread count is unknown
+                unreadStats = null;
+            }
+        } else {
+            $('#content .entry.unread').each(function() {
+                var entryBottomPos = $(this).offset().top + $(this).outerHeight();
+                if (entryBottomPos < foldPos) {
+                    unreadStats--;
+                } else {
+                    // we reached the bottom of the visible window, no need to go further
+                    return false;
+                }
+            });
+        }
+
+        return unreadStats;
+    },
+
+
+    /**
+     * counts the number of unread entries in the current view
+     *
+     * @return int number of unread entries in the current view
+     */
+    countCurrentUnread: function() {
+        // the result might already be computed
+        var $currentUnreadCount = $('#current-unread-count');
+        if ($currentUnreadCount.length > 0) {
+            return $currentUnreadCount.data('unreadCount');
+        }
+
+        var unreadStats = parseInt($('.nav-filter-unread span').html()); // unread total
+        var $selectedSource = $('#nav-tags-wrapper li.active'); // selected tag/source
+        var unreadSource = parseInt($selectedSource.find('span.unread').html()); // unread tag/source
+        if (!$selectedSource.hasClass('nav-tags-all')) {
+            // using the unread count from the tag/source except for "all tags"
+            unreadStats = unreadSource > 0 ? unreadSource : 0;
+        }
+
+        // saving the result in the current view, to avoid most of the work next time
+        $currentUnreadCount = $('<div id="current-unread-count"></div>');
+        $currentUnreadCount.hide();
+        $currentUnreadCount.data('unreadCount', unreadStats);
+        $('#content').prepend($currentUnreadCount);
+
+        return unreadStats;
     }
 };

--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -153,6 +153,12 @@
     <ul id="search-list">
     </ul>
     
+    <!-- unread count below the fold -->
+    <div id="floating-unread" aria-hidden="true">
+        <span class="floating-unread-count"></span>
+        <div class="bottom-triangle"></div>
+    </div>
+
     <!-- content -->
     <div id="content" role="main">
         <?PHP echo $this->content; ?>


### PR DESCRIPTION
Unread entries might appear far down in the list of entries for many reasons. For example, when marking a source as read, the recent entries list will be a mix of read / unread entries.
When marking everything as read we might have missed a few unread entries because they were too far down in the list.

This PR adds an indicator displaying the number of unread entries below the fold:

![Indicator of below the fold unread entries](http://i.imgur.com/WWiBYnp.png)

It only appears on desktop browsers (width > 1024px), and requires the `floating_unread_count_enabled=true` config parameter to be shown (disabled by default).

It might display `?` when the number of unread entries is unknown, for example when using the search feature.