### PR TITLE
Fix navigation on mobile

### DIFF
--- a/public/js/selfoss-events.js
+++ b/public/js/selfoss-events.js
@@ -13,6 +13,12 @@ selfoss.events = {
 
     entryId: null,
 
+    SCROLLBAR_UNLOADED: 0,
+    SCROLLBAR_LOADING: 1,
+    SCROLLBAR_LOADED: 2,
+
+    scrollBarState: 0, /* SCROLLBAR_UNLOADED */
+
     /**
      * init events when page loads first time
      */
@@ -260,14 +266,22 @@ selfoss.events = {
             var windowHeight = $(window).height();
             $('#nav-tags-wrapper').height(windowHeight - start - 100);
             $('#nav').show();
-            $('#nav-tags-wrapper').mCustomScrollbar({
-                advanced: {
-                    updateOnContentResize: true
-                }
-            });
+            if (selfoss.events.scrollBarState === selfoss.events.SCROLLBAR_UNLOADED) {
+                selfoss.events.scrollBarState = selfoss.events.SCROLLBAR_LOADING;
+                $('#nav-tags-wrapper').mCustomScrollbar({
+                    advanced: {
+                        updateOnContentResize: true
+                    }
+                });
+                selfoss.events.scrollBarState = selfoss.events.SCROLLBAR_LOADED;
+            }
         } else {
             $('#nav-tags-wrapper').height('auto');
-            $('#nav-tags-wrapper').mCustomScrollbar('destroy');
+            if (selfoss.events.scrollBarState === selfoss.events.SCROLLBAR_LOADED) {
+                selfoss.events.scrollBarState = selfoss.events.SCROLLBAR_LOADING;
+                $('#nav-tags-wrapper').mCustomScrollbar('destroy');
+                selfoss.events.scrollBarState = selfoss.events.SCROLLBAR_UNLOADED;
+            }
         }
     }
 };

--- a/public/js/selfoss-events.js
+++ b/public/js/selfoss-events.js
@@ -28,11 +28,6 @@ selfoss.events = {
         }
 
         // window resize
-        $('#nav-tags-wrapper').mCustomScrollbar({
-            advanced: {
-                updateOnContentResize: true
-            }
-        });
         $(window).bind('resize', selfoss.events.resize);
         selfoss.events.resize();
 
@@ -265,9 +260,14 @@ selfoss.events = {
             var windowHeight = $(window).height();
             $('#nav-tags-wrapper').height(windowHeight - start - 100);
             $('#nav').show();
+            $('#nav-tags-wrapper').mCustomScrollbar({
+                advanced: {
+                    updateOnContentResize: true
+                }
+            });
         } else {
             $('#nav-tags-wrapper').height('auto');
-            $('#nav-tags-wrapper').mCustomScrollbar('disable', selfoss.isSmartphone());
+            $('#nav-tags-wrapper').mCustomScrollbar('destroy');
         }
     }
 };


### PR DESCRIPTION
In 8946e49e75e8b82815e341f683badf2a40e97e79, we upgraded the scrollbar plug-in. Due to [changes] in version 3.1.0 of the plugin, the height of a hidden container is set to zero. This caused the navigation to be invisible in mobile layout.

With this patch, the scrollbar library will only be initialized when using desktop layout.

Closes: #953

[changes]: https://github.com/malihu/malihu-custom-scrollbar-plugin/commit/12513564a32dbb7638dbf70b3d9d8b3f1b6655e8#diff-379285ae10c1a5aad9c2ba1ccd07dd96L517