### PR TITLE
Handle rewritten URLs correctly

### DIFF
--- a/helpers/Authentication.php
+++ b/helpers/Authentication.php
@@ -38,7 +38,7 @@ class Authentication {
             $cookie_domain = $_SERVER['HTTP_X_FORWARDED_SERVER'];
         } else {
             // cookie path is script dir.
-            $cookie_path = dirname($_SERVER['SCRIPT_NAME'])==='/'?'/':dirname($_SERVER['SCRIPT_NAME']).'/';
+            $cookie_path = dirname($_SERVER['REQUEST_URI'])==='/'?'/':dirname($_SERVER['REQUEST_URI']).'/';
             $cookie_domain = $_SERVER['SERVER_NAME'];
         }
         session_set_cookie_params($cookie_expire, $cookie_path, $cookie_domain,

--- a/helpers/View.php
+++ b/helpers/View.php
@@ -44,8 +44,8 @@ class View {
                 
         // auto generate base url
         } else {
-            $lastSlash = strrpos($_SERVER['SCRIPT_NAME'], '/');
-            $subdir = $lastSlash!==false ? substr($_SERVER['SCRIPT_NAME'], 0, $lastSlash) : '';
+            $lastSlash = strrpos($_SERVER['REQUEST_URI'], '/');
+            $subdir = $lastSlash!==false ? substr($_SERVER['REQUEST_URI'], 0, $lastSlash) : '';
             
             $protocol = 'http';
             if (isset($_SERVER["HTTPS"]) && ($_SERVER["HTTPS"]=="on" || $_SERVER["HTTPS"]==1) ||


### PR DESCRIPTION
selfoss should use the URL the application is actually accessed through, instead of the script location (which may differ).