### PR TITLE
Do not use cache unnecessarily

### DIFF
--- a/helpers/Image.php
+++ b/helpers/Image.php
@@ -103,9 +103,7 @@ class Image {
         }
 
         // get image type
-        $tmp = \F3::get('cache') . '/' . md5($url);
-        file_put_contents($tmp, $data);
-        $imgInfo = @getimagesize($tmp);
+        $imgInfo = @getimagesizefromstring($data);
         if (in_array(strtolower($imgInfo['mime']), self::$faviconMimeTypes, true)) {
             $type = 'ico';
         } elseif (strtolower($imgInfo['mime']) == 'image/png') {


### PR DESCRIPTION
When loading an image, the data were written to a file to determine the file type. This file was previously cleaned but the clean-up was accidentally dropped in d1307573d3d75a7a8078c8e2942c44ba6aa63036.

PHP 5.4 introduced `getimagesizefromstring` function, which allows to use data already in memory, removing the need for writing to a temporary file and thus a clean-up.