### PR TITLE
Open item link failed on mobile sometimes

### DIFF
--- a/public/js/selfoss-events-entriestoolbar.js
+++ b/public/js/selfoss-events-entriestoolbar.js
@@ -21,7 +21,8 @@ selfoss.events.entriesToolbar = function(parent) {
     
     // open in new window
     parent.find('.entry-newwindow').unbind('click').click(function(e) {
-        window.open($(this).parents(".entry").children(".entry-datetime").attr("href"));
+        var itemLink = $(this).parents(".entry").children(".entry-datetime").attr("href");
+        window.open(itemLink);
         e.preventDefault();
         return false;
     });


### PR DESCRIPTION
Couldn't find the exakt reason but sometimes I wasn't able to open item links with the "open" Button on mobile. The window opened with "about:blank" on Chrome (Android 5.1.1).

This is an example on how it works to me now.
Maybe someone knows there might be a problem on mobile devices and knows a better solution.