### PR TITLE
Do not use columns for long articles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - Thumbnails can be disabled ([#897](https://github.com/SSilence/selfoss/pull/897))
 - Reddit spout replaced fragile imgur heuristics with previews provided by the JSON API ([#1033](https://github.com/SSilence/selfoss/pull/1033))
 - Support for **using selfoss offline** was added. Note that this is only available in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts), that is, over HTTPS. ([#1014](https://github.com/SSilence/selfoss/issues/1014))
+- Long articles will no longer be arranged into columns, allowing for smoother reading experience ([#1081](https://github.com/SSilence/selfoss/pull/1081))
 
 ### Bug fixes
 - Reddit spout allows wider range of URLs, including absolute URLs and searches ([#1033](https://github.com/SSilence/selfoss/pull/1033))

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -602,6 +602,7 @@ body * {
             -webkit-column-count: 1;
             column-count: 1;
             max-width: 750px;
+            margin: auto;
         }
 
         .entry-content pre, .entry-content table {

--- a/public/js/selfoss-events-entries.js
+++ b/public/js/selfoss-events-entries.js
@@ -110,6 +110,11 @@ selfoss.events.entries = function() {
                 if ($('#config').data('scroll_to_article_header') == '1') {
                     parent.get(0).scrollIntoView();
                 }
+
+                // turn of column view if entry is too long
+                if (entryContent.height() > $(window).height()) {
+                    entryContent.addClass('entry-content-nocolumns');
+                }
             }
 
             // load images not on mobile devices


### PR DESCRIPTION
If long articles use columns, it forces the user to scroll up and down repeatedly.

This was originally introduced in a7f24906f9df3329a8d6fdd0088049e766b0f068 but later reverted for reasons unknown in 42e0ed4bfd3a95353fb3f458363eff0acc2ae691.

Let’s re-add the condition and also centre the body for nicer experience.

Closes: #1080, #629 

Example feed: https://dolphin-emu.org/blog/feeds/

cc @niol