### PR TITLE
Do not double-escape tweet bodies

### DIFF
--- a/spouts/twitter/usertimeline.php
+++ b/spouts/twitter/usertimeline.php
@@ -389,8 +389,6 @@ class usertimeline extends \spouts\spout {
                     $entity = $entities[$cpi];
                     $appended = '<a href="' . $entity['url'] . '" target="_blank" rel="noopener noreferrer">' . $entity['text'] . '</a>';
                     $skipUntilCp = $entity['end'];
-                } elseif (in_array($c, ['<', '>', '&', '"', '\''])) { // needs to be escaped
-                    $appended = htmlspecialchars($c);
                 } else {
                     $appended = $c;
                 }


### PR DESCRIPTION
In 481ecf3d507870d9194587987b320b46f90791f9, we have switched to using full text body of tweets. Unlike the previously used `text` property, the `full_text` string is already HTML-escaped.

The spout no longer needs to escape the text.