### PR TITLE
Fix img src path to search.png and remove.png

### DIFF
--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -148,8 +148,8 @@
     <!-- search -->
     <div id="search" role="search">
         <input type="search" id="search-term">
-        <button id="search-remove" title="<?PHP echo \F3::get('lang_searchremove')?>"><img src="public/images/remove.png" alt=""></button>
-        <button id="search-button" title="<?PHP echo \F3::get('lang_searchbutton')?>"><img src="public/images/search.png" alt=""></button>
+        <button id="search-remove" title="<?PHP echo \F3::get('lang_searchremove')?>"><img src="images/remove.png" alt=""></button>
+        <button id="search-button" title="<?PHP echo \F3::get('lang_searchbutton')?>"><img src="images/search.png" alt=""></button>
     </div>
     
     <ul id="search-list">


### PR DESCRIPTION
The img src to remove.png and search.png (added with 462e91ccfb522b37a20a848d57d77d15364709af) causes broken links to these images.

![image](https://cloud.githubusercontent.com/assets/8281193/16355948/635c1cd4-3ac8-11e6-8284-2b15dd6b678c.png)

default.log:
06-25-16 9:26:23 Error HTTP 404 (GET /public/images/remove.png)
06-25-16 9:26:23 Error HTTP 404 (GET /public/images/search.png)