### PR TITLE
Handle feeds with date that cannot be parsed

### DIFF
--- a/helpers/ContentLoader.php
+++ b/helpers/ContentLoader.php
@@ -131,6 +131,10 @@ class ContentLoader {
 
             // test date: continue with next if item too old
             $itemDate = new \DateTime($item->getDate());
+            // if date cannot be parsed it will default to epoch. Change to current time.
+            if ($itemDate->getTimestamp() == 0) {
+                $itemDate = new \DateTime();
+            }
             if ($itemDate < $minDate) {
                 \F3::get('logger')->debug('item "' . $item->getTitle() . '" (' . $item->getDate() . ') older than ' . \F3::get('items_lifetime') . ' days');
                 continue;


### PR DESCRIPTION
I have a feed where SimplePie cannot parse the pubDate. The format looks like this: "<pubDate>ma, 08 okt 2018 10:09:29 +0000</pubDate>".
The result is a date for the item that is epoch (which is too old). Therefore the items will never show up in the reader as they are too old. By falling back to current time when the date cannot be parsed will make the items show up in selfoss.