### PR TITLE
client: Log out user instead of showing 403 Forbidden error

### DIFF
--- a/public/js/selfoss-db.js
+++ b/public/js/selfoss-db.js
@@ -130,7 +130,10 @@ selfoss.dbOnline = {
             error: function(jqXHR, textStatus, errorThrown) {
                 if (textStatus == "abort")
                     return;
-                else if (errorThrown)
+                else if (selfoss.hasSession() && errorThrown === 'Forbidden') {
+                    selfoss.ui.showError('Your session has expired');
+                    selfoss.logout();
+                } else if (errorThrown)
                     selfoss.ui.showError('Load list error: '+
                                          textStatus+' '+errorThrown);
                 selfoss.events.entries();

--- a/public/js/selfoss-events.js
+++ b/public/js/selfoss-events.js
@@ -202,7 +202,10 @@ selfoss.events = {
                 error: function(jqXHR, textStatus, errorThrown) {
                     if (textStatus == "abort")
                         return;
-                    else if (errorThrown)
+                    else if (selfoss.hasSession() && errorThrown === 'Forbidden') {
+                        selfoss.ui.showError('Your session has expired');
+                        selfoss.logout();
+                    } else if (errorThrown)
                         selfoss.ui.showError('Load list error: '+
                                              textStatus+' '+errorThrown);
                 },


### PR DESCRIPTION
Pull Request #931 moved the authentication client side, which worsened the issue #919 by displaying error instead of the login form on opening selfoss when user did not log out and their session expired on the server.

This patch redirects user to login form whenever client side session is registered and 403 Forbidden error is received.

This is a temporary fix before offline support is merged.