### PR TITLE
Use PSR-4 for autoloading

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -19,9 +19,11 @@ $rules = [
     'trailing_comma_in_multiline_array' => false,
     // additional rules
     'array_syntax' => ['syntax' => 'short'],
+    'psr4' => true,
     'phpdoc_order' => true,
 ];
 
 return PhpCsFixer\Config::create()
     ->setRules($rules)
+    ->setRiskyAllowed(true)
     ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,12 @@
         }
     ],
     "autoload": {
-        "classmap": [
-            "controllers/",
-            "daos/",
-            "helpers/",
-            "spouts/"
-        ]
+        "psr-4": {
+            "controllers\\": "controllers/",
+            "daos\\": "daos/",
+            "helpers\\": "helpers/",
+            "spouts\\": "spouts/"
+        }
     },
     "config": {
         "platform": {


### PR DESCRIPTION
When we introduced the use of Composer classmaps for autoloading in df6f5d033ff73c4a29e9118abcb0ae7968710009, we lost the ability to define custom spouts without dumping the autoloader. PSR-4 would fix this issue but at the time I came to conclusion we would have to change selfoss file structure to support it.

Since that assumption seems to be false, we are switching to PSR-4, thus having the cake and eating it too. The only caveat is the need for more strict file naming conventions.

Closes: #958

### Upgrading
If you use any custom classes like spouts, make sure they follow [PSR-4], namely the namespace should match the file path (even in letter case).

For example, if you have custom spout class named `PrivateSpout` in `spouts\private` namespace, it will have to be located in `spouts/private/PrivateSpout.php`.

This also means each file can only contain a single class.

[PSR-4]: http://www.php-fig.org/psr/psr-4/

### Upgrading (developers)
Once you checked for compliance, run `composer install` as described in the [development section](https://github.com/SSilence/selfoss/blob/master/README.md#development) of README to switch to PSR-4 autoloader.
