### PR TITLE
Make selfoss navigable

### DIFF
--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -233,7 +233,10 @@ class Index extends BaseController {
                         || $_SERVER['REMOTE_ADDR'] === $_SERVER['SERVER_ADDR']
                         || $_SERVER['REMOTE_ADDR'] === "127.0.0.1"
                         || \F3::get('auth')->isLoggedin() == 1;
-        if ($options['source'] && $canUpdate) {
+        $firstPage = $options['offset'] == 0
+                        && $options['offset_from_id'] == ''
+                        && $options['offset_from_datetime'] == '';
+        if ($options['source'] && $canUpdate && $firstPage) {
             $itemsHtml = '<button type="button" id="refresh-source" class="refresh-source">' . \F3::get('lang_source_refresh') . '</button>';
         }
 

--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -26,11 +26,19 @@ class Index extends BaseController {
         $options = array();
         if (\F3::get('homepage')!='')
             $options = array( 'type' => \F3::get('homepage') );
-        
+
         // use ajax given params?
         if(count($_GET)>0)
             $options = $_GET;
-        
+
+        if(!isset($options['ajax'])) {
+            // show as full html page
+            $this->view->publicMode = \F3::get('auth')->isLoggedin()!==true && \F3::get('public')==1;
+            $this->view->loggedin = \F3::get('auth')->isLoggedin()===true;
+            echo $this->view->render('templates/home.phtml');
+            return;
+        }
+
         // get search param
         if(isset($options['search']) && strlen($options['search'])>0)
             $this->view->search = $options['search'];
@@ -81,11 +89,6 @@ class Index extends BaseController {
                 "sources"  => $this->view->sources
             ));
         }
-        
-        // show as full html page
-        $this->view->publicMode = \F3::get('auth')->isLoggedin()!==true && \F3::get('public')==1;
-        $this->view->loggedin = \F3::get('auth')->isLoggedin()===true;
-        echo $this->view->render('templates/home.phtml');
     }
     
     

--- a/daos/mysql/Items.php
+++ b/daos/mysql/Items.php
@@ -193,16 +193,16 @@ class Items extends Database {
      */
     public function get($options = array()) {
         $params = array();
-        $where = '';
+        $where = array('TRUE');
         $order = 'DESC';
                 
         // only starred
         if(isset($options['type']) && $options['type']=='starred')
-            $where .= ' AND '.$this->stmt->isTrue('starred');
+            $where[] = $this->stmt->isTrue('starred');
             
         // only unread
         else if(isset($options['type']) && $options['type']=='unread'){
-            $where .= ' AND '.$this->stmt->isTrue('unread');
+            $where[] = $this->stmt->isTrue('unread');
             if(\F3::get('unread_order')=='asc'){
                 $order = 'ASC';
             }
@@ -212,29 +212,39 @@ class Items extends Database {
         if(isset($options['search']) && strlen($options['search'])>0) {
             $search = implode('%', \helpers\Search::splitTerms($options['search']));
             $params[':search'] = $params[':search2'] = $params[':search3'] = array("%".$search."%", \PDO::PARAM_STR);
-            $where .= ' AND (items.title LIKE :search OR items.content LIKE :search2 OR sources.title LIKE :search3) ';
+            $where[] = '(items.title LIKE :search OR items.content LIKE :search2 OR sources.title LIKE :search3) ';
         }
         
         // tag filter
         if(isset($options['tag']) && strlen($options['tag'])>0) {
-            $params[':tag'] = array( "%,".$options['tag'].",%" , \PDO::PARAM_STR );
-            if ( \F3::get( 'db_type' ) == 'mysql' ) {
-              $where .= " AND ( CONCAT( ',' , sources.tags , ',' ) LIKE _utf8mb4 :tag COLLATE utf8mb4_general_ci ) ";
-            } else {
-              $where .= " AND ( (',' || sources.tags || ',') LIKE :tag ) ";
-            }
+            $params[':tag'] = $options['tag'];
+            $where[] = "items.source=sources.id";
+            $where[] = $this->stmt->csvRowMatches('sources.tags', ':tag');
         }
         // source filter
         elseif(isset($options['source']) && strlen($options['source'])>0) {
             $params[':source'] = array($options['source'], \PDO::PARAM_INT);
-            $where .= " AND items.source=:source ";
+            $where[] = "items.source=:source ";
         }
 
         // update time filter
         if(isset($options['updatedsince']) && strlen($options['updatedsince'])>0) {
             $params[':updatedsince'] = array($options['updatedsince'], \PDO::PARAM_STR);
-            $where .= " AND items.updatetime > :updatedsince ";
+            $where[] = "items.updatetime > :updatedsince ";
         }
+
+        $where_ids = '';
+        // extra ids to include in stream
+        if( isset($options['extra_ids']) ) {
+            $extra_ids_stmt = $this->stmt->intRowMatches('items.id',
+                                                         $options['extra_ids']);
+            if( !is_null($extra_ids_stmt) )
+                $where_ids = $extra_ids_stmt;
+        }
+
+        // finalize items filter
+        $where_sql = implode(' AND ', $where);
+        if( $where_ids != '' ) $where_sql = "(($where_sql) OR $where_ids)";
 
         // set limit
         if(!is_numeric($options['items']) || $options['items']>200)
@@ -247,16 +257,16 @@ class Items extends Database {
         // first check whether more items are available
         $result = \F3::get('db')->exec('SELECT items.id
                    FROM '.\F3::get('db_prefix').'items AS items, '.\F3::get('db_prefix').'sources AS sources
-                   WHERE items.source=sources.id '.$where.' 
+                   WHERE items.source=sources.id AND '.$where_sql.'
                    LIMIT 1 OFFSET ' . ($options['offset']+$options['items']), $params);
         $this->hasMore = count($result);
 
         // get items from database
-        return \F3::get('db')->exec('SELECT 
+        return \F3::get('db')->exec('SELECT
                     items.id, datetime, items.title AS title, content, unread, starred, source, thumbnail, icon, uid, link, updatetime, author, sources.title as sourcetitle, sources.tags as tags
                    FROM '.\F3::get('db_prefix').'items AS items, '.\F3::get('db_prefix').'sources AS sources
-                   WHERE items.source=sources.id '.$where.' 
-                   ORDER BY items.datetime '.$order.' 
+                   WHERE items.source=sources.id AND '.$where_sql.'
+                   ORDER BY items.datetime '.$order.'
                    LIMIT ' . $options['items'] . ' OFFSET '. $options['offset'], $params);
     }
     

--- a/daos/mysql/Statements.php
+++ b/daos/mysql/Statements.php
@@ -84,4 +84,28 @@ class Statements{
 
         return "CONCAT(',', $column, ',') LIKE CONCAT('%,', $value, ',%') COLLATE utf8mb4_general_ci";
     }
+
+   /**
+     * check column against int list.
+     *
+     * @param int column to check
+     * @param array of string or int values to match column against
+     * @return full statement
+     */
+    public static function intRowMatches($column, $ints) {
+        // checks types
+        if( !is_array($ints) && sizeof($ints) < 1 ) return null;
+        $all_ints = array();
+        foreach( $ints as $ints_str ) {
+            $i = (int)$ints_str;
+            if( $i > 0 ) $all_ints[] = $i;
+        }
+
+        if( sizeof($all_ints) > 0 ) {
+            $comma_ints = implode(',', $all_ints);
+            return $column." IN ($comma_ints)";
+        }
+
+        return null;
+    }
 }

--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -215,6 +215,7 @@ var selfoss = {
                 else if (errorThrown)
                     selfoss.showError('Load list error: '+
                                         textStatus+' '+errorThrown);
+                selfoss.events.entries();
                 $('.stream-error').show();
             },
             complete: function(jqXHR, textStatus) {

--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -457,7 +457,7 @@ var selfoss = {
         $('#content').addClass('loading').html("");
 
         // close opened entry and list
-        location.hash = selfoss.events.path;
+        selfoss.events.processHash(selfoss.events.path);
         selfoss.filterReset();
 
         $.ajax({

--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -364,7 +364,15 @@ var selfoss = {
     refreshSources: function(sources, currentSource) {
         $('#nav-sources li').remove();
         $('#nav-sources').append(sources);
-        $('#source' + selfoss.filter.source).addClass('active');
+        if( selfoss.filter.source ) {
+            $('#source' + selfoss.filter.source).addClass('active');
+            $('#nav-tags > li').removeClass('active');
+        }
+
+        selfoss.sourcesNavLoaded = true;
+        if( $('#nav-sources-title').hasClass("nav-sources-collapsed") )
+            $('#nav-sources-title').click(); // expand sources nav
+
         selfoss.events.navigation();
     },
     

--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -51,9 +51,9 @@ var selfoss = {
         
             // set items per page
             selfoss.filter.itemsPerPage = $('#config').data('items_perpage');
-            
+
             // initialize type by homepage config param
-            selfoss.filter.type = $('#nav-filter li.active').attr('id').replace('nav-filter-', '');
+            selfoss.filter.type = $('#config').data('homepage');
 
             // read the html title configured
             selfoss.htmlTitle = $('#config').data('html_title')
@@ -159,9 +159,11 @@ var selfoss = {
             selfoss.activeAjaxReq.abort();
 
         if (location.hash == "#sources") {
-            location.hash = "";
             return;
         }
+
+        if( selfoss.events.entryId )
+            selfoss.filter.extra_ids.push(selfoss.events.entryId);
 
         $('.stream-error').css('display', 'block').hide();
         $('#content').addClass('loading').html("");
@@ -193,16 +195,12 @@ var selfoss = {
                     selfoss.refreshSources(data.sources, currentSource);
             },
             error: function(jqXHR, textStatus, errorThrown) {
-                if (textStatus == "parsererror")
-                    location.reload();
-                else {
-                    if (textStatus == "abort")
-                        return;
-                    else if (errorThrown)
-                        selfoss.showError('Load list error: '+
-                                          textStatus+' '+errorThrown);
-                    $('.stream-error').show();
-                }
+                if (textStatus == "abort")
+                    return;
+                else if (errorThrown)
+                    selfoss.showError('Load list error: '+
+                                        textStatus+' '+errorThrown);
+                $('.stream-error').show();
             },
             complete: function(jqXHR, textStatus) {
                 // clean up
@@ -323,12 +321,18 @@ var selfoss = {
      * @param tags the new taglist as html
      */
     refreshTags: function(tags) {
-        var currentTag = $('#nav-tags li').index($('#nav-tags .active'));
         $('.color').spectrum('destroy');
         $('#nav-tags li:not(:first)').remove();
         $('#nav-tags').append(tags);
-        if(currentTag>=0)
-            $('#nav-tags li:eq('+currentTag+')').addClass('active');
+        if( selfoss.filter.tag ) {
+            $('#nav-tags li:first').removeClass('active');
+            $('#nav-tags > li').filter(function( index ) {
+                if( $('.tag', this) )
+                    return $('.tag', this).html() == selfoss.filter.tag;
+                else
+                    return false;
+            }).addClass('active');
+        }
         selfoss.events.navigation();
     },
     
@@ -343,11 +347,9 @@ var selfoss = {
      * @param currentSource the index of the active source
      */
     refreshSources: function(sources, currentSource) {
-        var currentSourceIndex = currentSource >= 0 ? currentSource : $('#nav-sources li').index($('#nav-sources .active'));
         $('#nav-sources li').remove();
         $('#nav-sources').append(sources);
-        if(currentSourceIndex>=0)
-            $('#nav-sources li:eq('+currentSourceIndex+')').addClass('active');
+        $('#source' + selfoss.filter.source).addClass('active');
         selfoss.events.navigation();
     },
     
@@ -430,6 +432,11 @@ var selfoss = {
         var articleList = content.html();
         $('#content').addClass('loading').html("");
 
+        // close opened entry and list
+        location.hash = selfoss.events.path;
+        selfoss.filter.extra_ids.length = 0;
+        selfoss.filter.offset = 0;
+
         $.ajax({
             url: $('base').attr('href') + 'mark',
             type: 'POST',
@@ -447,9 +454,6 @@ var selfoss = {
                 // hide nav on smartphone if visible
                 if(selfoss.isSmartphone() && $('#nav').is(':visible')==true)
                     $('#nav-mobile-settings').click();
-
-                // close opened entry
-                selfoss.events.itemId = null;
 
                 // refresh list
                 selfoss.reloadList();

--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -13,6 +13,8 @@ var selfoss = {
      */
     filter: {
         offset: 0,
+        offset_from_datetime: null,
+        offset_from_id: null,
         itemsPerPage: 0,
         search: '',
         type: 'newest',
@@ -146,6 +148,19 @@ var selfoss = {
         if($(window).width()<=640)
             return true;
         return false;
+    },
+
+
+    /**
+     * reset filter
+     *
+     * @return void
+     */
+    filterReset: function() {
+        selfoss.filter.offset = 0;
+        selfoss.filter.offset_from_datetime = null;
+        selfoss.filter.offset_from_id = null;
+        selfoss.filter.extra_ids.length = 0;
     },
     
     
@@ -434,8 +449,7 @@ var selfoss = {
 
         // close opened entry and list
         location.hash = selfoss.events.path;
-        selfoss.filter.extra_ids.length = 0;
-        selfoss.filter.offset = 0;
+        selfoss.filterReset();
 
         $.ajax({
             url: $('base').attr('href') + 'mark',

--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -19,6 +19,7 @@ var selfoss = {
         tag: '',
         source: '',
         sourcesNav: false,
+        extra_ids: [],
         ajax: true
     },
 

--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -177,7 +177,7 @@ var selfoss = {
             return;
         }
 
-        if( selfoss.events.entryId )
+        if( selfoss.events.entryId && selfoss.filter.offset_from_id == null )
             selfoss.filter.extra_ids.push(selfoss.events.entryId);
 
         $('.stream-error').css('display', 'block').hide();

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -103,7 +103,8 @@ selfoss.events.entries = function(e) {
                 selfoss.setupFancyBox(content, parent.attr('id').substr(5));
 
                 // scroll to article header
-                if ($('#config').data('scroll_to_article_header') == '1') {
+                if ($('#config').data('scroll_to_article_header') == '1' ||
+                    selfoss.events.entryId ) {
                   parent.get(0).scrollIntoView();
                 }
             }

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -167,22 +167,7 @@ selfoss.events.entries = function(e) {
     if (selfoss.isSmartphone() == false) {
         $('.entry-source').unbind('click').click(function(e) {
             var entry = $(this).parents('.entry');
-            var deferred = $.Deferred();
-            if ($('#nav-sources-title').is('.nav-sources-collapsed')) {
-                $('#nav-sources-title').trigger('click', deferred.resolve);
-            } else {
-                deferred.resolve();
-            }
-
-            deferred.then(function() {
-                var source = entry.attr('data-entry-source');
-                $('#nav-sources li').each(function(index, item) {
-                    if ($(item).attr('data-source-id') == source) {
-                        $(item).click();
-                        return false;
-                    }
-                });
-            });
+            location.hash = '#' + selfoss.filter.type + '/source-' + entry.attr('data-entry-source');
         });
     }
 

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -140,7 +140,7 @@ selfoss.events.entries = function(e) {
     // more
     $('.stream-more').unbind('click').click(function () {
         var streamMore = $(this);
-        var lastEntry = $('.entry').filter(':last');
+        var lastEntry = $('.entry').not('.fullscreen').filter(':last');
         selfoss.filter.offset_from_datetime = lastEntry.data('entry-datetime');
         selfoss.filter.offset_from_id = lastEntry.data('entry-id');
         

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -25,10 +25,10 @@ selfoss.events.entries = function(e) {
         // anonymize
         selfoss.anonymize(parent.find('.entry-content'));
         
+        var entryId = parent.attr('data-entry-id');
+
          // show entry in popup
         if(selfoss.isSmartphone()) {
-            location.hash = "show";
-            
             // hide nav
             if($('#nav').is(':visible')) {
                 var scrollTop = $(window).scrollTop();
@@ -48,6 +48,7 @@ selfoss.events.entries = function(e) {
             var fullscreen = $('#fullscreen-entry');
             fullscreen.html('<div id="entrr'+parent.attr('data-entry-id')+'" class="entry fullscreen" data-entry-id="'+parent.attr('data-entry-id')+'">'+parent.html()+'</div>');
             fullscreen.show();
+            location.hash = selfoss.events.path + '/' + entryId;
 
             // lazy load images in fullscreen
             if($('#config').data('load_images_on_mobile')=="1") {
@@ -66,7 +67,7 @@ selfoss.events.entries = function(e) {
                     $('#'+parent.attr('id')).hide();
                 }
                 content.show();
-                location.hash = "";
+                location.hash = selfoss.events.path;
                 $(window).scrollTop(scrollTop);
                 fullscreen.hide();
             });
@@ -83,11 +84,13 @@ selfoss.events.entries = function(e) {
             if(content.is(':visible')) {
                 parent.find('.entry-toolbar').hide();
                 content.hide();
+                location.hash = selfoss.events.path;
             } else {
                 if($('#config').data('auto_collapse')=="1"){
                     $('.entry-content, .entry-toolbar').hide();
                 }
                 content.show();
+                location.hash = selfoss.events.path + '/' + entryId;
                 selfoss.events.entriesToolbar(parent);
                 parent.find('.entry-toolbar').show();
                 
@@ -220,4 +223,9 @@ selfoss.events.entries = function(e) {
             }
         });
     });
+
+    // open selected entry
+    if( selfoss.events.entryId) {
+        $('#entry' + selfoss.events.entryId).children('.entry-title').click();
+    }
 };

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -212,8 +212,9 @@ selfoss.events.entries = function(e) {
         });
     });
 
-    // open selected entry
-    if( selfoss.events.entryId) {
+    // open selected entry only if entry was request (i.e. if not streaming
+    // more)
+    if( selfoss.events.entryId && selfoss.filter.offset_from_id == null ) {
         $('#entry' + selfoss.events.entryId).children('.entry-title').click();
     }
 };

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -139,7 +139,9 @@ selfoss.events.entries = function(e) {
     // more
     $('.stream-more').unbind('click').click(function () {
         var streamMore = $(this);
-        selfoss.filter.offset += selfoss.filter.itemsPerPage;
+        var lastEntry = $('.entry').filter(':last');
+        selfoss.filter.offset_from_datetime = lastEntry.data('entry-datetime');
+        selfoss.filter.offset_from_id = lastEntry.data('entry-id');
         
         streamMore.addClass('loading');
         $.ajax({

--- a/public/js/selfoss-events-entriestoolbar.js
+++ b/public/js/selfoss-events-entriestoolbar.js
@@ -192,6 +192,10 @@ selfoss.events.entriesToolbar = function(parent) {
                 url: $('base').attr('href') + (unread ? 'mark/' : 'unmark/') + id,
                 data: { ajax: true },
                 type: 'POST',
+                success: function(data) {
+                    if( unread )
+                        selfoss.filter.extra_ids.push(id);
+                },
                 error: function(jqXHR, textStatus, errorThrown) {
                     // rollback ui changes
                     updateStats(!unread);

--- a/public/js/selfoss-events-entriestoolbar.js
+++ b/public/js/selfoss-events-entriestoolbar.js
@@ -192,10 +192,6 @@ selfoss.events.entriesToolbar = function(parent) {
                 url: $('base').attr('href') + (unread ? 'mark/' : 'unmark/') + id,
                 data: { ajax: true },
                 type: 'POST',
-                success: function(data) {
-                    if( unread )
-                        selfoss.filter.extra_ids.push(id);
-                },
                 error: function(jqXHR, textStatus, errorThrown) {
                     // rollback ui changes
                     updateStats(!unread);

--- a/public/js/selfoss-events-navigation.js
+++ b/public/js/selfoss-events-navigation.js
@@ -121,8 +121,6 @@ selfoss.events.navigation = function() {
                 type: 'GET',
                 success: function(data) {
                     selfoss.refreshSources(data.sources);
-                    selfoss.sourcesNavLoaded = true;
-                    toggle();
                 },
                 error: function(jqXHR, textStatus, errorThrown) {
                     selfoss.showError('Can not load nav stats: '+

--- a/public/js/selfoss-events-navigation.js
+++ b/public/js/selfoss-events-navigation.js
@@ -45,6 +45,7 @@ selfoss.events.navigation = function() {
         $(this).addClass('active');
         
         selfoss.filter.offset = 0;
+        selfoss.filter.extra_ids.length = 0;
         selfoss.reloadList();
         
         if(selfoss.isSmartphone())
@@ -74,6 +75,7 @@ selfoss.events.navigation = function() {
             selfoss.filter.tag = $(this).find('span').html();
             
         selfoss.filter.offset = 0;
+        selfoss.filter.extra_ids.length = 0;
         selfoss.reloadList();
         
         if(selfoss.isSmartphone())
@@ -99,6 +101,7 @@ selfoss.events.navigation = function() {
         selfoss.filter.source = $(this).attr('id').substr(6);
             
         selfoss.filter.offset = 0;
+        selfoss.filter.extra_ids.length = 0;
         selfoss.reloadList();
         
         if(selfoss.isSmartphone())

--- a/public/js/selfoss-events-navigation.js
+++ b/public/js/selfoss-events-navigation.js
@@ -148,16 +148,12 @@ selfoss.events.navigation = function() {
         // show
         if(nav.is(':visible')==false) {
             nav.slideDown(400, function() {
-                location.hash = "nav";
                 $(window).scrollTop(0);
             });
             
         // hide
         } else {
             nav.slideUp(400, function() {
-                if(location.hash=="#nav") {
-                    location.hash = "";
-                }
                 $(window).scrollTop(0);
             });
         }

--- a/public/js/selfoss-events-navigation.js
+++ b/public/js/selfoss-events-navigation.js
@@ -40,15 +40,16 @@ selfoss.events.navigation = function() {
             selfoss.filter.type='unread';
         else if($(this).hasClass('nav-filter-starred'))
             selfoss.filter.type='starred';
+
+        if( selfoss.events.section != selfoss.filter.type ) {
+            location.hash = '#' + selfoss.filter.type
+                            + '/' + selfoss.events.subsection;
+        }
         
         $('#nav-filter > li').removeClass('active');
         $(this).addClass('active');
         
-        selfoss.filter.offset = 0;
-        selfoss.filter.extra_ids.length = 0;
-        selfoss.reloadList();
-        
-        if(selfoss.isSmartphone())
+        if(selfoss.isSmartphone() && $('#nav').is(':visible'))
             $('#nav-mobile-settings').click();
     });
     
@@ -69,16 +70,13 @@ selfoss.events.navigation = function() {
         $('#nav-sources > li').removeClass('active');
         $(this).addClass('active');
         
-        selfoss.filter.source = '';
-        selfoss.filter.tag = '';
-        if($(this).hasClass('nav-tags-all')==false)
-            selfoss.filter.tag = $(this).find('span').html();
+        if($(this).hasClass('nav-tags-all')==false) {
+            location.hash = '#' + selfoss.filter.type + '/tag-' + $(this).find('span').html();
+        } else {
+            location.hash = '#' + selfoss.filter.type + '/all';
+        }
             
-        selfoss.filter.offset = 0;
-        selfoss.filter.extra_ids.length = 0;
-        selfoss.reloadList();
-        
-        if(selfoss.isSmartphone())
+        if(selfoss.isSmartphone() && $('#nav').is(':visible'))
             $('#nav-mobile-settings').click();
     });
     
@@ -96,15 +94,10 @@ selfoss.events.navigation = function() {
         $('#nav-tags > li').removeClass('active');
         $('#nav-sources > li').removeClass('active');
         $(this).addClass('active');
+
+        location.hash = '#' + selfoss.filter.type + '/source-' + $(this).attr('id').substr(6);
         
-        selfoss.filter.tag = '';
-        selfoss.filter.source = $(this).attr('id').substr(6);
-            
-        selfoss.filter.offset = 0;
-        selfoss.filter.extra_ids.length = 0;
-        selfoss.reloadList();
-        
-        if(selfoss.isSmartphone())
+        if(selfoss.isSmartphone() && $('#nav').is(':visible'))
             $('#nav-mobile-settings').click();
     });
     

--- a/public/js/selfoss-events-navigation.js
+++ b/public/js/selfoss-events-navigation.js
@@ -102,16 +102,13 @@ selfoss.events.navigation = function() {
     });
     
     // hide/show sources
-    $('#nav-sources-title').unbind('click').click(function (e, onExpand) {
+    $('#nav-sources-title').unbind('click').click(function () {
         var toggle = function () {
             $('#nav-sources').slideToggle("slow");
             $('#nav-sources-title').toggleClass("nav-sources-collapsed nav-sources-expanded");
             $('#nav-sources-title').attr('aria-expanded', function (i, attr) {
                 return attr == 'true' ? 'false' : 'true';
             });
-            if (typeof onExpand == 'function') {
-                onExpand();
-            }
         }
 
         selfoss.filter.sourcesNav = $('#nav-sources-title').hasClass("nav-sources-collapsed");

--- a/public/js/selfoss-events-navigation.js
+++ b/public/js/selfoss-events-navigation.js
@@ -71,7 +71,7 @@ selfoss.events.navigation = function() {
         $(this).addClass('active');
         
         if($(this).hasClass('nav-tags-all')==false) {
-            location.hash = '#' + selfoss.filter.type + '/tag-' + $(this).find('span').html();
+            location.hash = '#' + selfoss.filter.type + '/tag-' + $(this).find('span').html().replace('%', '%25');
         } else {
             location.hash = '#' + selfoss.filter.type + '/all';
         }

--- a/public/js/selfoss-events-search.js
+++ b/public/js/selfoss-events-search.js
@@ -37,6 +37,7 @@ selfoss.events.search = function() {
         // execute search
         $('#search').removeClass('active');
         selfoss.filter.offset = 0;
+        selfoss.filter.extra_ids.length = 0;
         selfoss.filter.search = term;
         selfoss.reloadList();
         
@@ -90,6 +91,7 @@ selfoss.events.search = function() {
         }
         
         selfoss.filter.offset = 0;
+        selfoss.filter.extra_ids.length = 0;
         selfoss.filter.search = '';
         $('#search-list').hide();
         $('#search-list').html('');

--- a/public/js/selfoss-events-search.js
+++ b/public/js/selfoss-events-search.js
@@ -36,8 +36,7 @@ selfoss.events.search = function() {
         
         // execute search
         $('#search').removeClass('active');
-        selfoss.filter.offset = 0;
-        selfoss.filter.extra_ids.length = 0;
+        selfoss.filterReset();
         selfoss.filter.search = term;
         selfoss.reloadList();
         
@@ -90,8 +89,7 @@ selfoss.events.search = function() {
             return;
         }
         
-        selfoss.filter.offset = 0;
-        selfoss.filter.extra_ids.length = 0;
+        selfoss.filterReset();
         selfoss.filter.search = '';
         $('#search-list').hide();
         $('#search-list').html('');

--- a/public/js/selfoss-events-search.js
+++ b/public/js/selfoss-events-search.js
@@ -38,6 +38,7 @@ selfoss.events.search = function() {
         $('#search').removeClass('active');
         selfoss.filterReset();
         selfoss.filter.search = term;
+        selfoss.events.processHash(selfoss.events.path);
         selfoss.reloadList();
         
         if(term=="")
@@ -91,6 +92,7 @@ selfoss.events.search = function() {
         
         selfoss.filterReset();
         selfoss.filter.search = '';
+        selfoss.events.processHash(selfoss.events.path);
         $('#search-list').hide();
         $('#search-list').html('');
         $('#search').removeClass('active');

--- a/public/js/selfoss-events.js
+++ b/public/js/selfoss-events.js
@@ -46,11 +46,14 @@ selfoss.events = {
      * handle History change
      */
     hashChange: function() {
-        if( location.hash == selfoss.events.lasthash )
+        // assume the hash is encoded
+        var hash = decodeURIComponent(location.href.split('#').splice(1).join('#'));
+
+        if( hash == selfoss.events.lasthash )
             return;
 
         // parse hash
-        var hashPath = location.hash.substring(1).split('/');
+        var hashPath = hash.split('/');
 
         selfoss.events.section = hashPath[0];
 
@@ -69,7 +72,7 @@ selfoss.events = {
         else
             selfoss.events.entryId = null;
 
-        selfoss.events.lasthash = location.hash;
+        selfoss.events.lasthash = hash;
 
         // do not reload list if list is the same
         if ( selfoss.events.lastpath == selfoss.events.path )
@@ -81,7 +84,7 @@ selfoss.events = {
             selfoss.filter.tag = '';
             selfoss.filter.source = '';
             if( selfoss.events.subsection.substr(0, 4) == 'tag-') {
-                selfoss.filter.tag = decodeURIComponent(selfoss.events.subsection.substr(4));
+                selfoss.filter.tag = selfoss.events.subsection.substr(4);
             } else if( selfoss.events.subsection.substr(0, 7) == 'source-') {
                 var sourceId = parseInt(selfoss.events.subsection.substr(7));
                 if( sourceId ) {
@@ -94,7 +97,7 @@ selfoss.events = {
 
             $('#nav-filter-'+selfoss.events.section).click();
             selfoss.reloadList();
-        } else if(location.hash=="#sources") { // load sources
+        } else if(hash=="sources") { // load sources
             if (selfoss.activeAjaxReq !== null)
                 selfoss.activeAjaxReq.abort();
 

--- a/public/js/selfoss-events.js
+++ b/public/js/selfoss-events.js
@@ -3,13 +3,17 @@ selfoss.events = {
     /* last hash before hash change */
     lasthash: "",
 
+    path:       null,
+    lastpath:   null,
+    section:    null,
+    subsection: 'all',
+    entryId:    null,
+
     /**
      * init events when page loads first time
      */
     init: function() {
         selfoss.events.navigation();
-        selfoss.events.entries();
-        selfoss.events.search();
 
         // re-init on media query change
         if ((typeof window.matchMedia) != "undefined") {
@@ -26,14 +30,15 @@ selfoss.events = {
         });
         $(window).bind("resize", selfoss.events.resize);
         selfoss.events.resize();
+
+        if( location.hash == '' )
+            location.hash = '#' + $('#config').data('homepage') + '/all';
         
         // hash change event
         window.onhashchange = selfoss.events.hashChange;
-        
-        // remove given hash (we just use it for history support)
-        if(location.hash.trim().length!=0)
-            location.hash = "";
 
+        // process current hash
+        selfoss.events.hashChange();
     },
     
     
@@ -41,26 +46,55 @@ selfoss.events = {
      * handle History change
      */
     hashChange: function() {
-        // return to main page
-        if(location.hash.length==0) {
-            // from entry popup
-            if(selfoss.events.lasthash=="#show" && $('#fullscreen-entry').is(':visible')) {
-                $('#fullscreen-entry .entry-close').click();
+        if( location.hash == selfoss.events.lasthash )
+            return;
+
+        // parse hash
+        var hashPath = location.hash.substring(1).split('/');
+
+        selfoss.events.section = hashPath[0];
+
+        if( hashPath.length > 1 ) {
+            selfoss.events.subsection = hashPath[1];
+        } else
+            selfoss.events.subsection = 'all';
+
+        selfoss.events.lastpath = selfoss.events.path;
+        selfoss.events.path = selfoss.events.section
+                              + '/' + selfoss.events.subsection;
+
+        var entryId = null;
+        if( hashPath.length > 2 && (entryId = parseInt(hashPath[2])) )
+            selfoss.events.entryId = entryId;
+        else
+            selfoss.events.entryId = null;
+
+        selfoss.events.lasthash = location.hash;
+
+        // do not reload list if list is the same
+        if ( selfoss.events.lastpath == selfoss.events.path )
+            return;
+
+        // load items
+        if( $.inArray(selfoss.events.section,
+                      ["newest", "unread", "starred"]) > -1 ) {
+            selfoss.filter.tag = '';
+            selfoss.filter.source = '';
+            if( selfoss.events.subsection.substr(0, 4) == 'tag-') {
+                selfoss.filter.tag = selfoss.events.subsection.substr(4);
+            } else if( selfoss.events.subsection.substr(0, 7) == 'source-') {
+                var sourceId = parseInt(selfoss.events.subsection.substr(7));
+                if( sourceId ) {
+                    selfoss.filter.source = sourceId;
+                }
             }
-                
-            // from sources
-            if(selfoss.events.lasthash=="#sources") {
-                $('#nav-filter li.active').click();
-            }
-                
-            // from navigation
-            if(selfoss.events.lasthash=="#nav" && $('#nav').is(':visible')) {
-                $('#nav-mobile-settings').click();
-            }
-        }
-        
-        // load sources
-        if(location.hash=="#sources") {
+
+            selfoss.filter.offset = 0;
+            selfoss.filter.extra_ids.length = 0;
+
+            $('#nav-filter-'+selfoss.events.section).click();
+            selfoss.reloadList();
+        } else if(location.hash=="#sources") { // load sources
             if (selfoss.activeAjaxReq !== null)
                 selfoss.activeAjaxReq.abort();
 
@@ -84,8 +118,6 @@ selfoss.events = {
                 }
             });
         }
-        
-        selfoss.events.lasthash = location.hash;
     },
     
     

--- a/public/js/selfoss-events.js
+++ b/public/js/selfoss-events.js
@@ -81,7 +81,7 @@ selfoss.events = {
             selfoss.filter.tag = '';
             selfoss.filter.source = '';
             if( selfoss.events.subsection.substr(0, 4) == 'tag-') {
-                selfoss.filter.tag = selfoss.events.subsection.substr(4);
+                selfoss.filter.tag = decodeURIComponent(selfoss.events.subsection.substr(4));
             } else if( selfoss.events.subsection.substr(0, 7) == 'source-') {
                 var sourceId = parseInt(selfoss.events.subsection.substr(7));
                 if( sourceId ) {

--- a/public/js/selfoss-events.js
+++ b/public/js/selfoss-events.js
@@ -89,11 +89,11 @@ selfoss.events = {
                 var sourceId = parseInt(selfoss.events.subsection.substr(7));
                 if( sourceId ) {
                     selfoss.filter.source = sourceId;
+                    selfoss.filter.sourcesNav = true;
                 }
             }
 
-            selfoss.filter.offset = 0;
-            selfoss.filter.extra_ids.length = 0;
+            selfoss.filterReset();
 
             $('#nav-filter-'+selfoss.events.section).click();
             selfoss.reloadList();

--- a/public/js/selfoss-events.js
+++ b/public/js/selfoss-events.js
@@ -38,7 +38,7 @@ selfoss.events = {
         window.onhashchange = selfoss.events.hashChange;
 
         // process current hash
-        selfoss.events.hashChange();
+        selfoss.events.processHash();
     },
     
     
@@ -46,11 +46,29 @@ selfoss.events = {
      * handle History change
      */
     hashChange: function() {
+        if( selfoss.events.processHashChange )
+            selfoss.events.processHash();
+    },
+
+    processHashChange: true,
+
+    processHash: function(hash=false) {
+        var done = function() {
+            selfoss.events.processHashChange = true;
+        };
+
+        if( hash ) {
+            selfoss.events.processHashChange = false;
+            location.hash = hash
+        }
+
         // assume the hash is encoded
         var hash = decodeURIComponent(location.href.split('#').splice(1).join('#'));
 
-        if( hash == selfoss.events.lasthash )
+        if( hash == selfoss.events.lasthash ) {
+            done();
             return;
+        }
 
         // parse hash
         var hashPath = hash.split('/');
@@ -75,8 +93,10 @@ selfoss.events = {
         selfoss.events.lasthash = hash;
 
         // do not reload list if list is the same
-        if ( selfoss.events.lastpath == selfoss.events.path )
+        if ( selfoss.events.lastpath == selfoss.events.path ) {
+            done();
             return;
+        }
 
         // load items
         if( $.inArray(selfoss.events.section,
@@ -121,6 +141,7 @@ selfoss.events = {
                 }
             });
         }
+        done();
     },
     
     

--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -70,6 +70,7 @@
 
     <!-- other settings -->
     <span id="config"
+        data-homepage="<?PHP echo (\F3::get('homepage')) ? \F3::get('homepage') : 'newest' ?>"
         data-anonymizer="<?PHP echo \helpers\Anonymizer::getAnonymizer(); ?>"
         data-share="<?PHP echo \F3::get('share'); ?>"
         data-wallabag="<?PHP echo \F3::get('wallabag'); ?>"
@@ -85,7 +86,7 @@
 
     <!-- menue open for smartphone -->
     <div id="nav-mobile">
-        <div id="nav-mobile-logo"><span class="unread-count<?PHP echo $this->statsUnread>0 ? ' unread' : ''; ?>"><?PHP echo $this->statsUnread; ?></span></div>
+        <div id="nav-mobile-logo"><span class="unread-count"></span></div>
         <div id="nav-mobile-settings"></div>
     </div>
     
@@ -94,13 +95,12 @@
         <div id="nav-logo"></div>
         <button id="nav-mark"><?PHP echo \F3::get('lang_markread')?></button>
 
-        <?PHP $active = (\F3::get('homepage')) ? \F3::get('homepage') : 'newest' ?>
         <div id="nav-filter-wrapper">
         <h2 id="nav-filter-title" class="nav-filter-expanded" tabindex="0" aria-haspopup="true" aria-expanded="true"><?PHP echo \F3::get('lang_filter') ?></h2>
         <ul id="nav-filter">
-            <li id="nav-filter-newest" class="nav-filter-newest<?PHP if($active=='newest') : ?> active<?PHP endif; ?>" role="link" tabindex="0"><?PHP echo \F3::get('lang_newest')?> <span><?PHP echo $this->statsAll; ?></span></li>
-            <li id="nav-filter-unread" class="nav-filter-unread<?PHP if($active=='unread') : ?> active<?PHP endif; ?>" role="link" tabindex="0"><?PHP echo \F3::get('lang_unread')?> <span class="unread-count<?PHP echo $this->statsUnread>0 ? ' unread' : ''; ?>"><?PHP echo $this->statsUnread; ?></span></li>
-            <li id="nav-filter-starred" class="nav-filter-starred<?PHP if($active=='starred') : ?> active<?PHP endif; ?>" role="link" tabindex="0"><?PHP echo \F3::get('lang_starred') ?> <span><?PHP echo $this->statsStarred; ?></span></li>
+            <li id="nav-filter-newest" class="nav-filter-newest" role="link" tabindex="0"><?PHP echo \F3::get('lang_newest')?> <span></span></li>
+            <li id="nav-filter-unread" class="nav-filter-unread" role="link" tabindex="0"><?PHP echo \F3::get('lang_unread')?> <span class="unread-count"></span></li>
+            <li id="nav-filter-starred" class="nav-filter-starred" role="link" tabindex="0"><?PHP echo \F3::get('lang_starred') ?> <span></span></li>
         </ul>
         </div>
 
@@ -110,11 +110,9 @@
         <h2 id="nav-tags-title" class="nav-tags-expanded" tabindex="0" aria-haspopup="true" aria-expanded="true"><?PHP echo \F3::get('lang_tags') ?></h2>
         <ul id="nav-tags">
             <li class="active nav-tags-all" role="link" tabindex="0"><?PHP echo \F3::get('lang_alltags')?></li>
-            <?PHP echo $this->tags; ?>
         </ul>
         <h2 id="nav-sources-title" class="nav-sources-collapsed" tabindex="0" aria-haspopup="true" aria-expanded="false"><?PHP echo \F3::get('lang_sources') ?></h2>
         <ul id="nav-sources">
-            <?PHP echo $this->sources; ?>
         </ul>
         </div>
         

--- a/templates/item.phtml
+++ b/templates/item.phtml
@@ -22,6 +22,7 @@
 <div id="entry<?PHP echo $this->item['id']; ?>"
      data-entry-id="<?PHP echo $this->item['id']; ?>"
      data-entry-source="<?PHP echo $this->item['source']; ?>"
+     data-entry-datetime="<?PHP echo $this->item['datetime']; ?>"
      class="entry
             <?PHP echo $this->item['unread']==1 ? 'unread' : ''; ?>" role="article">
 


### PR DESCRIPTION
These patches make selfoss navigable using the url hash. This makes the url reflect whats displayed in selfoss. This also makes it possible to reload the item that was open before a browser crash or when the tab containing selfoss was offloaded from memory on a mobile browser.