### PR TITLE
Fix compatibility with PaaSs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,11 @@
     "grunt-contrib-compress": "^0.10.0",
     "grunt-eslint": "^20.0.0",
     "grunt-text-replace": "~0.3"
+  },
+  "engines": {
+    "npm": ">=5"
+  },
+  "scripts": {
+    "postinstall": "npm install --prefix public/"
   }
 }


### PR DESCRIPTION
On Heroku and other services, client side resources are not installed since the client package.json is in a subdirectory. We need to install them manually.

This patch adds the client installation script into postinstall hook.

Please note that you still need to enable node.js buildpack (or carry out an equivalent procedure for your PaaS) for the hook to be run.