### PR TITLE
Fix client side manifest not included into built package

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -106,9 +106,8 @@ module.exports = function(grunt) {
                     // do not pack bundled assets and assets not listed in index.php
                     { expand: true, cwd: 'public/', src: ['**'], dest: '/public', filter: function(file) {
                         const bundle = file === 'public/all.js' || file === 'public/all.css';
-                        const packageDesc = file === 'public/package.json';
                         const thirdPartyRubbish = file.startsWith('public/node_modules/') && requiredAssets.indexOf(file) === -1;
-                        const allowed = !bundle && !packageDesc && !thirdPartyRubbish;
+                        const allowed = !bundle && !thirdPartyRubbish;
 
                         return allowed;
                     }},


### PR DESCRIPTION
In 4e4094cc0d492fe1022a25619d69cba26b8c2f95, client side `package.json` was erroneously added to the blacklist of files to be included in the built package.