### PR TITLE
Fix database migration and make them more consistent

### DIFF
--- a/daos/mysql/Database.php
+++ b/daos/mysql/Database.php
@@ -235,6 +235,14 @@ class Database {
                         'INSERT INTO ' . \F3::get('db_prefix') . 'version (version) VALUES (11)'
                     ]);
                 }
+                if (strnatcmp($version, '12') < 0) {
+                    \F3::get('db')->exec([
+                        'UPDATE ' . \F3::get('db_prefix') . 'items SET updatetime = datetime WHERE updatetime IS NULL',
+                        'ALTER TABLE ' . \F3::get('db_prefix') . 'items MODIFY updatetime DATETIME NOT NULL',
+                        'ALTER TABLE ' . \F3::get('db_prefix') . 'items MODIFY lastseen DATETIME NOT NULL',
+                        'INSERT INTO ' . \F3::get('db_prefix') . 'version (version) VALUES (12)'
+                    ]);
+                }
             }
 
             // just initialize once

--- a/daos/pgsql/Database.php
+++ b/daos/pgsql/Database.php
@@ -220,6 +220,13 @@ class Database {
                         'INSERT INTO version (version) VALUES (11);'
                     ]);
                 }
+                if (strnatcmp($version, '12') < 0) {
+                    \F3::get('db')->exec([
+                        'UPDATE items SET updatetime = datetime WHERE updatetime IS NULL',
+                        'ALTER TABLE items ALTER COLUMN updatetime SET NOT NULL',
+                        'INSERT INTO version (version) VALUES (12)'
+                    ]);
+                }
             }
 
             // just initialize once

--- a/daos/sqlite/Database.php
+++ b/daos/sqlite/Database.php
@@ -215,6 +215,7 @@ class Database {
                             shared      BOOL,
                             lastseen    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
                         )',
+                        'UPDATE items SET updatetime = datetime WHERE updatetime IS NULL',
                         'INSERT INTO new_items SELECT *, CURRENT_TIMESTAMP FROM items',
                         'DROP TABLE items',
                         'ALTER TABLE new_items RENAME TO items',


### PR DESCRIPTION
In 14442c03b882a8f4e2255c5b654459a7bd8c5f78, `updatetime` field was introduced to the `items` table. Unfortunately, unlike the initialization, the migration did not flag the field `NOT NULL`. Additionally, the `lastseen` column in MySQL database was added as `NULL`able in 83794f415e4ba8b8339b1236155d52769e799dc6. These inconsistencies can lead to incorrect assumptions and cause bugs like #954.

This PR fills the `NULL` fields during SQLite migration, fixing #954, and adds the `NOT NULL` constraint for `updatetime` and `lastseen` fields, making them consistent accross databases and migration paths.


