### PR TITLE
Add config option to hide the thumbnails

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
 # selfoss news
+## 2.19 – unreleased
+### New features
+- Thumbnails can be disabled ([#897](https://github.com/SSilence/selfoss/pull/897))
+
+
 ## 2.18 – 2018-03-05
 ### New features
 - Full-text RSS spout is now able to extract content from PDFs ([#897](https://github.com/SSilence/selfoss/pull/897))

--- a/_docs/website/index.html
+++ b/_docs/website/index.html
@@ -330,6 +330,10 @@ db_port=3306</code>
                         <td class="documentation-first-column">camo_key</td>
                         <td>Camo domain used to proxify images (optional). See <a href="https://github.com/atmos/camo">atmos/camo</a> for more details</td>
                     </tr>
+                    <tr>
+                        <td class="documentation-first-column">show_thumbnails</td>
+                        <td>If set to false, thumbnails are not shown in the collapsed view. Defaults to true.</td>
+                    </tr>
                 </table>
             </div>
 

--- a/defaults.ini
+++ b/defaults.ini
@@ -40,3 +40,4 @@ env_prefix=selfoss_
 camo_domain=
 camo_key=
 scroll_to_article_header=1
+show_thumbnails=1

--- a/spouts/twitter/usertimeline.php
+++ b/spouts/twitter/usertimeline.php
@@ -257,7 +257,7 @@ class usertimeline extends \spouts\spout {
                 $item = $item->retweeted_status;
             }
 
-            if (isset($item->extended_entities) && isset($item->extended_entities->media) && count($item->extended_entities->media) > 1) {
+            if (isset($item->extended_entities) && isset($item->extended_entities->media) && count($item->extended_entities->media) > 0) {
                 foreach ($item->extended_entities->media as $media) {
                     if ($media->type === 'photo') {
                         $result .= '<p><a href="' . $media->media_url_https . ':large"><img src="' . $media->media_url_https . ':small" alt=""></a></p>' . PHP_EOL;

--- a/templates/item.phtml
+++ b/templates/item.phtml
@@ -57,7 +57,7 @@
     <a href="<?= $this->item['link']; ?>" class="entry-link"></a>
 
     <!-- thumbnail -->
-    <?php if (isset($this->item['thumbnail']) && strlen(trim($this->item['thumbnail'])) > 0) : ?>
+    <?php if (\F3::get('show_thumbnails') && isset($this->item['thumbnail']) && strlen(trim($this->item['thumbnail'])) > 0) : ?>
     <div class="entry-thumbnail">
         <a href="<?= \helpers\Anonymizer::anonymize($this->item['link']); ?>" target="_blank" rel="noopener noreferrer">
             <img src="<?= 'thumbnails/' . $this->item['thumbnail']; ?>" alt="<?= htmLawed(htmlspecialchars_decode($this->item['title']), ['deny_attribute' => '*', 'elements' => '-*']); ?>" />


### PR DESCRIPTION
The thumbnails, e.g. of the Youtube spout bloat the layout of the single
items while collapsed. This allows the user to hide the thumbnails via a
config option.