### PR TITLE
remove $this in anonymous function for PHP7 compatibility

### DIFF
--- a/libs/f3/base.php
+++ b/libs/f3/base.php
@@ -1182,7 +1182,7 @@ class Base extends Prefab {
 				$this->redirect($item,$url);
 			return;
 		}
-		$this->route($pattern,function($this) use ($url) {
+		$this->route($pattern,function() use ($url) {
 			$this->reroute($url);
 		});
 	}


### PR DESCRIPTION
in PHP7
function($this) use ($url) {
leads to PHP Fatal error:  Cannot use $this as parameter in /selfoss/libs/f3/base.php on line 1185