### PR TITLE
Allow to change source in public mode

### DIFF
--- a/controllers/Sources.php
+++ b/controllers/Sources.php
@@ -221,7 +221,7 @@ class Sources extends BaseController {
      * @return void
      */
     public function sourcesStats() {
-        $this->needsLoggedIn();
+        $this->needsLoggedInOrPublicMode();
 
         $this->view->jsonSuccess(array(
             'success' => true,


### PR DESCRIPTION
It makes no sense that unauthenticated user can view pretty much anything but cannot view a list of sources to switch to a different one.