### PR TITLE
Fixed the search offset

### DIFF
--- a/public/js/selfoss-events-search.js
+++ b/public/js/selfoss-events-search.js
@@ -36,6 +36,7 @@ selfoss.events.search = function() {
         
         // execute search
         $('#search').removeClass('active');
+        selfoss.filter.offset = 0;
         selfoss.filter.search = term;
         selfoss.reloadList();
         


### PR DESCRIPTION
When scrolling enough to trigger the auto-stream and then going back to top to perform a search, the search keeps the previous offset instead of starting with an offset of zero.