### PR TITLE
Add ZDF Mediathek spout

### DIFF
--- a/spouts/rss/zdf.php
+++ b/spouts/rss/zdf.php
@@ -1,0 +1,50 @@
+<?PHP 
+
+namespace spouts\rss;
+
+/**
+ * Plugin for fetching media from the ZDF Mediathek
+ *
+ * @package    plugins
+ * @subpackage news
+ * @copyright  Copyright (c) Daniel Rudolf
+ * @license    GPLv3 (http://www.gnu.org/licenses/gpl-3.0.html)
+ * @author     Daniel Rudolf <http://daniel-rudolf.de/>
+ */
+class zdf extends feed
+{
+    /**
+     * name of spout
+     *
+     * @var string
+     */
+    public $name = 'ZDF Mediathek';
+
+
+    /**
+     * description of this source type
+     *
+     * @var string
+     */
+    public $description = 'This feed fetches media items from the ZDF Mediathek.';
+
+    /**
+     * loads the contents of the feed
+     *
+     * @param mixed $params the params of this source
+     * @return void
+     */
+    public function load($params)
+    {
+        parent::load($params);
+
+        foreach ($this->items as $key => $item) {
+            // remove future items
+            $time = $item->get_date('U');
+            if ($time && ($time > time())) {
+                unset($this->items[$key]);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
The RSS feed of the ZDF Mediathek (the VOD service of a german TV channel) often lists videos which actually haven't been released yet. This spout ignores such items.

Example: https://www.zdf.de/rss/zdf/wissen/leschs-kosmos lists various videos for the next show airing on Tuesday.