### PR TITLE
A11Y fixes for toolbar and some typo fixes for aria-labelledbyAccessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/assets/.cache
 /data/favicons/*.png
 /data/favicons/*.jpg
 /data/thumbnails/*.png

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -316,6 +316,10 @@ span.offline-count.diff {
     text-align: center;
 }
 
+.nav-toolbar li {
+    display: inline-block;
+}
+
 body:not(.publicupdate) #nav-login {
     width: 140px;
     margin-left: 0;

--- a/assets/js/selfoss-ui.js
+++ b/assets/js/selfoss-ui.js
@@ -26,7 +26,7 @@ selfoss.ui = {
 
         initIcons();
 
-        $('body').append(<div id="loginform">
+        $('body').append(<div id="loginform" role="main">
             <form action="" method="post">
                 <ul id="login">
                     <li><h1>{`${selfoss.config.htmlTitle} login`}</h1></li>

--- a/assets/js/selfoss-ui.js
+++ b/assets/js/selfoss-ui.js
@@ -58,7 +58,7 @@ selfoss.ui = {
 
                 <div id="nav-filter-wrapper">
                     <h2><button type="button" id="nav-filter-title" class="nav-section-toggle nav-filter-expanded" aria-expanded="true"><i class="fas fa-caret-down fa-lg fa-fw"></i> {selfoss.ui._('filter')}</button></h2>
-                    <ul id="nav-filter" aria-labeledby="nav-filter-title">
+                    <ul id="nav-filter" aria-labelledby="nav-filter-title">
                         <li>
                             <a id="nav-filter-newest" class="nav-filter-newest" href="#">
                                 {selfoss.ui._('newest')}
@@ -89,11 +89,11 @@ selfoss.ui = {
 
                 <div id="nav-tags-wrapper">
                     <h2><button type="button" id="nav-tags-title" class="nav-section-toggle nav-tags-expanded" aria-expanded="true"><i class="fas fa-caret-down fa-lg fa-fw"></i> {selfoss.ui._('tags')}</button></h2>
-                    <ul id="nav-tags" aria-labeledby="nav-tags-title">
+                    <ul id="nav-tags" aria-labelledby="nav-tags-title">
                         <li><a class="active nav-tags-all" href="#">{selfoss.ui._('alltags')}</a></li>
                     </ul>
                     <h2><button type="button" id="nav-sources-title" class="nav-section-toggle nav-sources-collapsed" aria-expanded="false"><i class="fas fa-caret-right fa-lg fa-fw"></i> {selfoss.ui._('sources')}</button></h2>
-                    <ul id="nav-sources" aria-labeledby="nav-sources-title">
+                    <ul id="nav-sources" aria-labelledby="nav-sources-title">
                     </ul>
                 </div>
 

--- a/assets/js/selfoss-ui.js
+++ b/assets/js/selfoss-ui.js
@@ -105,12 +105,12 @@ selfoss.ui = {
                     <hr />
                 </div>
 
-                <div class="nav-toolbar">
-                    <button id="nav-refresh" title={selfoss.ui._('refreshbutton')} aria-label={selfoss.ui._('refreshbutton')} accesskey="r"><i class="fas fa-sync-alt"></i></button>
-                    <button id="nav-settings" title={selfoss.ui._('settingsbutton')} aria-label={selfoss.ui._('settingsbutton')} accesskey="t"><i class="fas fa-cloud-upload-alt"></i></button>
-                    <button id="nav-logout" title={selfoss.ui._('logoutbutton')} aria-label={selfoss.ui._('logoutbutton')} accesskey="l"><i class="fas fa-sign-out-alt"></i></button>
-                    <button id="nav-login" title={selfoss.ui._('loginbutton')} aria-label={selfoss.ui._('loginbutton')} accesskey="l"><i class="fas fa-key"></i></button>
-                </div>
+                <ul class="nav-toolbar" aria-label={selfoss.ui._('nav_toolbar_label')}>
+                    <li><button id="nav-refresh" title={selfoss.ui._('refreshbutton')} aria-label={selfoss.ui._('refreshbutton')} accesskey="r"><i class="fas fa-sync-alt"></i></button></li>
+                    <li><button id="nav-settings" title={selfoss.ui._('settingsbutton')} aria-label={selfoss.ui._('settingsbutton')} accesskey="t"><i class="fas fa-cloud-upload-alt"></i></button></li>
+                    <li><button id="nav-logout" title={selfoss.ui._('logoutbutton')} aria-label={selfoss.ui._('logoutbutton')} accesskey="l"><i class="fas fa-sign-out-alt"></i></button></li>
+                    <li><button id="nav-login" title={selfoss.ui._('loginbutton')} aria-label={selfoss.ui._('loginbutton')} accesskey="l"><i class="fas fa-key"></i></button></li>
+                </ul>
             </div>
 
             {/* search */}

--- a/assets/locale/en.json
+++ b/assets/locale/en.json
@@ -92,5 +92,6 @@
   "lang_error_share_native_abort": "Unable to share item – either there are no share targets, or you cancelled it.",
   "lang_error_share_native": "Unable to share item.",
   "lang_info_url_copied": "URL copied to clipboard.",
-  "lang_article_actions": "Actions"
+  "lang_article_actions": "Actions",
+  "lang_nav_toolbar_label": "Navigation Toolbar"
 }


### PR DESCRIPTION
There were some typos in aria-labelled by.
Fixed them.
Previously they were written as aria-labeledby which I noticed that is wrong.
Also, made some improvements in the toolbar accessibility.
Excluded the assets/.cache directory from the VCS.