### PR TITLE
Improve entry icon style

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -582,16 +582,19 @@ body * {
             vertical-align: sub;
         }
 
-    .entry-icon,
-    .entry-icon img {
-        margin-top:3px;
-        display:block;
-        float:left;
-        width:16px;
-        height:16px;
-        text-decoration:none;
+    .entry-icon {
+        float: left;
+        text-decoration: none;
+        margin-right: 0;
     }
-    
+
+    .entry-icon img {
+        display: block;
+        padding: 6px;
+        width: 16px;
+        height: 16px;
+    }
+
     .entry-link {
         display:none;
     }


### PR DESCRIPTION
Top margin pushed entry icons out of their parent links, resulting in difficulties when clicking the icon on mobile devices.

![incorrect style](https://user-images.githubusercontent.com/705123/32324623-4b619818-bfcc-11e7-89a5-50badb33c36d.png) → ![fixed style](https://user-images.githubusercontent.com/705123/32325184-38728f62-bfce-11e7-845c-d8049e03a04f.png)


This patch removes the margin and adds a padding for even better clickability.
