### PR TITLE
Use Guzzle with SimplePIe

### DIFF
--- a/helpers/SimplePieFileGuzzle.php
+++ b/helpers/SimplePieFileGuzzle.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace helpers;
+
+/**
+ * Bridge to make SimplePie fetch resources using Guzzle library
+ */
+class SimplePieFileGuzzle extends \SimplePie_File {
+    public function __construct($url, $timeout = 10, $redirects = 5, $headers = [], $useragent = null, $force_fsockopen = false) {
+        $this->url = $url;
+        $this->permanent_url = $url;
+        $this->useragent = $useragent;
+
+        if (preg_match('/^https?:\/\//i', $url)) {
+            $this->method = SIMPLEPIE_FILE_SOURCE_REMOTE | SIMPLEPIE_FILE_SOURCE_CURL;
+
+            $client = \helpers\WebClient::getHttpClient();
+            try {
+                $response = $client->get($url, [
+                    'allow_redirects' => [
+                        'max' => $redirects,
+                    ],
+                    'headers' => [
+                        'User-Agent' => $useragent,
+                        'Referer' => $url,
+                    ] + $headers,
+                    'timeout' => $timeout,
+                    'connect_timeout' => $timeout,
+                ]);
+
+                $this->headers = $response->getHeaders();
+                $this->url = $response->getEffectiveUrl();
+                $this->body = (string) $response->getBody();
+                $this->status_code = $response->getStatusCode();
+            } catch (\GuzzleHttp\Exception\RequestException $e) {
+                $this->error = $e->getMessage();
+                $this->success = false;
+            }
+        } else {
+            $this->method = SIMPLEPIE_FILE_SOURCE_LOCAL | SIMPLEPIE_FILE_SOURCE_FILE_GET_CONTENTS;
+            if (empty($url) || !($this->body = trim(file_get_contents($url)))) {
+                $this->error = 'file_get_contents could not read the file';
+                $this->success = false;
+            }
+        }
+    }
+}

--- a/spouts/rss/feed.php
+++ b/spouts/rss/feed.php
@@ -141,6 +141,7 @@ class feed extends \spouts\spout {
         $this->feed = @new \SimplePie();
         @$this->feed->set_cache_location(\F3::get('cache'));
         @$this->feed->set_cache_duration(1800);
+        @$this->feed->set_file_class('\helpers\SimplePieFileGuzzle');
         @$this->feed->set_feed_url(htmlspecialchars_decode($params['url']));
         @$this->feed->set_autodiscovery_level(SIMPLEPIE_LOCATOR_AUTODISCOVERY | SIMPLEPIE_LOCATOR_LOCAL_EXTENSION | SIMPLEPIE_LOCATOR_LOCAL_BODY);
         $this->feed->set_useragent(\helpers\WebClient::getUserAgent(['SimplePie/' . SIMPLEPIE_VERSION]));

--- a/spouts/rss/feed.php
+++ b/spouts/rss/feed.php
@@ -144,7 +144,7 @@ class feed extends \spouts\spout {
         @$this->feed->set_file_class('\helpers\SimplePieFileGuzzle');
         @$this->feed->set_feed_url(htmlspecialchars_decode($params['url']));
         @$this->feed->set_autodiscovery_level(SIMPLEPIE_LOCATOR_AUTODISCOVERY | SIMPLEPIE_LOCATOR_LOCAL_EXTENSION | SIMPLEPIE_LOCATOR_LOCAL_BODY);
-        $this->feed->set_useragent(\helpers\WebClient::getUserAgent(['SimplePie/' . SIMPLEPIE_VERSION]));
+        $this->feed->set_useragent(\helpers\WebClient::getUserAgent());
 
         // fetch items
         @$this->feed->init();


### PR DESCRIPTION
SimplePie uses custom code for fetching resources from web but this is inconsistent and error-prone. To fix this, we will be overloading SimplePie’s `File` class with our own subclass using Guzzle.

Additionally, we will be no longer adding “Simplepie/X.Y.Z” string to the `User-Agent` header. Given that this is just an implementation detail, and that many websites actively block SimplePie.