### PR TITLE
js: Fix expanding list of sources

### DIFF
--- a/public/js/selfoss-events-navigation.js
+++ b/public/js/selfoss-events-navigation.js
@@ -113,7 +113,9 @@ selfoss.events.navigation = function() {
             $('#nav-sources-title').attr('aria-expanded', function (i, attr) {
                 return attr == 'true' ? 'false' : 'true';
             });
-            onExpand();
+            if (typeof onExpand == 'function') {
+                onExpand();
+            }
         }
 
         selfoss.filter.sourcesNav = $('#nav-sources-title').hasClass("nav-sources-collapsed");


### PR DESCRIPTION
PR #794 allows to specify a callback to be executed after expanding the list of sources. The argument was called even when no callback was passed, resulting in an error.

This commit adds a check whether the callback is specified.