### PR TITLE
Pass mass-marked entry ids as JSON

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,10 +19,12 @@
 - URLs containing special characters like commas in query string are now handled correctly ([#1082](https://github.com/SSilence/selfoss/pull/1082))
 - Set 60 second timeout to spout HTTP requests to prevent a single feed blocking other updates ([#1104](https://github.com/SSilence/selfoss/issues/1104))
 - Significantly improved accessibility ([#1133](https://github.com/SSilence/selfoss/pull/1133), [#1134](https://github.com/SSilence/selfoss/pull/1134) and [#1141](https://github.com/SSilence/selfoss/pull/1141))
+- Fixed marking more than 1000 items as read at the same time ([#1182](https://github.com/SSilence/selfoss/issues/1182))
 
 ### API changes
 - `tags` attribute is now consistently array of strings, numbers are numbers and booleans are booleans. **This might break third-party clients that have not updated yet.** ([#948](https://github.com/SSilence/selfoss/pull/948))
 - API is now versioned separately from selfoss and follows [semantic versioning](https://semver.org/) ([#1137](https://github.com/SSilence/selfoss/pull/1137))
+- *API 2.21.0*: `/mark` now accepts list of item IDs encoded as JSON. Requests using `application/x-www-form-urlencoded` are deprecated. ([#1182](https://github.com/SSilence/selfoss/pull/1182))
 
 ### Customization changes
 - `selfoss.shares.register` changed its signature: it no longer takes a boolean argument, and the callback is expected to open a window itself, instead of returning a URL. The `register` method now also expects a label and a HTML code of an icon (you can use a `<img>` tag, inline `<svg>`, emoji, etc.).

--- a/assets/js/selfoss-base.js
+++ b/assets/js/selfoss-base.js
@@ -603,9 +603,8 @@ var selfoss = {
             url: 'mark',
             type: 'POST',
             dataType: 'json',
-            data: {
-                ids: ids
-            },
+            contentType: 'application/json; charset=utf-8',
+            data: JSON.stringify(ids),
             success: function() {
                 selfoss.db.setOnline();
                 displayNextUnread();

--- a/docs/api-description.json
+++ b/docs/api-description.json
@@ -3,7 +3,7 @@
   "servers": [],
   "info": {
     "description": "You can access selfoss by using the same backend as selfoss user interface: The RESTful HTTP JSON API. There are a few urls where you can get information from selfoss and some for updating data. Assume you want all tags for rendering this in your own app. You have to make an HTTP GET call on the url /tags:\n\n```\nGET http://yourselfossurl.com/tags\n```\nThe result is following JSON formatted response (in this example two tags “blog” and “deviantart” are available:\n\n```\n[{\"tag\":\"blog\",\"color\":\"#251f10\",\"unread\":\"1\"},\n{\"tag\":\"deviantart\",\"color\":\"#e78e5c\",\"unread\":\"0\"}]\n```\n\nFollowing docs shows you which calls are possible and which response you can expect.",
-    "version": "2.20.0",
+    "version": "2.21.0",
     "title": "selfoss"
   },
   "tags": [
@@ -330,8 +330,18 @@
         },
         "requestBody": {
           "content": {
+            "application/json": {
+              "schema": {
+                "description": "a list of all ids for marking as read",
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              }
+            },
             "application/x-www-form-urlencoded": {
               "schema": {
+                "deprecated": true,
                 "type": "object",
                 "properties": {
                   "ids": {

--- a/src/controllers/Items.php
+++ b/src/controllers/Items.php
@@ -43,8 +43,14 @@ class Items {
 
         if (isset($params['item'])) {
             $lastid = $params['item'];
-        } elseif (isset($_POST['ids'])) {
-            $lastid = $_POST['ids'];
+        } else {
+            $headers = \F3::get('HEADERS');
+            if (isset($headers['Content-Type']) && strpos($headers['Content-Type'], 'application/json') === 0) {
+                $body = \F3::get('BODY');
+                $lastid = json_decode($body, true);
+            } elseif (isset($_POST['ids'])) {
+                $lastid = $_POST['ids'];
+            }
         }
 
         // validate id or ids


### PR DESCRIPTION
PHP can only handle 1000 POST variables by default so marking will fail with more entries. Passing it as JSON is more reliable and even sends less data.

Fixes: https://github.com/SSilence/selfoss/issues/1037