### PR TITLE
Link entry source to source listing

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -453,6 +453,10 @@ body * {
         cursor:pointer;
     }
 
+    .entry-source {
+        cursor: pointer;
+    }
+
     .entry-title {
         cursor:pointer;
         color:#999999;

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -46,7 +46,7 @@ selfoss.events.entries = function(e) {
             
             // show fullscreen
             var fullscreen = $('#fullscreen-entry');
-            fullscreen.html('<div id="entrr'+parent.attr('id').substr(5)+'" class="entry fullscreen">'+parent.html()+'</div>');
+            fullscreen.html('<div id="entrr'+parent.attr('data-entry-id')+'" class="entry fullscreen" data-entry-id="'+parent.attr('data-entry-id')+'">'+parent.html()+'</div>');
             fullscreen.show();
 
             // lazy load images in fullscreen
@@ -112,7 +112,7 @@ selfoss.events.entries = function(e) {
 
     // no source click
     if(selfoss.isSmartphone())
-        $('.entry-source, .entry-icon').unbind('click').click(function(e) {e.preventDefault(); return false });
+        $('.entry-icon, .entry-datetime').unbind('click').click(function(e) {e.preventDefault(); return false });
     
     // scroll load more
     $(window).unbind('scroll').scroll(function() {
@@ -154,7 +154,30 @@ selfoss.events.entries = function(e) {
             }
         });
     });
-    
+
+    // click a source
+    if (selfoss.isSmartphone() == false) {
+        $('.entry-source').unbind('click').click(function(e) {
+            var entry = $(this).parents('.entry');
+            var deferred = $.Deferred();
+            if ($('#nav-sources-title').is('.nav-sources-collapsed')) {
+                $('#nav-sources-title').trigger('click', deferred.resolve);
+            } else {
+                deferred.resolve();
+            }
+
+            deferred.then(function() {
+                var source = entry.attr('data-entry-source');
+                $('#nav-sources li').each(function(index, item) {
+                    if ($(item).attr('data-source-id') == source) {
+                        $(item).click();
+                        return false;
+                    }
+                });
+            });
+        });
+    }
+
     // click a tag
     if(selfoss.isSmartphone()==false) {
         $('.entry-tags-tag').unbind('click').click(function() {

--- a/public/js/selfoss-events-entriestoolbar.js
+++ b/public/js/selfoss-events-entriestoolbar.js
@@ -21,7 +21,7 @@ selfoss.events.entriesToolbar = function(parent) {
     
     // open in new window
     parent.find('.entry-newwindow').unbind('click').click(function(e) {
-        window.open($(this).parents(".entry").children(".entry-source").attr("href"));
+        window.open($(this).parents(".entry").children(".entry-datetime").attr("href"));
         e.preventDefault();
         return false;
     });
@@ -116,7 +116,8 @@ selfoss.events.entriesToolbar = function(parent) {
         
         // read/unread
         parent.find('.entry-unread').unbind('click').click(function() {
-            var id = $(this).parents('.entry').attr('id').substr(5);
+            var entry = $(this).parents('.entry');
+            var id = entry.attr('data-entry-id');
             var unread = $(this).hasClass('active')==true;
             var button = $("#entry"+id+" .entry-unread, #entrr"+id+" .entry-unread");
             var parent = $("#entry"+id+", #entrr"+id);
@@ -147,7 +148,7 @@ selfoss.events.entriesToolbar = function(parent) {
                 selfoss.refreshUnread(unreadstats);
                     
                 // update unread count on sources
-                var sourceId = $('#entry'+id+' .entry-source').attr('class').substr(25);
+                var sourceId = entry.attr('data-entry-source');
                 var sourceNav = $('#source'+sourceId+' .unread');
                 var sourceCount = parseInt(sourceNav.html());
                 if(typeof sourceCount != "number" || isNaN(sourceCount)==true)

--- a/public/js/selfoss-events-navigation.js
+++ b/public/js/selfoss-events-navigation.js
@@ -106,13 +106,14 @@ selfoss.events.navigation = function() {
     });
     
     // hide/show sources
-    $('#nav-sources-title').unbind('click').click(function () {
+    $('#nav-sources-title').unbind('click').click(function (e, onExpand) {
         var toggle = function () {
             $('#nav-sources').slideToggle("slow");
             $('#nav-sources-title').toggleClass("nav-sources-collapsed nav-sources-expanded");
             $('#nav-sources-title').attr('aria-expanded', function (i, attr) {
                 return attr == 'true' ? 'false' : 'true';
             });
+            onExpand();
         }
 
         selfoss.filter.sourcesNav = $('#nav-sources-title').hasClass("nav-sources-collapsed");

--- a/public/js/selfoss-shortcuts.js
+++ b/public/js/selfoss-shortcuts.js
@@ -97,7 +97,7 @@ selfoss.shortcuts = {
         
         // 'v': open target
         $(document).bind('keydown', 'v', function(e) {
-            window.open($('.entry.selected .entry-source').attr('href'));
+            window.open($('.entry.selected .entry-datetime').attr('href'));
             e.preventDefault();
             return false;
         });
@@ -114,7 +114,7 @@ selfoss.shortcuts = {
             }
             
             // open item in new window
-            $('.entry.selected .entry-source').click();
+            $('.entry.selected .entry-datetime').click();
         });
         
         // 'r': Reload the current view

--- a/templates/item.phtml
+++ b/templates/item.phtml
@@ -20,6 +20,8 @@
     $date = $this->viewHelper->dateago($this->item['datetime']);
 ?>
 <div id="entry<?PHP echo $this->item['id']; ?>"
+     data-entry-id="<?PHP echo $this->item['id']; ?>"
+     data-entry-source="<?PHP echo $this->item['source']; ?>"
      class="entry
             <?PHP echo $this->item['unread']==1 ? 'unread' : ''; ?>" role="article">
 
@@ -40,8 +42,7 @@
     </span>
 
     <!-- source -->
-    <a href="<?PHP echo \helpers\Anonymizer::anonymize($this->item['link']); ?>" class="entry-source entry-source<?PHP echo $this->item['source']; ?>" target="_blank"><?PHP echo $sourcetitle ?></a>
-    <a href="<?PHP echo $this->item['link']; ?>" class="entry-link"></a>
+    <span class="entry-source"><?PHP echo $sourcetitle ?></span>
 
     <span class="entry-separator">&bull;</span>
 
@@ -52,9 +53,10 @@
     <?PHP endif; ?>
 
     <!-- datetime -->
-    <span class="entry-datetime">
+    <a href="<?PHP echo \helpers\Anonymizer::anonymize($this->item['link']); ?>" class="entry-datetime" target="_blank">
         <?PHP echo $date; ?>
-    </span>
+    </a>
+    <a href="<?PHP echo $this->item['link']; ?>" class="entry-link"></a>
 
     <!-- thumbnail -->
     <?PHP if(isset($this->item['thumbnail']) && strlen(trim($this->item['thumbnail']))>0) : ?>

--- a/templates/source-nav.phtml
+++ b/templates/source-nav.phtml
@@ -1,4 +1,4 @@
-<li id="source<?PHP echo $this->sourceid; ?>" class="<?PHP if($this->unread>0) echo 'unread';?>" role="link" tabindex="0">
+<li id="source<?PHP echo $this->sourceid; ?>" class="<?PHP if($this->unread>0) echo 'unread';?>" role="link" tabindex="0" data-source-id="<?PHP echo $this->sourceid; ?>">
     <span class="nav-source"><?PHP echo $this->source; ?></span>
     <span class="unread"><?PHP if ($this->unread>0) echo $this->unread; ?></span>
 </li>


### PR DESCRIPTION
Clicking the item’s source (previously opened item’s URL) will open the source’s list of items, similar to how the tags open tag listing. The item’s URL can be now opened by clicking the date, consistent with other applications like Twitter.