### PR TITLE
Added the scroll_to_article_header option

### DIFF
--- a/_docs/website/index.html
+++ b/_docs/website/index.html
@@ -315,6 +315,10 @@ db_port=3306</code>
                         <td>hide read articles on mobile devices</td>
                     </tr>
                     <tr>
+                        <td class="documentation-first-column">scroll_to_article_header</td>
+                        <td>scrolls to the article header after selecting an article (enabled by default)</td>
+                    </tr>
+                    <tr>
                         <td class="documentation-first-column">env_prefix</td>
                         <td>only consider ENV variables that start with this prefix as additional config variables. Defaults to "SELFOSS_".</td>
                     </tr>

--- a/defaults.ini
+++ b/defaults.ini
@@ -38,3 +38,4 @@ auto_hide_read_on_mobile=0
 env_prefix=selfoss_
 camo_domain=
 camo_key=
+scroll_to_article_header=1

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -100,7 +100,9 @@ selfoss.events.entries = function(e) {
                 selfoss.setupFancyBox(content, parent.attr('id').substr(5));
 
                 // scroll to article header
-                parent.get(0).scrollIntoView();
+                if ($('#config').data('scroll_to_article_header') == '1') {
+                  parent.get(0).scrollIntoView();
+                }
             }
             
             // load images not on mobile devices

--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -80,6 +80,7 @@
         data-load_images_on_mobile="<?PHP echo \F3::get('load_images_on_mobile'); ?>"
         data-items_perpage="<?PHP echo \F3::get('items_perpage'); ?>"
         data-auto_hide_read_on_mobile="<?PHP echo \F3::get('auto_hide_read_on_mobile'); ?>"
+        data-scroll_to_article_header="<?PHP echo \F3::get('scroll_to_article_header'); ?>"
         data-html_title="<?PHP echo trim(\F3::get('html_title')); ?>"></span>
 
     <!-- menue open for smartphone -->


### PR DESCRIPTION
The scroll to the article header can be really annoying when reading articles from bottom to top.
The boolean option "scroll_to_article_header" allows to disable the scroll. It is still enabled by default to keep the current behavior.