### PR TITLE
Apply upstream patch to f3/base.php

### DIFF
--- a/libs/f3/base.php
+++ b/libs/f3/base.php
@@ -1182,8 +1182,8 @@ class Base extends Prefab {
 				$this->redirect($item,$url);
 			return;
 		}
-		$this->route($pattern,function($this) use ($url) {
-			$this->reroute($url);
+		$this->route($pattern,function($fw) use ($url) {
+			$fw->reroute($url);
 		});
 	}
 


### PR DESCRIPTION
Fix #767. Now uses the parameter name `$fw` instead of `$this`, which
does not produce a fatal error. This comes from version 3.5.0 upstream.