### PR TITLE
fix fr lang_markread

### DIFF
--- a/public/lang/fr.ini
+++ b/public/lang/fr.ini
@@ -1,4 +1,4 @@
-lang_markread=Marquer tout comme lu
+lang_markread=Marquer comme lu
 lang_filter=Filtres
 lang_newest=Tous
 lang_unread=Non lus


### PR DESCRIPTION
'Marquer tout comme lu' means 'Mark all read', which is wrong: the button
only marks visible read.