### PR TITLE
Fix favicon for GitHub spout

### DIFF
--- a/spouts/github/commits.php
+++ b/spouts/github/commits.php
@@ -69,7 +69,7 @@ class commits extends \spouts\spout {
     protected $htmlUrl = '';
 
     /** @var string URL of the favicon */
-    protected $faviconUrl = '';
+    protected $faviconUrl = 'https://assets-cdn.github.com/favicon.ico';
 
     //
     // Iterator Interface
@@ -216,17 +216,6 @@ class commits extends \spouts\spout {
      * @return string icon url
      */
     public function getIcon() {
-        if (isset($this->faviconUrl)) {
-            return $this->faviconUrl;
-        }
-
-        $this->faviconUrl = false;
-        $imageHelper = $this->getImageHelper();
-        $htmlUrl = $this->getHtmlUrl();
-        if ($htmlUrl && $imageHelper->fetchFavicon($htmlUrl)) {
-            $this->faviconUrl = $imageHelper->getFaviconUrl();
-        }
-
         return $this->faviconUrl;
     }
 


### PR DESCRIPTION
3c9da8de68763c86c700496cda0c38b978d832ef broke obtaining the favicon.

Since the icon is always the same, this patch fixes it by hardcoding the URL, saving a roundtrip to GitHub servers.