### PR TITLE
Sync client from server using last update timestamp

### DIFF
--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -48,8 +48,8 @@ class Index extends BaseController {
         $tags = $tagsDao->getWithUnread();
         
         // load items
-        $itemsHtml = $this->loadItems($options, $tags);
-        $this->view->content = $itemsHtml;
+        $items = $this->loadItems($options, $tags);
+        $this->view->content = $items['html'];
         
         // load stats
         $itemsDao = new \daos\Items();
@@ -82,6 +82,7 @@ class Index extends BaseController {
         if(isset($options['ajax'])) {
             $this->view->jsonSuccess(array(
                 "lastUpdate" => \helpers\ViewHelper::date_iso8601($itemsDao->lastUpdate()),
+                "hasMore"    => $items['hasMore'],
                 "entries"    => $this->view->content,
                 "all"        => $this->view->statsAll,
                 "unread"     => $this->view->statsUnread,
@@ -255,15 +256,10 @@ class Index extends BaseController {
             $itemsHtml .= $this->view->render('templates/item.phtml');
         }
 
-        if(strlen($itemsHtml)==0) {
-            $itemsHtml = '<div class="stream-empty">'. \F3::get('lang_no_entries').'</div>';
-        } else {
-            if($itemDao->hasMore())
-                $itemsHtml .= '<div class="stream-more"><span>'. \F3::get('lang_more').'</span></div>';
-                $itemsHtml .= '<div class="mark-these-read"><span>'. \F3::get('lang_markread').'</span></div>';
-        }
-        
-        return $itemsHtml;
+        return array(
+            'html'    => $itemsHtml,
+            'hasMore' => $itemDao->hasMore()
+        );
     }
     
     

--- a/controllers/Index.php
+++ b/controllers/Index.php
@@ -81,12 +81,13 @@ class Index extends BaseController {
         // ajax call = only send entries and statistics not full template
         if(isset($options['ajax'])) {
             $this->view->jsonSuccess(array(
-                "entries"  => $this->view->content,
-                "all"      => $this->view->statsAll,
-                "unread"   => $this->view->statsUnread,
-                "starred"  => $this->view->statsStarred,
-                "tags"     => $this->view->tags,
-                "sources"  => $this->view->sources
+                "lastUpdate" => \helpers\ViewHelper::date_iso8601($itemsDao->lastUpdate()),
+                "entries"    => $this->view->content,
+                "all"        => $this->view->statsAll,
+                "unread"     => $this->view->statsUnread,
+                "starred"    => $this->view->statsStarred,
+                "tags"       => $this->view->tags,
+                "sources"    => $this->view->sources
             ));
         }
     }

--- a/controllers/Items.php
+++ b/controllers/Items.php
@@ -189,7 +189,7 @@ class Items extends BaseController {
         $last_update = new \DateTime($itemsDao->lastUpdate());
 
         $sync = array(
-            'last_update' => $last_update->format(\DateTime::ISO8601),
+            'last_update' => $last_update->format(\DateTime::ATOM),
         );
 
         if( $last_update > $since ) {
@@ -208,7 +208,7 @@ class Items extends BaseController {
 
             $wantItemsStatuses = array_key_exists('items_statuses', $_GET) && $_GET['items_statuses'] == 'true';
             if( $wantItemsStatuses ) {
-                $sync['items'] = $itemsDao->statuses($since->format(\DateTime::ISO8601));
+                $sync['items'] = $itemsDao->statuses($since->format(\DateTime::ATOM));
             }
         }
         $this->view->jsonSuccess($sync);

--- a/daos/mysql/Database.php
+++ b/daos/mysql/Database.php
@@ -229,4 +229,37 @@ class Database {
     public function optimize() {
         @\F3::get('db')->exec('OPTIMIZE TABLE `'.\F3::get('db_prefix').'sources`, `'.\F3::get('db_prefix').'items`');
     }
+
+
+    /**
+     * Ensure row values have the appropriate PHP type. This assumes we are
+     * using buffered queries (sql results are in PHP memory).
+     *
+     * @param expectedRowTypes associative array mapping columns to PDO types
+     * @param rows array of associative array representing row results
+     * @return array of associative array representing row results having
+     *         expected types
+     */
+    public function ensureRowTypes($expectedRowTypes, &$rows) {
+        foreach($rows as $rowIndex => $row) {
+            foreach($expectedRowTypes as $column => $type) {
+                if( array_key_exists($column, $row) ) {
+                    switch($type) {
+                        case \PDO::PARAM_INT:
+                            $value = intval($row[$column]);
+                            break;
+                        case \PDO::PARAM_BOOL:
+                            if( $row[$column] == "1" )
+                                $value = true;
+                            else
+                                $value = false;
+                            break;
+                    }
+                    // $row is only a reference, so we change $rows[$rowIndex]
+                    $rows[$rowIndex][$column] = $value;
+                }
+            }
+        }
+        return $rows;
+    }
 }

--- a/daos/mysql/Database.php
+++ b/daos/mysql/Database.php
@@ -240,7 +240,7 @@ class Database {
      * @return array of associative array representing row results having
      *         expected types
      */
-    public function ensureRowTypes($expectedRowTypes, &$rows) {
+    public function ensureRowTypes($expectedRowTypes, $rows) {
         foreach($rows as $rowIndex => $row) {
             foreach($expectedRowTypes as $column => $type) {
                 if( array_key_exists($column, $row) ) {

--- a/daos/mysql/Items.php
+++ b/daos/mysql/Items.php
@@ -476,10 +476,10 @@ class Items extends Database {
             '.$this->stmt->sumBool('unread').' AS unread,
             '.$this->stmt->sumBool('starred').' AS starred
             FROM '.\F3::get('db_prefix').'items;');
-        $this->ensureRowTypes(array('total'   => \PDO::PARAM_INT,
-                                    'unread'  => \PDO::PARAM_INT,
-                                    'starred' => \PDO::PARAM_INT),
-                              $res);
+        $res = $this->ensureRowTypes(array('total'   => \PDO::PARAM_INT,
+                                           'unread'  => \PDO::PARAM_INT,
+                                           'starred' => \PDO::PARAM_INT),
+                                     $res);
         return $res[0];
     }
 
@@ -508,10 +508,10 @@ class Items extends Database {
             FROM '.\F3::get('db_prefix').'items
             WHERE '.\F3::get('db_prefix').'items.updatetime > :since;',
                 array(':since' => array($since, \PDO::PARAM_STR)));
-        $this->ensureRowTypes(array('id'      => \PDO::PARAM_INT,
-                                    'unread'  => \PDO::PARAM_BOOL,
-                                    'starred' => \PDO::PARAM_BOOL),
-                              $res);
+        $res = $this->ensureRowTypes(array('id'      => \PDO::PARAM_INT,
+                                           'unread'  => \PDO::PARAM_BOOL,
+                                           'starred' => \PDO::PARAM_BOOL),
+                                     $res);
         return $res;
     }
 }

--- a/daos/mysql/Items.php
+++ b/daos/mysql/Items.php
@@ -476,6 +476,10 @@ class Items extends Database {
             '.$this->stmt->sumBool('unread').' AS unread,
             '.$this->stmt->sumBool('starred').' AS starred
             FROM '.\F3::get('db_prefix').'items;');
+        $this->ensureRowTypes(array('total'   => \PDO::PARAM_INT,
+                                    'unread'  => \PDO::PARAM_INT,
+                                    'starred' => \PDO::PARAM_INT),
+                              $res);
         return $res[0];
     }
 
@@ -504,6 +508,10 @@ class Items extends Database {
             FROM '.\F3::get('db_prefix').'items
             WHERE '.\F3::get('db_prefix').'items.updatetime > :since;',
                 array(':since' => array($since, \PDO::PARAM_STR)));
+        $this->ensureRowTypes(array('id'      => \PDO::PARAM_INT,
+                                    'unread'  => \PDO::PARAM_BOOL,
+                                    'starred' => \PDO::PARAM_BOOL),
+                              $res);
         return $res;
     }
 }

--- a/daos/mysql/Items.php
+++ b/daos/mysql/Items.php
@@ -478,4 +478,32 @@ class Items extends Database {
             FROM '.\F3::get('db_prefix').'items;');
         return $res[0];
     }
+
+
+    /**
+     * returns the datetime of the last item update or user action in db
+     *
+     * @return timestamp
+     */
+    public function lastUpdate() {
+        $res = \F3::get('db')->exec('SELECT
+            MAX(updatetime) AS last_update_time
+            FROM '.\F3::get('db_prefix').'items;');
+        return $res[0]['last_update_time'];
+    }
+
+
+    /**
+     * returns the statuses of items last update
+     *
+     * @param date since to return item statuses
+     * @return array of unread, starred, etc. status of specified items
+     */
+    public function statuses($since) {
+        $res = \F3::get('db')->exec('SELECT id, unread, starred
+            FROM '.\F3::get('db_prefix').'items
+            WHERE '.\F3::get('db_prefix').'items.updatetime > :since;',
+                array(':since' => array($since, \PDO::PARAM_STR)));
+        return $res;
+    }
 }

--- a/daos/pgsql/Database.php
+++ b/daos/pgsql/Database.php
@@ -245,7 +245,7 @@ class Database {
      * @return array of associative array representing row results having
      *         expected types
      */
-    public function ensureRowTypes($expectedRowTypes, &$rows) {
+    public function ensureRowTypes($expectedRowTypes, $rows) {
         return $rows; // pgsql returns correct PHP types
     }
 }

--- a/daos/pgsql/Database.php
+++ b/daos/pgsql/Database.php
@@ -205,6 +205,13 @@ class Database {
                         'INSERT INTO version (version) VALUES (9);'
                     ));
                 }
+                if(strnatcmp($version, "10") < 0) {
+                    \F3::get('db')->exec(array(
+                        'ALTER TABLE items ALTER COLUMN datetime SET DATA TYPE timestamp(0) with time zone;',
+                        'ALTER TABLE items ALTER COLUMN updatetime SET DATA TYPE timestamp(0) with time zone;',
+                        'INSERT INTO version (version) VALUES (10);'
+                    ));
+                }
             }
             
             // just initialize once

--- a/daos/pgsql/Database.php
+++ b/daos/pgsql/Database.php
@@ -234,4 +234,18 @@ class Database {
     public function optimize() {
         \F3::get('db')->exec("VACUUM ANALYZE");
     }
+
+
+    /**
+     * Ensure row values have the appropriate PHP type. This assumes we are
+     * using buffered queries (sql results are in PHP memory).
+     *
+     * @param expectedRowTypes associative array mapping columns to PDO types
+     * @param rows array of associative array representing row results
+     * @return array of associative array representing row results having
+     *         expected types
+     */
+    public function ensureRowTypes($expectedRowTypes, $rows) {
+        return $rows; // pgsql returns correct PHP types
+    }
 }

--- a/daos/pgsql/Database.php
+++ b/daos/pgsql/Database.php
@@ -245,7 +245,7 @@ class Database {
      * @return array of associative array representing row results having
      *         expected types
      */
-    public function ensureRowTypes($expectedRowTypes, $rows) {
+    public function ensureRowTypes($expectedRowTypes, &$rows) {
         return $rows; // pgsql returns correct PHP types
     }
 }

--- a/helpers/ViewHelper.php
+++ b/helpers/ViewHelper.php
@@ -79,7 +79,7 @@ class ViewHelper {
      */
     public static function date_iso8601($datestr) {
         $date = new \DateTime($datestr);
-        return $date->format(\DateTime::ISO8601);
+        return $date->format(\DateTime::ATOM);
     }
 
 

--- a/helpers/ViewHelper.php
+++ b/helpers/ViewHelper.php
@@ -70,6 +70,19 @@ class ViewHelper {
         return \F3::get('lang_timestamp', $date->getTimestamp());
     }
 
+
+    /**
+     * Return ISO8601 formatted date
+     *
+     * @param sql date
+     * @return string
+     */
+    public static function date_iso8601($datestr) {
+        $date = new \DateTime($datestr);
+        return $date->format(\DateTime::ISO8601);
+    }
+
+
     /**
      * Proxify imgs through atmos/camo when not https
      *

--- a/index.php
+++ b/index.php
@@ -68,6 +68,7 @@ $f3->route('GET /items',         'controllers\Items->listItems');   // json
 $f3->route('GET /tags',          'controllers\Tags->listTags');     // json
 $f3->route('GET /tagslist',      'controllers\Tags->tagslist');     // html
 $f3->route('GET /stats',         'controllers\Items->stats');       // json
+$f3->route('GET /items/sync',    'controllers\Items->sync');        // json
 $f3->route('GET /sources/stats', 'controllers\Sources->stats');     // json
 
 // only loggedin users

--- a/index.php
+++ b/index.php
@@ -22,6 +22,7 @@ $js=array(
     'public/js/selfoss-base.js',
     'public/js/selfoss-shares.js',
     'public/js/selfoss-db.js',
+    'public/js/selfoss-ui.js',
     'public/js/selfoss-events.js',
     'public/js/selfoss-events-navigation.js',
     'public/js/selfoss-events-search.js',

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -281,6 +281,10 @@ body * {
     #nav-refresh {
         background:url(images/nav-refresh.png) no-repeat center center #272325;
     }
+
+    #nav-refresh.loading {
+        background:url(images/ajax-loader.gif) center center no-repeat;
+    }
     
     #nav-settings {
         background:url(images/nav-sources.png) no-repeat center center #272325;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -398,14 +398,18 @@ body * {
     
 /* content */
 
-#content {
+#content, #stream-buttons {
     margin-left:220px;
+}
+
+#content {
     padding-top:20px;
     padding-bottom:20px;
 }
 
-    #content .stream-empty {
+    .stream-empty {
         text-align:center;
+        display: none;
     }
 
     #content.loading {
@@ -686,6 +690,7 @@ body * {
         font-weight:bold;
         cursor:pointer;
         text-align:center;
+        display: none;
     }
     
         .touch .stream-more {
@@ -1244,10 +1249,14 @@ body.publicmode.notloggedin .entry-unread {
         margin-left:10px;
     }
     
-    #content {
+    #content, #stream-buttons {
         margin:0;
         padding:0;
         width:100%;
+    }
+
+    .stream-empty {
+        padding-top: 20px;
     }
     
         .source,
@@ -1390,11 +1399,15 @@ body.publicmode.notloggedin .entry-unread {
         width:135px;
 	}
 	
-    #content {
+    #content, #stream-buttons {
         margin-left:165px;
         margin-top:0;
         margin-right:0;
         padding:0;
+    }
+
+    .stream-empty {
+        padding-top: 20px;
     }
     
  }

--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -243,9 +243,9 @@ var selfoss = {
      *
      * @return void
      */
-    sync: function() {
-        if( selfoss.lastUpdate == null ||
-            Date.now() - selfoss.lastSync < 5*60*1000 )
+    sync: function(force=false) {
+        if( !force && (selfoss.lastUpdate == null ||
+                       Date.now() - selfoss.lastSync < 5*60*1000) )
             return;
 
         $.ajax({

--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -274,6 +274,9 @@ var selfoss = {
 
                     if( 'sourceshtml' in data )
                         selfoss.refreshSources(data.sourceshtml);
+
+                    if( 'items' in data )
+                        selfoss.ui.refreshItemStatuses(data.items);
                 }
                 selfoss.lastUpdate = dataDate;
             },

--- a/public/js/selfoss-base.js
+++ b/public/js/selfoss-base.js
@@ -243,7 +243,9 @@ var selfoss = {
      *
      * @return void
      */
-    sync: function(force=false) {
+    sync: function(force) {
+        var force = (typeof force !== 'undefined') ? force : false;
+
         if( !force && (selfoss.lastUpdate == null ||
                        Date.now() - selfoss.lastSync < 5*60*1000) )
             return;
@@ -251,6 +253,7 @@ var selfoss = {
         $.ajax({
             url: 'items/sync',
             type: 'GET',
+            dataType: 'json',
             data: {
                 since:          selfoss.lastUpdate.toISOString(),
                 tags:           true,

--- a/public/js/selfoss-db.js
+++ b/public/js/selfoss-db.js
@@ -21,7 +21,7 @@ selfoss.db = {
             return !isValid; // break the loop if valid
         });
         return isValid;
-    },
+    }
 
 
 };

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -127,7 +127,7 @@ selfoss.events.entries = function(e) {
             return;
     
         var content = $('#content');
-        if($('.stream-more').length > 0 
+        if($('.stream-more').is(':visible')
            && $('.stream-more').position().top < $(window).height() + $(window).scrollTop() 
            && $('.stream-more').hasClass('loading')==false)
             $('.stream-more').click();

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -153,8 +153,9 @@ selfoss.events.entries = function(e) {
             dataType: 'json',
             data: selfoss.filter,
             success: function(data) {
-                streamMore.siblings('.mark-these-read').remove();
-                $('.stream-more').replaceWith(data.entries);
+                streamMore.removeClass('loading');
+                lastEntry.after(data.entries);
+                selfoss.ui.refreshStreamButtons(true, true, data.hasMore)
                 selfoss.events.entries();
             },
             error: function(jqXHR, textStatus, errorThrown) {

--- a/public/js/selfoss-events-entriestoolbar.js
+++ b/public/js/selfoss-events-entriestoolbar.js
@@ -72,19 +72,8 @@ selfoss.events.entriesToolbar = function(parent) {
             var parent = $(this).parents('.entry');
             var id = parent.attr('id').substr(5);
             var starr = $(this).hasClass('active')==false;
-            var button = $("#entry"+id+" .entry-starr, #entrr"+id+" .entry-starr");
-            
-            // update button
-            var setButton = function(starr) {
-                if(starr) {
-                    button.addClass('active');
-                    button.html($('#lang').data('unstar'));
-                } else {
-                    button.removeClass('active');
-                    button.html($('#lang').data('star'));
-                }
-            };
-            setButton(starr);
+
+            selfoss.ui.entryStarr(id, starr);
             
             // update statistics in main menue
             var updateStats = function(starr) {
@@ -104,7 +93,7 @@ selfoss.events.entriesToolbar = function(parent) {
                 type: 'POST',
                 error: function(jqXHR, textStatus, errorThrown) {
                     // rollback ui changes
-                    setButton(!starr);
+                    selfoss.ui.entryStarr(id, starr);
                     updateStats(!starr);
                     selfoss.showError('Can not star/unstar item: '+
                                       textStatus+' '+errorThrown);
@@ -119,22 +108,8 @@ selfoss.events.entriesToolbar = function(parent) {
             var entry = $(this).parents('.entry');
             var id = entry.attr('data-entry-id');
             var unread = $(this).hasClass('active')==true;
-            var button = $("#entry"+id+" .entry-unread, #entrr"+id+" .entry-unread");
-            var parent = $("#entry"+id+", #entrr"+id);
 
-            // update button
-            var setButton = function(unread) {
-                if(unread) {
-                    button.removeClass('active');
-                    button.html($('#lang').data('unmark'));
-                    parent.removeClass('unread');
-                } else {
-                    button.addClass('active');
-                    button.html($('#lang').data('mark'));
-                    parent.addClass('unread');
-                }
-            };
-            setButton(unread);
+            selfoss.ui.entryMark(id, !unread);
             
             // update statistics in main menue and the currently active tag
             var updateStats = function(unread) {
@@ -147,20 +122,22 @@ selfoss.events.entriesToolbar = function(parent) {
                 }
                 selfoss.refreshUnread(unreadstats);
                     
-                // update unread count on sources
-                var sourceId = entry.attr('data-entry-source');
-                var sourceNav = $('#source'+sourceId+' .unread');
-                var sourceCount = parseInt(sourceNav.html());
-                if(typeof sourceCount != "number" || isNaN(sourceCount)==true)
-                    sourceCount = 0;
-                sourceCount = unread ? sourceCount-1 : sourceCount+1;
-                if(sourceCount<=0) {
-                    sourceCount = "";
-                    $('#source'+sourceId+'').removeClass('unread');
-                } else {
-                    $('#source'+sourceId+'').addClass('unread');
+                if( selfoss.sourceNavLoaded ) {
+                    // update unread count on sources
+                    var sourceId = entry.attr('data-entry-source');
+                    var sourceNav = $('#source'+sourceId+' .unread');
+                    var sourceCount = parseInt(sourceNav.html());
+                    if(typeof sourceCount != "number" || isNaN(sourceCount)==true)
+                        sourceCount = 0;
+                    sourceCount = unread ? sourceCount-1 : sourceCount+1;
+                    if(sourceCount<=0) {
+                        sourceCount = "";
+                        $('#source'+sourceId+'').removeClass('unread');
+                    } else {
+                        $('#source'+sourceId+'').addClass('unread');
+                    }
+                    sourceNav.html(sourceCount);
                 }
-                sourceNav.html(sourceCount);
                 
                 // update unread on tags
                 $('#entry'+id+' .entry-tags-tag').each( function(index) {
@@ -194,8 +171,8 @@ selfoss.events.entriesToolbar = function(parent) {
                 type: 'POST',
                 error: function(jqXHR, textStatus, errorThrown) {
                     // rollback ui changes
+                    selfoss.ui.entryMark(id, unread);
                     updateStats(!unread);
-                    setButton(!unread);
                     selfoss.showError('Can not mark/unmark item: '+
                                       textStatus+' '+errorThrown);
                 }

--- a/public/js/selfoss-events-entriestoolbar.js
+++ b/public/js/selfoss-events-entriestoolbar.js
@@ -93,7 +93,7 @@ selfoss.events.entriesToolbar = function(parent) {
                 type: 'POST',
                 error: function(jqXHR, textStatus, errorThrown) {
                     // rollback ui changes
-                    selfoss.ui.entryStarr(id, starr);
+                    selfoss.ui.entryStarr(id, !starr);
                     updateStats(!starr);
                     selfoss.showError('Can not star/unstar item: '+
                                       textStatus+' '+errorThrown);

--- a/public/js/selfoss-events-navigation.js
+++ b/public/js/selfoss-events-navigation.js
@@ -157,11 +157,8 @@ selfoss.events.navigation = function() {
 
     // updates sources
     $('#nav-refresh').unbind('click').click(function () {
-        // show loading
-        var content = $('#content');
-        var articleList = content.html();
-        $('#content').addClass('loading').html("");
-          
+        $('#nav-refresh').addClass('loading');
+
         $.ajax({
             url: $('base').attr('href') + 'update',
             type: 'GET',
@@ -173,12 +170,13 @@ selfoss.events.navigation = function() {
                     $('#nav-mobile-settings').click();
                     
                 // refresh list
-                 selfoss.reloadList();
+                selfoss.sync(true);
             },
             error: function(jqXHR, textStatus, errorThrown) {
-                content.html(articleList);
-                $('#content').removeClass('loading');
-                alert('Can not refresh sources: ' + errorThrown);
+                selfoss.showError('Cannot refresh sources: ' + errorThrown);
+            },
+            complete: function(data) {
+                $('#nav-refresh').removeClass('loading');
             }
         });
     });

--- a/public/js/selfoss-events.js
+++ b/public/js/selfoss-events.js
@@ -56,7 +56,9 @@ selfoss.events = {
 
     processHashChange: true,
 
-    processHash: function(hash=false) {
+    processHash: function(hash) {
+        var hash = (typeof hash != 'undefined') ? hash : false;
+
         var done = function() {
             selfoss.events.processHashChange = true;
         };
@@ -176,7 +178,11 @@ selfoss.events = {
     },
     
 
-    setHash: function(section='same', subsection='same', entryId=false) {
+    setHash: function(section, subsection, entryId) {
+        var section = (typeof section !== 'undefined') ? section : 'same';
+        var subsection = (typeof subsection !== 'undefined') ? subsection : 'same';
+        var entryId = (typeof entryId !== 'undefined') ? entryId : false;
+
         if( section == 'same' )
             section = selfoss.events.section;
         newHash = new Array(section);

--- a/public/js/selfoss-events.js
+++ b/public/js/selfoss-events.js
@@ -149,6 +149,7 @@ selfoss.events = {
             if (selfoss.activeAjaxReq !== null)
                 selfoss.activeAjaxReq.abort();
 
+            selfoss.ui.refreshStreamButtons();
             $('#content').addClass('loading').html("");
             selfoss.activeAjaxReq = $.ajax({
                 url: $('base').attr('href')+'sources',

--- a/public/js/selfoss-ui.js
+++ b/public/js/selfoss-ui.js
@@ -46,6 +46,25 @@ selfoss.ui = {
                 selfoss.ui.entryMark(id, new_status.unread);
             }
         });
+    },
+
+
+    refreshStreamButtons: function(entries=false,
+                                   hasEntries=false, hasMore=false) {
+        $('.stream-button, .stream-empty').css('display', 'block').hide();
+        if( entries ) {
+            if( hasEntries ) {
+                $('.stream-empty').hide();
+                if( selfoss.isSmartphone() )
+                    $('.mark-these-read').show();
+                if( hasMore )
+                    $('.stream-more').show();
+            } else {
+                $('.stream-empty').show();
+                if( selfoss.isSmartphone() )
+                    $('.mark-these-read').hide();
+            }
+        }
     }
 
 

--- a/public/js/selfoss-ui.js
+++ b/public/js/selfoss-ui.js
@@ -45,7 +45,7 @@ selfoss.ui = {
                 return newStatus;
             });
             if( newStatus ) {
-                selfoss.ui.entryStarr(id, newStatus.starr);
+                selfoss.ui.entryStarr(id, newStatus.starred);
                 selfoss.ui.entryMark(id, newStatus.unread);
             }
         });

--- a/public/js/selfoss-ui.js
+++ b/public/js/selfoss-ui.js
@@ -1,0 +1,52 @@
+/**
+ * ui change functions
+ */
+selfoss.ui = {
+
+
+    entryStarr: function(id, starred) {
+        var button = $("#entry"+id+" .entry-starr, #entrr"+id+" .entry-starr");
+
+        // update button
+        if(starred) {
+            button.addClass('active');
+            button.html($('#lang').data('unstar'));
+        } else {
+            button.removeClass('active');
+            button.html($('#lang').data('star'));
+        }
+    },
+
+
+    entryMark: function(id, unread) {
+        var button = $("#entry"+id+" .entry-unread, #entrr"+id+" .entry-unread");
+        var parent = $("#entry"+id+", #entrr"+id);
+
+        // update button and entry style
+        if(unread) {
+            button.addClass('active');
+            button.html($('#lang').data('mark'));
+            parent.addClass('unread');
+        } else {
+            button.removeClass('active');
+            button.html($('#lang').data('unmark'));
+            parent.removeClass('unread');
+        }
+    },
+
+
+    refreshItemStatuses: function(entry_statuses) {
+        $('.entry').each(function(index, item) {
+            var id = $(this).data(('entry-id'));
+            new_status = entry_statuses.find(function(entry_status) {
+                return entry_status.id == id;
+            });
+            if( new_status ) {
+                selfoss.ui.entryStarr(id, new_status.starr);
+                selfoss.ui.entryMark(id, new_status.unread);
+            }
+        });
+    }
+
+
+};

--- a/public/js/selfoss-ui.js
+++ b/public/js/selfoss-ui.js
@@ -37,7 +37,7 @@ selfoss.ui = {
 
     refreshItemStatuses: function(entryStatuses) {
         $('.entry').each(function(index, item) {
-            var id = $(this).data(('entry-id'));
+            var id = $(this).data('entry-id');
             var newStatus = false;
             entryStatuses.some(function(entryStatus) {
                 if( entryStatus.id == id )

--- a/public/js/selfoss-ui.js
+++ b/public/js/selfoss-ui.js
@@ -41,7 +41,7 @@ selfoss.ui = {
             var newStatus = false;
             entryStatuses.some(function(entryStatus) {
                 if( entryStatus.id == id )
-                    newStatus = entryStatus.id;
+                    newStatus = entryStatus;
                 return newStatus;
             });
             if( newStatus ) {

--- a/public/js/selfoss-ui.js
+++ b/public/js/selfoss-ui.js
@@ -35,22 +35,28 @@ selfoss.ui = {
     },
 
 
-    refreshItemStatuses: function(entry_statuses) {
+    refreshItemStatuses: function(entryStatuses) {
         $('.entry').each(function(index, item) {
             var id = $(this).data(('entry-id'));
-            new_status = entry_statuses.find(function(entry_status) {
-                return entry_status.id == id;
+            var newStatus = false;
+            entryStatuses.some(function(entryStatus) {
+                if( entryStatus.id == id )
+                    newStatus = entryStatus.id;
+                return newStatus;
             });
-            if( new_status ) {
-                selfoss.ui.entryStarr(id, new_status.starr);
-                selfoss.ui.entryMark(id, new_status.unread);
+            if( newStatus ) {
+                selfoss.ui.entryStarr(id, newStatus.starr);
+                selfoss.ui.entryMark(id, newStatus.unread);
             }
         });
     },
 
 
-    refreshStreamButtons: function(entries=false,
-                                   hasEntries=false, hasMore=false) {
+    refreshStreamButtons: function(entries, hasEntries, hasMore) {
+        var entries = (typeof entries !== 'undefined') ? entries : false;
+        var hasEntries = (typeof hasEntries !== 'undefined') ? hasEntries : false;
+        var hasMore = (typeof hasMore !== 'undefined') ? hasMore : false;
+
         $('.stream-button, .stream-empty').css('display', 'block').hide();
         if( entries ) {
             if( hasEntries ) {

--- a/templates/home.phtml
+++ b/templates/home.phtml
@@ -156,8 +156,13 @@
     <div id="content" role="main">
         <?PHP echo $this->content; ?>
     </div>
-    
-    <div class="stream-error"><?PHP echo trim(\F3::get('lang_streamerror')); ?></div>
+
+    <div id="stream-buttons">
+        <div class="stream-empty"><?PHP echo trim(\F3::get('lang_no_entries')); ?></div>
+        <div class="stream-button stream-more"><span><?PHP echo trim(\F3::get('lang_more')); ?></span></div>
+        <div class="stream-button mark-these-read"><span><?PHP echo trim(\F3::get('lang_markread')); ?></span></div>
+        <div class="stream-button stream-error"><?PHP echo trim(\F3::get('lang_streamerror')); ?></div>
+    </div>
 
     <!-- fullscreen popup -->
     <div id="fullscreen-entry"></div>

--- a/templates/item.phtml
+++ b/templates/item.phtml
@@ -22,7 +22,7 @@
 <div id="entry<?PHP echo $this->item['id']; ?>"
      data-entry-id="<?PHP echo $this->item['id']; ?>"
      data-entry-source="<?PHP echo $this->item['source']; ?>"
-     data-entry-datetime="<?PHP echo $this->item['datetime']; ?>"
+     data-entry-datetime="<?PHP echo $this->viewHelper->date_iso8601($this->item['datetime']); ?>"
      class="entry
             <?PHP echo $this->item['unread']==1 ? 'unread' : ''; ?>" role="article">
 


### PR DESCRIPTION
This PR includes #834 .

Those changes add a new /items/sync API endpoint that sends database changes from a given datetime. This ensures only data absent from the client side is sent. This PR includes some client side changes to take advantage of this, including some functional enhancements such as cross-device updating of item statuses.