### PR TITLE
Drop alt attribute of source favicons

### DIFF
--- a/templates/source.phtml
+++ b/templates/source.phtml
@@ -3,7 +3,7 @@
         class="source <?= isset($this->source) === false ? 'source-new' : '' ?> <?= (isset($this->source) && isset($this->source['error']) && strlen($this->source['error'] > 0)) ? 'error' : '' ?>">
     <div class="source-icon">
         <?php if (isset($this->source) && isset($this->source['icon']) && $this->source['icon'] !== false && $this->source['icon'] != '0') : ?>
-        <img src="<?= 'favicons/' . $this->source['icon']; ?>" alt="<?= isset($this->source) ? $this->source['title'] : ''; ?>" />
+        <img src="<?= 'favicons/' . $this->source['icon']; ?>" alt="" />
         <?php endif; ?>
     </div>
 


### PR DESCRIPTION
The favicons in the source list contained the title of the feed in their alt attribute. This was redundant since the title is already shown next to the item, resulting in the title being read multiple times by accessibility technologies. It was also displayed over the title when the favicon file was missing.

Closes: #975