### PR TITLE
Add a simple tooltip that show spout description

### DIFF
--- a/templates/source.phtml
+++ b/templates/source.phtml
@@ -58,7 +58,7 @@
             <select id="type-<?= $idAttr ?>" class="source-spout" name="spout">
                 <option value=""><?= \F3::get('lang_source_select')?></option>
                 <?php foreach ($this->spouts as $spouttype => $spout) : ?>
-                <option value="<?= str_replace('\\', '_', $spouttype); ?>" <?= isset($this->source) && $spouttype == $this->source['spout'] ? 'selected="selected"' : ''; ?>>
+                <option title="<?= $spout->description ?>" value="<?= str_replace('\\', '_', $spouttype); ?>" <?= isset($this->source) && $spouttype == $this->source['spout'] ? 'selected="selected"' : ''; ?>>
                     <?= $spout->name; ?>
                 </option>
                 <?php endforeach; ?>


### PR DESCRIPTION
Hi @jtojnar, here is my deadly simple and useful selfoss commit 😉 

I have just added a simple "tootlip" that show the description of feed type when you put your cursor on it.

Here is a demo on my server :
![image](https://user-images.githubusercontent.com/6597721/47755854-4082eb80-dca0-11e8-810c-6ce9e1bf3a83.png)
