### PR TITLE
Fix asset routing for PHP built-in server

### DIFF
--- a/run.php
+++ b/run.php
@@ -2,7 +2,7 @@
 
 // Only run this if running from php 5.4 embedded server
 if (php_sapi_name() == 'cli-server') {
-    if (preg_match('/\.(?:js|ico|gif|jpg|png|css|asc|txt|eot|woff|ttf|ttf|svg)$/', $_SERVER['REQUEST_URI'])) {
+    if (preg_match('/\.(?:js|ico|gif|jpg|png|css|asc|txt|eot|woff|ttf|ttf|svg)(?:\?.*)?$/', $_SERVER['REQUEST_URI'])) {
         // serves fronted
         if (preg_match('/^\/public/', $_SERVER['REQUEST_URI'])) {
             return false;


### PR DESCRIPTION
Pull request #907 switched to using query string as a cache busting strategy but the runner for the PHP built-in server did not anticipate any text after file name extension.

See also: https://github.com/SSilence/selfoss/issues/910