### PR TITLE
Use a more secure password hash

### DIFF
--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -101,7 +101,7 @@ class Index extends BaseController {
         $this->view = new \helpers\View();
         $this->view->password = true;
         if(isset($_POST['password']))
-            $this->view->hash = hash("sha512", \F3::get('salt') . $_POST['password']);
+            $this->view->hash = password_hash($_POST['password'], PASSWORD_DEFAULT);
         echo $this->view->render('templates/login.phtml');
     }
     

--- a/defaults.ini
+++ b/defaults.ini
@@ -15,7 +15,6 @@ items_lifetime=30
 base_url=
 username=
 password=
-salt=lkjl1289
 public=
 html_title=selfoss
 rss_title=selfoss feed

--- a/helpers/Authentication.php
+++ b/helpers/Authentication.php
@@ -98,7 +98,7 @@ class Authentication {
     public function login($username, $password) {
         if($this->enabled()) {
             if(
-                $username == \F3::get('username') &&  hash("sha512", \F3::get('salt') . $password) == \F3::get('password')
+                $username == \F3::get('username') && password_verify($password, \F3::get('password'))
             ) {
                 $this->loggedin = true;
                 $_SESSION['loggedin'] = true;


### PR DESCRIPTION
This patch changes the password hashing system to use `password_hash` and `password_verify` rather than sha512. This system uses a more expensive hashing function to make brute-forcing infeasible. It also generates its own salt securely, so you don't need to worry about that.

Unfortunately, this does bump the PHP requirement to 5.5. Since 5.3 is not officially supported anymore, this should not be too much of a problem.