### PR TITLE
Add syntax linting using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: php
+
+matrix:
+    include:
+        - php: 7.1
+        - php: 7.0
+        - php: 5.6
+        - php: 5.5
+          env: REMOVE_TWITEROAUTH=true
+        - php: 5.4
+          env: REMOVE_TWITEROAUTH=true
+    fast_finish: true
+
+cache:
+    directories:
+        - vendor
+        - $HOME/.composer/cache
+
+before_install:
+    - if [ -n "$GH_TOKEN" ]; then composer config github-oauth.github.com ${GH_TOKEN}; fi
+    - composer create-project --no-dev --no-interaction jakub-onderka/php-parallel-lint utils/php-parallel-lint
+
+install:
+    - composer self-update
+
+before_script:
+    # TwitterOAuth specifies PHP ^5.6 as a requirement
+    - if [ $REMOVE_TWITEROAUTH = true ]; then composer remove --no-interaction abraham/twitteroauth; fi
+    - composer install --prefer-dist --no-interaction
+
+script:
+    - utils/php-parallel-lint/parallel-lint controllers daos helpers spouts templates


### PR DESCRIPTION
We are linting the code on all supported versions of PHP.

Note that we remove TwitterOAuth library when running PHP older than 5.6 because TwitterOAuth declares 5.6 as minimal version. Except for one small detail, I have filed a pull request for, it still works, though.