### PR TITLE
Remove spout_obj key

### DIFF
--- a/controllers/Opml.php
+++ b/controllers/Opml.php
@@ -32,6 +32,14 @@ class Opml extends BaseController {
     */
     private $imported = array();
 
+    /** @var \helpers\SpoutLoader */
+    private $spoutLoader;
+
+    public function __construct() {
+        parent::__construct();
+
+        $this->spoutLoader = new \helpers\SpoutLoader($this);
+    }
 
     /** 
      * Shows a simple html form
@@ -230,7 +238,7 @@ class Opml extends BaseController {
     private function writeSource($source) {
         // retrieve the feed url of the source
         $params = json_decode(html_entity_decode($source['params']), true);
-        $feedUrl = $source['spout_obj']->getXmlUrl($params);
+        $feedUrl = $this->spoutLoader->get($source['spout'])->getXmlUrl($params);
 
         // if the spout doesn't return a feed url, the source isn't an RSS feed
         if ($feedUrl !== false)

--- a/controllers/Sources.php
+++ b/controllers/Sources.php
@@ -316,7 +316,6 @@ class Sources extends BaseController {
         for($i=0; $i<count($sources); $i++) {
             $sources[$i]['params'] = json_decode(html_entity_decode($sources[$i]['params']), true);
             $sources[$i]['error'] = $sources[$i]['error']==null ? '' : $sources[$i]['error'];
-            unset($sources[$i]['spout_obj']);
         }
         
         $this->view->jsonSuccess($sources);

--- a/daos/mysql/Sources.php
+++ b/daos/mysql/Sources.php
@@ -135,9 +135,6 @@ class Sources extends Database {
      */
     public function getByLastUpdate() {
         $ret = \F3::get('db')->exec('SELECT id, title, tags, spout, params, filter, error, lastupdate, lastentry FROM '.\F3::get('db_prefix').'sources ORDER BY lastupdate ASC');
-        $spoutLoader = new \helpers\SpoutLoader();
-        for($i=0;$i<count($ret);$i++)
-            $ret[$i]['spout_obj'] = $spoutLoader->get( $ret[$i]['spout'] );
         return $ret;
     }
     
@@ -154,18 +151,13 @@ class Sources extends Database {
         if (isset($id)) {
             $ret = \F3::get('db')->exec('SELECT id, title, tags, spout, params, filter, error FROM '.\F3::get('db_prefix').'sources WHERE id=:id',
                                     array(':id' => $id));
-            $spoutLoader = new \helpers\SpoutLoader();
             if (isset($ret[0])) {
                 $ret = $ret[0];
-                $ret['spout_obj'] = $spoutLoader->get( $ret['spout'] );
             } else {
                 $ret = false;    
             }
         } else { 
             $ret = \F3::get('db')->exec('SELECT id, title, tags, spout, params, filter, error FROM '.\F3::get('db_prefix').'sources ORDER BY error DESC, lower(title) ASC');
-            $spoutLoader = new \helpers\SpoutLoader();
-            for($i=0;$i<count($ret);$i++)
-                $ret[$i]['spout_obj'] = $spoutLoader->get( $ret[$i]['spout'] );
         }
         return $ret;
     }
@@ -209,9 +201,6 @@ class Sources extends Database {
                  ) AS sourceicons
                 ON sources.id=sourceicons.source
             ORDER BY '.$this->stmt->nullFirst('sources.error', 'DESC').', lower(sources.title)');
-        $spoutLoader = new \helpers\SpoutLoader();
-        for($i=0;$i<count($ret);$i++)
-            $ret[$i]['spout_obj'] = $spoutLoader->get( $ret[$i]['spout'] );
         return $ret;
     }
 


### PR DESCRIPTION
The key first appeared in the initial commit (045dd9bb06d0664c51bba4d6da7868d93ab95ffb) but it does not look like it was used anywhere apart from the OPML controller. To make future changes easier, I am removing it.

Does anyone have any idea what is it for?