### PR TITLE
Fix fancybox being considered extraneous package

### DIFF
--- a/public/package.json
+++ b/public/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "fancybox": "github:fancyapps/fancybox#v3.1.20",
+    "@fancyapps/fancybox": "^3.1.20",
     "jquery": "^2.2.4",
     "jquery-hotkeys": "^0.2.2",
     "jquery-mousewheel": "^3.1.13",


### PR DESCRIPTION
Since Debian-provided version of NPM does not support scoped packages, we have to install FancyBox from Git. I also changed the dependency name in the `package.json` to just `fancybox` in order
not to trigger the outdated NPM. Apparently, this will make NPM think the package is extraneous due to a mismatch between the package name and the name in the `package.json`.