### PR TITLE
Fix error handler causing an error

### DIFF
--- a/common.php
+++ b/common.php
@@ -34,16 +34,12 @@ $f3->set(
 $f3->set('ONERROR',
     function($f3) {
         $trace = $f3->get('ERROR.trace');
-        $tracestr = "\n";
-        foreach($trace as $entry) {
-            $tracestr = $tracestr . $entry['file'] . ':' . $entry['line'] . "\n";
-        }
 
-        \F3::get('logger')->log($f3->get('ERROR.text') . $tracestr, \ERROR);
+        \F3::get('logger')->log($f3->get('ERROR.text') . "\n" . $trace, \ERROR);
         if (\F3::get('DEBUG')!=0) {
             echo $f3->get('lang_error') . ": ";
             echo $f3->get('ERROR.text') . "\n";
-            echo $tracestr;
+            echo $trace;
         } else {
             echo $f3->get('lang_error');
         }


### PR DESCRIPTION
Update of f3 framework to version 3.5.0 contained following change

```
Change in behavior: ERROR.trace is a multiline string now
```

which broke our trace handling in `ONERROR`.

Closes #800