### PR TITLE
logging: Allow logging to web server error_log

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - It is possible to set tag or source to be opened after user logs in ([#927](https://github.com/SSilence/selfoss/pull/927))
 - Displaying multiple images from tweets with galleries is supported ([#934](https://github.com/SSilence/selfoss/pull/934))
 - Quoted tweets are supported ([#934](https://github.com/SSilence/selfoss/pull/934))
+- Logging destination can be changed ([#1004](https://github.com/SSilence/selfoss/pull/1004))
 
 ### Bug fixes
 - Fixed Full-text RSS spout ([#897](https://github.com/SSilence/selfoss/pull/897))

--- a/_docs/website/index.html
+++ b/_docs/website/index.html
@@ -211,8 +211,12 @@ db_port=3306</code>
                         <td>port for database connections (3306 for mysql, 5432 for PostgreSQL</td>
                     </tr>
                     <tr>
+                        <td class="documentation-first-column">logger_destination</td>
+                        <td>By default, the logs are saved to <code>data/logs/default.log</code> but you can choose a different file by specifying a file path prefixed by <code>file:</code>. Setting <code>file:php://stderr</code> is especially useful when running selfoss on a PaaS or inside Docker. Alternately, you can set the option to <code>error_log</code> to redirect the messages to <a href="https://secure.php.net/manual/en/function.error-log.php">SAPI error log</a> – handy for PHP-FPM, which <a href="https://secure.php.net/manual/en/install.fpm.configuration.php#catch-workers-output">discards stderr</a> by default.</td>
+                    </tr>
+                    <tr>
                         <td class="documentation-first-column">logger_level</td>
-                        <td>set logging level – following logging levels are available: <code>EMERGENCY</code>, <code>ALERT</code>, <code>CRITICAL</code>, <code>ERROR</code>, <code>WARNING</code>, <code>NOTICE</code>, <code>INFO</code>, <code>DEBUG</code>. Additionally, you can use <code>NONE</code> pseudo-level to turn the logging off completely.<br>Use this for troubleshooting on updating feeds (but be aware that the log file can become very large.) The logged messages will be saved to <code>/data/logs/default.log</code>.</td>
+                        <td>set logging level – following logging levels are available: <code>EMERGENCY</code>, <code>ALERT</code>, <code>CRITICAL</code>, <code>ERROR</code>, <code>WARNING</code>, <code>NOTICE</code>, <code>INFO</code>, <code>DEBUG</code>. Additionally, you can use <code>NONE</code> pseudo-level to turn the logging off completely.<br>Use this for troubleshooting on updating feeds (but be aware that the log file can become very large.)</td>
                     </tr>
                     <tr>
                         <td class="documentation-first-column">items_perpage</td>

--- a/common.php
+++ b/common.php
@@ -1,6 +1,7 @@
 <?php
 
 use Monolog\Formatter\LineFormatter;
+use Monolog\Handler\ErrorLogHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 
@@ -39,7 +40,17 @@ foreach ($f3->get('ENV') as $key => $value) {
 // init logger
 $log = new Logger('selfoss');
 if ($f3->get('logger_level') !== 'NONE') {
-    $handler = new StreamHandler(__DIR__ . '/data/logs/default.log', $f3->get('logger_level'));
+    $logger_destination = $f3->get('logger_destination');
+
+    if (strpos($logger_destination, 'file:') === 0) {
+        $handler = new StreamHandler(substr($logger_destination, 5), $f3->get('logger_level'));
+    } elseif ($logger_destination === 'error_log') {
+        $handler = new ErrorLogHandler(ErrorLogHandler::OPERATING_SYSTEM, $f3->get('logger_level'));
+    } else {
+        echo 'The `logger_destination` option needs to be either `error_log` or a file path prefixed by `file:`.';
+        exit;
+    }
+
     $formatter = new LineFormatter(null, null, true, true);
     $formatter->includeStacktraces(true);
     $handler->setFormatter($formatter);

--- a/defaults.ini
+++ b/defaults.ini
@@ -9,6 +9,7 @@ db_username=root
 db_password=
 db_port=
 db_prefix=
+logger_destination=file:data/logs/default.log
 logger_level=ERROR
 items_perpage=50
 items_lifetime=30


### PR DESCRIPTION
This PR adds a new configuration option `logger_destination` allowing to choose between Monolog’s [`ErrorLogHandler`](https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/ErrorLogHandler.php) and [`StreamHandler`](https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/StreamHandler.php).