### PR TITLE
Update style.css

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -572,6 +572,10 @@ body * {
         .entry-content blockquote {
             overflow-x: unset;
         }
+        
+        .entry-content pre {
+            white-space: pre-wrap;
+        }
     
         .entry-content p,
         .entry-content ol,


### PR DESCRIPTION
Wrap text in code blocks to prevent column overflow

It looks like my proposed rule can cause some issues as well. In the example in my screenshot, the line numbers are a separate element, which causes a mismatch in the middle column, but not in the left column for some reason. I'm just throwing this out there because as it stands, the text spilling over into other columns is much worse in my opinion.

![untitled](https://cloud.githubusercontent.com/assets/5256208/15303786/a2a36fec-1b87-11e6-91b4-b094aef9eeea.png)

Top is before, bottom is after.