### PR TITLE
Revert "Prefer item link for obtaining favicon"

### DIFF
--- a/spouts/rss/feed.php
+++ b/spouts/rss/feed.php
@@ -249,12 +249,8 @@ class feed extends \spouts\spout {
 
         $this->faviconUrl = false;
         $imageHelper = $this->getImageHelper();
-        $link = $this->getLink();
-        if (!$link) {
-            $link = $this->getHtmlUrl();
-        }
-
-        if ($link && $imageHelper->fetchFavicon($link, true)) {
+        $htmlUrl = $this->getHtmlUrl();
+        if ($htmlUrl && $imageHelper->fetchFavicon($htmlUrl, true)) {
             $this->faviconUrl = $imageHelper->getFaviconUrl();
             \F3::get('logger')->debug('icon: using feed homepage favicon: ' . $this->faviconUrl);
         } else {


### PR DESCRIPTION
When RSS feed item link redirects to a different site (e.g. Feedburner) and there are no icon link elements, favicon.ico in the root of the site will be checked. Unfortunately, the site root is determined from the original item link before redirection, therefore incorrect icon might be used. Until we can determine the correct site root easily, possibly once we switch to Guzzle, the original behaviour is preferred.

Additionally, the commit caused that the links in link aggregators like Haskell News used the favicon of the first link.

This reverts commit cac783d75cd6d81ac545879d5b45f39432236d20.