### PR TITLE
Fix encoding problems caused by camo

### DIFF
--- a/helpers/ViewHelper.php
+++ b/helpers/ViewHelper.php
@@ -83,16 +83,9 @@ class ViewHelper {
         }
 
         $camo = new \WillWashburn\Phpamo\Phpamo(\F3::get('camo_key'), \F3::get('camo_domain'));
-        $dom = new \DOMDocument();
-        $dom->loadHTML($content);
 
-        foreach ($dom->getElementsByTagName('img') as $item) {
-            if ($item->hasAttribute('src')) {
-                $src = $item->getAttribute('src');
-                $item->setAttribute('src', $camo->camoHttpOnly($src));
-            }
-        }
-
-        return $dom->saveHTML();
+        return preg_replace_callback("/<img([^<]+)src=(['\"])([^\"']*)(['\"])([^<]*)>/i", function($matches) use ($camo) {
+            return '<img' . $matches[1] . 'src=' . $matches[2] . $camo->camoHttpOnly($matches[3]) . $matches[2] . $matches[3] . '>';
+        }, $content);
     }
 }

--- a/helpers/ViewHelper.php
+++ b/helpers/ViewHelper.php
@@ -85,7 +85,7 @@ class ViewHelper {
         $camo = new \WillWashburn\Phpamo\Phpamo(\F3::get('camo_key'), \F3::get('camo_domain'));
 
         return preg_replace_callback("/<img([^<]+)src=(['\"])([^\"']*)(['\"])([^<]*)>/i", function($matches) use ($camo) {
-            return '<img' . $matches[1] . 'src=' . $matches[2] . $camo->camoHttpOnly($matches[3]) . $matches[2] . $matches[3] . '>';
+            return '<img' . $matches[1] . 'src=' . $matches[2] . $camo->camoHttpOnly($matches[3]) . $matches[4] . $matches[5] . '>';
         }, $content);
     }
 }


### PR DESCRIPTION
Loading HTML in DomDocument create encoding issues.
Additionally, regex are faster than loading a document tree.

I often found this issue with fulltextrss spout and French feeds.

There might be another problem with encoding with this spout.
Indeed, I get similar problems on selfoss android app even if I apply this fix.