### PR TITLE
Add coding style checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ node_modules
 _wiki
 .env
 vendor/
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,28 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->exclude('libs')
+    ->exclude('utils')
+    ->in(__DIR__)
+    ->name('*.phtml');
+
+$rules = [
+    '@Symfony' => true,
+    // why would anyone put braces on different line
+    'braces' => ['position_after_functions_and_oop_constructs' => 'same'],
+    'function_declaration' => ['closure_function_spacing' => 'none'],
+    // overwrite some Symfony rules
+    'concat_space' => ['spacing' => 'one'],
+    'phpdoc_align' => false,
+    'phpdoc_no_empty_return' => false,
+    'phpdoc_summary' => false,
+    'trailing_comma_in_multiline_array' => false,
+    // additional rules
+    'array_syntax' => ['syntax' => 'short'],
+    'opening_tag_plus_echo_to_short_echo_tag' => true,
+    'phpdoc_order' => true,
+];
+
+return PhpCsFixer\Config::create()
+    ->setRules($rules)
+    ->setFinder($finder);

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
     include:
         - php: 7.1
         - php: 7.0
+          env: CS_FIXER=true
         - php: 5.6
         - php: 5.5
         - php: 5.4
@@ -26,6 +27,9 @@ cache:
 before_install:
     - nvm install 6
     - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi
+    # We need to use our modified version until the fixers are merged upstream.
+    - "export FIXER_REPO=--repository='{\"type\": \"vcs\", \"url\": \"https://github.com/jtojnar/php-cs-fixer\"}'"
+    - if [ "$CS_FIXER" = true ]; then composer create-project --no-dev --no-interaction "$FIXER_REPO" friendsofphp/php-cs-fixer utils/php-cs-fixer dev-selfoss; fi
     - composer create-project --no-dev --no-interaction jakub-onderka/php-parallel-lint utils/php-parallel-lint
 
 install:
@@ -36,6 +40,7 @@ before_script:
 
 script:
     - utils/php-parallel-lint/parallel-lint controllers daos helpers spouts templates
+    - if [ "$CS_FIXER" = true ]; then utils/php-cs-fixer/php-cs-fixer fix --verbose --dry-run; fi
 
 before_deploy:
     - source utils/package.sh
@@ -55,4 +60,3 @@ deploy:
       on:
           tags: true
           condition: $DEPLOY = true
-


### PR DESCRIPTION
## Blocked by
* https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2505
* https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2459

--------------------

Travis will check for coding style violations.

Symfony Coding Style mostly works for selfoss. It is essentially PSR-2 sprinkled with some more rules for cases when PSR-2 is silent. When the code base was not consistent, I choose the most common format.

These are the deviations from Symfony CS:

* Opening braces after functions, methods, classes, interfaces, traits, etc. go on the same line. (Unlike PSR-2)
* Lambdas do not have a space after function keyword. (Unlike PSR-2)
* Concatenation operator `.` requires spaces from both sides. The codebase was actually fairly tied on this issue: 170 vs 167
lines had to be changed. The spaced variant was, however, more widely spread 52 vs 34 affected files. (Unlike Symfony)
* We also do not require adding a comma after last item of multi-line array. (Unlike Symfony)
* Finally, there are some minor differences from Symfony with regards to docstring handling.

--------------

Currently the tests are failing, I will fix the code before merging this. #865 should be merged first, though.