### PR TITLE
make it unlikely that the client browser gets outdated js or css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 /data/logs/*.log
 /data/sqlite/*.db
 /public/all.*
-/public/all-v*.*
 user.css
 user.js
 /_bin/*.*

--- a/README.md
+++ b/README.md
@@ -41,10 +41,9 @@ UPDATE
 3. Upload all new files and folders excluding the data folder (IMPORTANT: also upload the invisible .htaccess files)
 4. Make the folder "public" writeable
 5. Rename your folder /data/icons into /data/favicons
-6. Delete the files /public/all-v*.css and /public/all-v*.js
-7. Clean your browser cache
-8. Insert your current database connection and your individual configuration in config.ini. Important: we change the config.ini and add new options in newer versions. You have to update the config.ini too.
-9. The database will be updated automatically (ensure that your database has enought rights for creating triggers)
+6. Clean your browser cache
+7. Insert your current database connection and your individual configuration in config.ini. Important: we change the config.ini and add new options in newer versions. You have to update the config.ini too.
+8. The database will be updated automatically (ensure that your database has enought rights for creating triggers)
 
 For further questions or on any problem use our support forum: http://selfoss.aditu.de/forum
 

--- a/_docs/website/index.html
+++ b/_docs/website/index.html
@@ -156,7 +156,7 @@ db_port=3306</code>
                     <li><b>IMPORTANT: don't delete the "data" folder</b>. Delete all old files and folders excluding the folder "data".</li>
                     <li>Upload all new files and folders excluding the data folder (IMPORTANT: also upload the invisible .htaccess files).</li>
                     <li>Rename your folder /data/icons into /data/favicons</li>
-                    <li>Delete the files /public/all-v<var>*</var>.css and /public/all-v<var>*</var>.js</li>
+                    <li>If upgrading from 2.17 or earlier, delete the files <code>/public/all-v<var>*</var>.css</code> and <code>/public/all-v<var>*</var>.js</code></li>
                     <li>Clean your browser cache.</li>
                 </ol>
 

--- a/helpers/View.php
+++ b/helpers/View.php
@@ -13,11 +13,23 @@ class View {
     /** @var string current base url */
     public $base = '';
 
+    /** @internal JS static resource type */
+    const STATIC_RESOURCE_JS = 'js';
+    /** @internal CSS static resource type */
+    const STATIC_RESOURCE_CSS = 'css';
+
+    public static $staticmtime = [
+        self::STATIC_RESOURCE_JS => 0,
+        self::STATIC_RESOURCE_CSS => 0
+    ];
+    public static $staticPrefix = 'all';
+
     /**
      * set global view vars
      */
     public function __construct() {
-        $this->genMinifiedJsAndCss();
+        $this->genMinified(self::STATIC_RESOURCE_JS);
+        $this->genMinified(self::STATIC_RESOURCE_CSS);
         $this->base = $this->getBaseUrl();
     }
 
@@ -125,12 +137,28 @@ class View {
     }
 
     /**
+     * returns max mtime for file paths given in array
+     *
+     * @param filePaths array of file paths
+     * @returns int max mtime (unix timestamp)
+     */
+    public static function maxmtime(array $filePaths) {
+        $maxmtime = 0;
+        foreach ($filePaths as $filePath) {
+            $fullPath = \F3::get('BASEDIR') . '/' . $filePath;
+            $maxmtime = max($maxmtime, filemtime($fullPath));
+        }
+
+        return $maxmtime;
+    }
+
+    /**
      * returns global JavaScript file name (all.js)
      *
      * @return string all.js file name
      */
     public static function getGlobalJsFileName() {
-        return 'all-v' . \F3::get('version') . '.js';
+        return self::$staticPrefix . '.js?v=' . self::$staticmtime[self::STATIC_RESOURCE_JS];
     }
 
     /**
@@ -139,33 +167,38 @@ class View {
      * @return string all.css file name
      */
     public static function getGlobalCssFileName() {
-        return 'all-v' . \F3::get('version') . '.css';
+        return self::$staticPrefix . '.css?v=' . self::$staticmtime[self::STATIC_RESOURCE_CSS];
     }
 
     /**
      * generate minified css and js
      *
+     * @param string type
+     *
      * @return void
      */
-    public function genMinifiedJsAndCss() {
-        // minify js
-        $targetJs = \F3::get('BASEDIR') . '/public/' . self::getGlobalJsFileName();
-        if (!file_exists($targetJs) || \F3::get('DEBUG') != 0) {
-            $js = '';
-            foreach (\F3::get('js') as $file) {
-                $js = $js . "\n" . $this->minifyJs(file_get_contents(\F3::get('BASEDIR') . '/' . $file));
-            }
-            file_put_contents($targetJs, $js);
-        }
+    private function genMinified($type) {
+        self::$staticmtime[$type] = self::maxmtime(\F3::get($type));
 
-        // minify css
-        $targetCss = \F3::get('BASEDIR') . '/public/' . self::getGlobalCssFileName();
-        if (!file_exists($targetCss) || \F3::get('DEBUG') != 0) {
-            $css = '';
-            foreach (\F3::get('css') as $file) {
-                $css = $css . "\n" . $this->minifyCss(file_get_contents(\F3::get('BASEDIR') . '/' . $file));
+        if ($type == self::STATIC_RESOURCE_JS) {
+            $filename = self::getGlobalJsFileName();
+        } elseif ($type == self::STATIC_RESOURCE_CSS) {
+            $filename = self::getGlobalCssFileName();
+        }
+        $target = \F3::get('BASEDIR') . '/public/' . self::$staticPrefix . '.' . $type;
+
+        // build if needed
+        if (!file_exists($target) || filemtime($target) < self::$staticmtime[$type]) {
+            $minified = '';
+            foreach (\F3::get($type) as $file) {
+                if ($type == self::STATIC_RESOURCE_JS) {
+                    $minifiedFile = $this->minifyJs(file_get_contents(\F3::get('BASEDIR') . '/' . $file));
+                } elseif ($type == self::STATIC_RESOURCE_CSS) {
+                    $minifiedFile = $this->minifyCss(file_get_contents(\F3::get('BASEDIR') . '/' . $file));
+                }
+                $minified = $minified . "\n" . $minifiedFile;
             }
-            file_put_contents($targetCss, $css);
+            file_put_contents($target, $minified);
         }
     }
 


### PR DESCRIPTION
This change makes the js and css generated to a file containing the
max mtime of source material in its name. Therefore, each time the
source js or css files are changed, a new file with a new name gets
generated and referenced in the app. From the client browser's view,
this is a new ressource that needs to get fetched regardless of the
cache status of older css or js.

The trade-off is that each request implies stat'ing each source
material file. There is no notiecable time penalty in loading time.