### PR TITLE
Clean the Golem.de content a little bit

### DIFF
--- a/spouts/rss/golem.php
+++ b/spouts/rss/golem.php
@@ -146,13 +146,27 @@ class golem extends feed {
      */
     public function getContent() {
         if($this->items!==false && $this->valid()) {
-            $originalContent = file_get_contents($this->getLink());
+            $originalContent = $this->cleanContent(file_get_contents($this->getLink()));
             preg_match_all('|<!--content-->(.*?)<!--/content-->|ims', $originalContent, $matches, PREG_PATTERN_ORDER);
             if(is_array($matches) && is_array($matches[0]) && isset($matches[0][0])) {
                 return $matches[0][0];
             }
         }
         return parent::getContent();
+    }
+
+
+    /**
+     * clean the content
+     *
+     * @return string cleaned content
+     * @param string $content original content
+     */
+    private function cleanContent($content) {
+        $content = preg_replace('|<!-- begin ad tag \(tile=4\) -->(.*?)<!-- end ad tag \(tile=4\) -->|ims', '', $content);
+        $content = preg_replace('|<figure id="([^"]+)"></figure>|ims', '', $content);
+        $content = preg_replace('|<a class="golem-gallery2-nojs" href="([^"]+)">(.*?)<img src="([^"]+)" alt="([^"]+)" title="([^"]+)" data-src="([^"]+)" data-src-full="([^"]+)">(.*?)</a>|ims', '<p><a href="$1" target="_blank"><img src="$3" alt="$4" title="$5" /></a></p>', $content);
+        return $content;
     }
 
 }


### PR DESCRIPTION
This patch tweaks the Golem.de spouts a little bit. It remove adds inside the content and replace a gallery with a single image and a link to all.