### PR TITLE
Prevent “$HTTP_RAW_POST_DATA is deprecated” error

### DIFF
--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -204,7 +204,7 @@ selfoss.events.entries = function(e) {
             url: $('base').attr('href') + 'source/' + selfoss.filter.source + '/update',
             type: 'POST',
             dataType: 'text',
-            data: {},
+            data: { ajax: true },
             success: function(response) {
                 // hide nav on smartphone
                 if(selfoss.isSmartphone()) {


### PR DESCRIPTION
Fixes another instance of #565, this time when refreshing single source.