### PR TITLE
Fix read count of secondary tags

### DIFF
--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -50,14 +50,12 @@ class Index extends BaseController {
         $this->view->statsUnread = $stats['unread'];
         $this->view->statsStarred = $stats['starred'];
 
-        if ($tagsDao->hasTag("#")) {
-		foreach ($tags as $tag) {
-			if (strcmp($tag["tag"], "#") !== 0) {
-				continue;
-			}
-			$this->view->statsUnread -= $tag["unread"];
-		}
-	}
+        foreach ($tags as $tag) {
+            if (strpos($tag['tag'], '#') !== 0) {
+                continue;
+            }
+            $this->view->statsUnread -= $tag['unread'];
+        }
 
         // prepare tags display list
         $tagsController = new \controllers\Tags();

--- a/controllers/Items.php
+++ b/controllers/Items.php
@@ -146,17 +146,15 @@ class Items extends BaseController {
 
         $itemsDao = new \daos\Items();
         $stats = $itemsDao->stats();
-	$stats['unread'] -= $itemsDao->numberOfUnreadForTag("#");
 
-	$tagsDao = new \daos\Tags();
-	$tags = $tagsDao->getWithUnread();
-        if ($tagsDao->hasTag("#")) {
-            foreach ($tags as $tag) {
-                if (strcmp($tag["tag"], "#") !== 0) {
-                    continue;
-                }
-                $stats['unread'] -= $tag["unread"];
+        $tagsDao = new \daos\Tags();
+        $tags = $tagsDao->getWithUnread();
+
+        foreach ($tags as $tag) {
+            if (strpos($tag['tag'], '#') !== 0) {
+                continue;
             }
+            $stats['unread'] -= $tag['unread'];
         }
 
         if( array_key_exists('tags', $_GET) && $_GET['tags'] == 'true' ) {

--- a/daos/Items.php
+++ b/daos/Items.php
@@ -85,8 +85,12 @@ class Items extends Database {
         // remove private posts with private tags
         if(!\F3::get('auth')->showPrivateTags()) {
             foreach($items as $idx => $item) {
-                if (strpos($item['tags'], "@") !== false) {
-                    unset($items[$idx]);
+                $tags = explode(',', $item['tags']);
+                foreach ($tags as $tag) {
+                    if (strpos(trim($tag), '@') === 0) {
+                        unset($items[$idx]);
+                        break;
+                    }
                 }
             }
             $items = array_values($items);
@@ -95,8 +99,12 @@ class Items extends Database {
         // remove posts with hidden tags
         if(!isset($options['tag']) || strlen($options['tag']) === 0) {
             foreach($items as $idx => $item) {
-                if (strpos($item['tags'], "#") !== false) {
-                    unset($items[$idx]);
+                $tags = explode(',', $item['tags']);
+                foreach ($tags as $tag) {
+                    if (strpos(trim($tag), '#') === 0) {
+                        unset($items[$idx]);
+                        break;
+                    }
                 }
             }
             $items = array_values($items);

--- a/daos/Sources.php
+++ b/daos/Sources.php
@@ -52,8 +52,12 @@ class Sources extends Database {
         // remove items with private tags
         if(!\F3::get('auth')->showPrivateTags()) {
             foreach($sources as $idx => $source) {
-                if (strpos($source['tags'], "@") !== false) {
-                    unset($sources[$idx]);
+                $tags = explode(',', $source['tags']);
+                foreach ($tags as $tag) {
+                    if (strpos(trim($tag), '@') === 0) {
+                        unset($sources[$idx]);
+                        break;
+                    }
                 }
             }
             $sources = array_values($sources);

--- a/daos/Tags.php
+++ b/daos/Tags.php
@@ -36,7 +36,7 @@ class Tags extends Database {
         // remove items with private tags
         if(!\F3::get('auth')->showPrivateTags()) {
             foreach($tags as $idx => $tag) {
-                if (strpos($tag['tag'], "@") !== false) {
+                if (strpos($tag['tag'], '@') === 0) {
                     unset($tags[$idx]);
                 }
             }


### PR DESCRIPTION
Cherry-picked https://github.com/wazari972/selfoss/commit/3853d6423c3925978119ed0be0171da1611ca5a4, should fix the error reported in #740 (not the issue itself though). It will also make hidden tags actually work as promised in #714.

Problems not fixed in this pull request:
* _Unread_ filter count is subtracted multiple times when a feed has multiple hidden tags (it can even show negative count).
* _Unread_ filter count is not AJAX-updated when you tag/untag a source with a hidden tag.
* Number of unread items below the fold (#747) doesn’t subtract the hidden items.
* Private tags are still displayed in sidebar, although they correctly don’t show any content.
* There is not documentation.
