### PR TITLE
Add JSON support for Sources::write

### DIFF
--- a/controllers/Sources.php
+++ b/controllers/Sources.php
@@ -130,7 +130,13 @@ class Sources extends BaseController {
         $sourcesDao = new \daos\Sources();
 
         // read data
-        parse_str(\F3::get('BODY'),$data);
+        $headers = \F3::get('HEADERS');
+        $body = \F3::get('BODY');
+        if (isset($headers['Content-Type']) && strpos($headers['Content-Type'], 'application/json') === 0) {
+            $data = json_decode($body, true);
+        } else {
+            parse_str($body,$data);
+        }
 
         if(!isset($data['title']))
             $this->view->jsonError(array('title' => 'no data for title given'));


### PR DESCRIPTION
Fixes #734 for `/source` and `/source/@id` endpoints. Requires f3 3.6.0 to work (use #845).