### PR TITLE
Render navigation client-side

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -228,6 +228,22 @@ span.offline-count.diff {
     flex-grow: 1;
 }
 
+#nav-tags-wrapper.offline {
+    display: none;
+}
+
+.nav-unavailable {
+    display: none;
+}
+
+.nav-unavailable.offline {
+    display: block;
+    text-align: center;
+    opacity: 0.8;
+    font-size: 0.7em;
+    line-height: 1.2em;
+}
+
 #nav-tags li a {
     position: relative;
     color: #b9b9b9;

--- a/assets/js/icons.js
+++ b/assets/js/icons.js
@@ -23,9 +23,11 @@ import { faKey } from '@fortawesome/free-solid-svg-icons/faKey';
 import { faSearch } from '@fortawesome/free-solid-svg-icons/faSearch';
 import { faShareAlt } from '@fortawesome/free-solid-svg-icons/faShareAlt';
 import { faSignOutAlt } from '@fortawesome/free-solid-svg-icons/faSignOutAlt';
+import { faSlash } from '@fortawesome/free-solid-svg-icons/faSlash';
 import { faStar } from '@fortawesome/free-solid-svg-icons/faStar';
 import { faSyncAlt } from '@fortawesome/free-solid-svg-icons/faSyncAlt';
 import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
+import { faWifi } from '@fortawesome/free-solid-svg-icons/faWifi';
 // ¡dom needs to be renamed to something else because jsx-dom takes precedence!
 import { library, dom as faDom } from '@fortawesome/fontawesome-svg-core';
 import wallabag from '../images/wallabag';
@@ -64,9 +66,11 @@ export function initIcons() {
         faSearch,
         faShareAlt,
         faSignOutAlt,
+        faSlash,
         faStar,
         faSyncAlt,
         faTimes,
+        faWifi,
         wallabagIcon
     );
 

--- a/assets/js/selfoss-base.js
+++ b/assets/js/selfoss-base.js
@@ -396,12 +396,10 @@ var selfoss = {
         $('#nav-tags').addClass('loading');
 
         $.ajax({
-            url: 'tagslist',
+            url: 'tags',
             type: 'GET',
             success: function(data) {
-                $('#nav-tags li:not(:first)').remove();
-                $('#nav-tags').append(data);
-                selfoss.events.navigation();
+                selfoss.refreshTags(data);
             },
             error: function(jqXHR, textStatus, errorThrown) {
                 selfoss.ui.showError(selfoss.ui._('error_load_tags') + ' ' +
@@ -420,10 +418,10 @@ var selfoss = {
      * @return void
      * @param tags the new taglist as html
      */
-    refreshTags: function(tags) {
+    refreshTags: function(tags, delayNavigation = false) {
         $('.color').spectrum('destroy');
-        $('#nav-tags li:not(:first)').remove();
-        $('#nav-tags').append(tags);
+        let renderedTags = templates.navTags({tags});
+        $('#nav-tags').html(renderedTags);
         if (selfoss.filter.tag) {
             if (!selfoss.db.isValidTag(selfoss.filter.tag)) {
                 selfoss.ui.showError(selfoss.ui._('error_unknown_tag') + ' ' + selfoss.filter.tag);
@@ -441,7 +439,9 @@ var selfoss = {
             $('.nav-tags-all').addClass('active');
         }
 
-        selfoss.events.navigation();
+        if (!delayNavigation) {
+            selfoss.events.navigation();
+        }
     },
 
 

--- a/assets/js/selfoss-base.js
+++ b/assets/js/selfoss-base.js
@@ -1,3 +1,5 @@
+import templates from './templates';
+
 /**
  * base javascript application
  *
@@ -451,9 +453,9 @@ var selfoss = {
      * @return void
      * @param sources the new sourceslist as html
      */
-    refreshSources: function(sources) {
-        $('#nav-sources li').remove();
-        $('#nav-sources').append(sources);
+    refreshSources: function(sources, delayNavigation = false) {
+        let renderedSources = templates.navSources({sources});
+        $('#nav-sources').html(renderedSources);
         if (selfoss.filter.source) {
             if (!selfoss.db.isValidSource(selfoss.filter.source)) {
                 selfoss.ui.showError(selfoss.ui._('error_unknown_source') + ' '
@@ -469,7 +471,9 @@ var selfoss = {
             $('#nav-sources-title').click(); // expand sources nav
         }
 
-        selfoss.events.navigation();
+        if (!delayNavigation) {
+            selfoss.events.navigation();
+        }
     },
 
 

--- a/assets/js/selfoss-db.js
+++ b/assets/js/selfoss-db.js
@@ -183,8 +183,8 @@ selfoss.dbOnline = {
                         data.stats.starred);
                 }
 
-                if ('tagshtml' in data) {
-                    selfoss.refreshTags(data.tagshtml);
+                if ('tags' in data) {
+                    selfoss.refreshTags(data.tags);
                 }
 
                 if ('sources' in data) {

--- a/assets/js/selfoss-db.js
+++ b/assets/js/selfoss-db.js
@@ -187,8 +187,8 @@ selfoss.dbOnline = {
                     selfoss.refreshTags(data.tagshtml);
                 }
 
-                if ('sourceshtml' in data) {
-                    selfoss.refreshSources(data.sourceshtml);
+                if ('sources' in data) {
+                    selfoss.refreshSources(data.sources);
                 }
 
                 if ('stats' in data && data.stats.unread > 0 &&

--- a/assets/js/selfoss-events-navigation.js
+++ b/assets/js/selfoss-events-navigation.js
@@ -138,10 +138,10 @@ selfoss.events.navigation = function() {
         selfoss.filter.sourcesNav = $('#nav-sources-title').hasClass('nav-sources-collapsed');
         if (selfoss.filter.sourcesNav && !selfoss.sourcesNavLoaded) {
             $.ajax({
-                url: 'sources/sourcesStats',
+                url: 'sources/stats',
                 type: 'GET',
                 success: function(data) {
-                    selfoss.refreshSources(data.sources);
+                    selfoss.refreshSources(data);
                 },
                 error: function(jqXHR, textStatus, errorThrown) {
                     selfoss.ui.showError(selfoss.ui._('error_loading_stats') + ' ' +

--- a/assets/js/selfoss-events-sources.js
+++ b/assets/js/selfoss-events-sources.js
@@ -87,8 +87,7 @@ selfoss.events.sources = function() {
                 parent.removeClass('source-new');
 
                 // update tags
-                $('#nav-tags li:not(:first)').remove();
-                $('#nav-tags').append(response.tags);
+                selfoss.refreshTags(response.tags, true);
 
                 // update sources
                 selfoss.refreshSources(response.sources, true);

--- a/assets/js/selfoss-events-sources.js
+++ b/assets/js/selfoss-events-sources.js
@@ -91,8 +91,7 @@ selfoss.events.sources = function() {
                 $('#nav-tags').append(response.tags);
 
                 // update sources
-                $('#nav-sources li').remove();
-                $('#nav-sources').append(response.sources);
+                selfoss.refreshSources(response.sources, true);
 
                 selfoss.events.navigation();
             },

--- a/assets/js/selfoss-sw-offline.js
+++ b/assets/js/selfoss-sw-offline.js
@@ -36,9 +36,7 @@ self.addEventListener('activate', function(event) {
 
 self.addEventListener('fetch', function(event) {
     event.respondWith(caches.match(event.request).then(function(resp) {
-        return resp || fetch(event.request).catch(function(err) {
-            return err;
-        });
+        return resp || fetch(event.request);
     }));
 });
 

--- a/assets/js/selfoss-ui.js
+++ b/assets/js/selfoss-ui.js
@@ -90,7 +90,6 @@ selfoss.ui = {
                 <div id="nav-tags-wrapper">
                     <h2><button type="button" id="nav-tags-title" class="nav-section-toggle nav-tags-expanded" aria-expanded="true"><i class="fas fa-caret-down fa-lg fa-fw"></i> {selfoss.ui._('tags')}</button></h2>
                     <ul id="nav-tags" aria-labelledby="nav-tags-title">
-                        <li><a class="active nav-tags-all" href="#">{selfoss.ui._('alltags')}</a></li>
                     </ul>
                     <h2><button type="button" id="nav-sources-title" class="nav-section-toggle nav-sources-collapsed" aria-expanded="false"><i class="fas fa-caret-right fa-lg fa-fw"></i> {selfoss.ui._('sources')}</button></h2>
                     <ul id="nav-sources" aria-labelledby="nav-sources-title">

--- a/assets/js/selfoss-ui.js
+++ b/assets/js/selfoss-ui.js
@@ -87,13 +87,20 @@ selfoss.ui = {
 
                 <div class="separator"><hr /></div>
 
-                <div id="nav-tags-wrapper">
+                <div id="nav-tags-wrapper" class="offlineable">
                     <h2><button type="button" id="nav-tags-title" class="nav-section-toggle nav-tags-expanded" aria-expanded="true"><i class="fas fa-caret-down fa-lg fa-fw"></i> {selfoss.ui._('tags')}</button></h2>
                     <ul id="nav-tags" aria-labelledby="nav-tags-title">
                     </ul>
                     <h2><button type="button" id="nav-sources-title" class="nav-section-toggle nav-sources-collapsed" aria-expanded="false"><i class="fas fa-caret-right fa-lg fa-fw"></i> {selfoss.ui._('sources')}</button></h2>
                     <ul id="nav-sources" aria-labelledby="nav-sources-title">
                     </ul>
+                </div>
+                <div class="nav-unavailable offlineable">
+                    <span class="fa-stack fa-2x">
+                        <i class="fas fa-wifi fa-stack-1x"></i>
+                        <i class="fas fa-slash fa-stack-1x"></i>
+                    </span>
+                    <p>{selfoss.ui._('offline_navigation_unavailable')}</p>
                 </div>
 
                 <div class="separator"><hr /></div>
@@ -201,10 +208,6 @@ selfoss.ui = {
     setOffline: function() {
         $('.offlineable').addClass('offline');
         $('.offlineable').removeClass('online');
-        $('#nav-tags li:not(:first)').remove();
-        if (!$('#nav-sources-title').hasClass('nav-sources-collapsed')) {
-            $('#nav-sources-title').click();
-        }
         selfoss.events.navigation();
     },
 

--- a/assets/js/templates.js
+++ b/assets/js/templates.js
@@ -1,7 +1,9 @@
 // Unfortunately we need to declare everything manually for Parcel to pick those up.
 
 import navSources from '../templates/nav-sources.js';
+import navTags from '../templates/nav-tags.js';
 
 export default {
-    navSources
+    navSources,
+    navTags
 };

--- a/assets/js/templates.js
+++ b/assets/js/templates.js
@@ -1,0 +1,7 @@
+// Unfortunately we need to declare everything manually for Parcel to pick those up.
+
+import navSources from '../templates/nav-sources.js';
+
+export default {
+    navSources
+};

--- a/assets/locale/cs.json
+++ b/assets/locale/cs.json
@@ -78,6 +78,7 @@
   "lang_error_invalid_subsection": "Podsekce neexistuje:",
   "lang_online_count": "Položky dostupné na serveru",
   "lang_offline_count": "Položky jsou dostupné v prohlížeči",
+  "lang_offline_navigation_unavailable": "Offline režim zatím neumožňuje přepínat mezi štítky a zdroji.",
   "lang_login_offline": "Ukládat data v prohlížeči",
   "lang_app_update": "selfoss byl aktualizován, prosím znovu načtěte stránku",
   "lang_app_reload": "Znovu načíst",

--- a/assets/locale/en.json
+++ b/assets/locale/en.json
@@ -6,6 +6,7 @@
   "lang_starred": "Starred",
   "lang_online_count": "Items available on the server",
   "lang_offline_count": "Items available locally",
+  "lang_offline_navigation_unavailable": "Switching tags and sources is currently not available in offline mode.",
   "lang_tags": "Tags",
   "lang_alltags": "All tags",
   "lang_timestamp": "{0,date} {0,time}",

--- a/assets/templates/nav-sources.js
+++ b/assets/templates/nav-sources.js
@@ -1,0 +1,8 @@
+export default ({sources}) => sources.map(source =>
+    <li>
+        <a href="#" id={`source${source.id}`} class={(source.unread > 0) ? 'unread' : ''} data-source-id={`${source.id}`}>
+            <span class="nav-source">{`${source.title}`}</span>
+            <span class="unread">{`${(source.unread > 0) ? `${source.unread}` : ''}`}</span>
+        </a>
+    </li>
+);

--- a/assets/templates/nav-tags.js
+++ b/assets/templates/nav-tags.js
@@ -1,0 +1,12 @@
+export default ({tags}) =>
+    [
+        <li><a class="active nav-tags-all" href="#">{selfoss.ui._('alltags')}</a></li>
+    ].concat(tags.map(tag =>
+        <li>
+            <a href="#">
+                <span class="tag">{`${tag.tag}`}</span>
+                <span class="unread">{`${(tag.unread > 0) ? tag.unread : ''}`}</span>
+                <span class="color" style={`background-color: ${tag.color}`}></span>
+            </a>
+        </li>
+    ))

--- a/index.php
+++ b/index.php
@@ -24,7 +24,6 @@ $f3->route('GET /rss', controllers\Rss::class . '->rss'); // rss
 $f3->route('GET /feed', controllers\Rss::class . '->rss'); // rss
 $f3->route('GET /items', controllers\Items::class . '->listItems'); // json
 $f3->route('GET /tags', controllers\Tags::class . '->listTags'); // json
-$f3->route('GET /tagslist', controllers\Tags::class . '->tagslist'); // html
 $f3->route('GET /stats', controllers\Items\Stats::class . '->stats'); // json
 $f3->route('GET /items/sync', controllers\Items\Sync::class . '->sync'); // json
 $f3->route('GET /sources/stats', controllers\Sources::class . '->stats'); // json

--- a/index.php
+++ b/index.php
@@ -41,7 +41,6 @@ $f3->route('GET /source/params', controllers\Sources::class . '->params'); // ht
 $f3->route('GET /sources', controllers\Sources::class . '->show'); // html
 $f3->route('GET /source', controllers\Sources::class . '->add'); // html
 $f3->route('GET /sources/list', controllers\Sources::class . '->listSources'); // json
-$f3->route('GET /sources/sourcesStats', controllers\Sources::class . '->sourcesStats'); // json
 $f3->route('POST /source/@id', controllers\Sources::class . '\Write->write'); // json
 $f3->route('POST /source', controllers\Sources::class . '\Write->write'); // json
 $f3->route('DELETE /source/@id', controllers\Sources::class . '->remove'); // json

--- a/src/controllers/Index.php
+++ b/src/controllers/Index.php
@@ -100,27 +100,22 @@ class Index {
         // prepare tags display list
         $this->view->tags = $this->tagsController->renderTags($tags);
 
+        $result = [
+            'lastUpdate' => \helpers\ViewHelper::date_iso8601($this->itemsDao->lastUpdate()),
+            'hasMore' => $items['hasMore'],
+            'entries' => $this->view->content,
+            'all' => $this->view->statsAll,
+            'unread' => $this->view->statsUnread,
+            'starred' => $this->view->statsStarred,
+            'tags' => $this->view->tags
+        ];
+
         if (isset($options['sourcesNav']) && $options['sourcesNav'] == 'true') {
             // prepare sources display list
-            $sources = $this->sourcesDao->getWithUnread();
-            $this->view->sources = $this->sourcesController->renderSources($sources);
-        } else {
-            $this->view->sources = '';
+            $result['sources'] = $this->sourcesDao->getWithUnread();
         }
 
-        // ajax call = only send entries and statistics not full template
-        if ($f3->ajax()) {
-            $this->view->jsonSuccess([
-                'lastUpdate' => \helpers\ViewHelper::date_iso8601($this->itemsDao->lastUpdate()),
-                'hasMore' => $items['hasMore'],
-                'entries' => $this->view->content,
-                'all' => $this->view->statsAll,
-                'unread' => $this->view->statsUnread,
-                'starred' => $this->view->statsStarred,
-                'tags' => $this->view->tags,
-                'sources' => $this->view->sources
-            ]);
-        }
+        $this->view->jsonSuccess($result);
     }
 
     /**

--- a/src/controllers/Index.php
+++ b/src/controllers/Index.php
@@ -97,9 +97,6 @@ class Index {
             $this->view->statsUnread -= $tag['unread'];
         }
 
-        // prepare tags display list
-        $this->view->tags = $this->tagsController->renderTags($tags);
-
         $result = [
             'lastUpdate' => \helpers\ViewHelper::date_iso8601($this->itemsDao->lastUpdate()),
             'hasMore' => $items['hasMore'],
@@ -107,7 +104,7 @@ class Index {
             'all' => $this->view->statsAll,
             'unread' => $this->view->statsUnread,
             'starred' => $this->view->statsStarred,
-            'tags' => $this->view->tags
+            'tags' => $tags
         ];
 
         if (isset($options['sourcesNav']) && $options['sourcesNav'] == 'true') {

--- a/src/controllers/Items/Stats.php
+++ b/src/controllers/Items/Stats.php
@@ -57,7 +57,7 @@ class Stats {
         }
 
         if (array_key_exists('tags', $_GET) && $_GET['tags'] == 'true') {
-            $stats['tagshtml'] = $this->tagsController->renderTags($tags);
+            $stats['tags'] = $tags;
         }
         if (array_key_exists('sources', $_GET) && $_GET['sources'] == 'true') {
             $stats['sources'] = $this->sourcesDao->getWithUnread();

--- a/src/controllers/Items/Stats.php
+++ b/src/controllers/Items/Stats.php
@@ -15,9 +15,6 @@ class Stats {
     /** @var \daos\Items items */
     private $itemsDao;
 
-    /** @var \controllers\Sources sources controller */
-    private $sourcesController;
-
     /** @var \daos\Sources sources */
     private $sourcesDao;
 
@@ -30,10 +27,9 @@ class Stats {
     /** @var View view helper */
     private $view;
 
-    public function __construct(Authentication $authentication, \daos\Items $itemsDao, \controllers\Sources $sourcesController, \daos\Sources $sourcesDao, \controllers\Tags $tagsController, \daos\Tags $tagsDao, View $view) {
+    public function __construct(Authentication $authentication, \daos\Items $itemsDao, \daos\Sources $sourcesDao, \controllers\Tags $tagsController, \daos\Tags $tagsDao, View $view) {
         $this->authentication = $authentication;
         $this->itemsDao = $itemsDao;
-        $this->sourcesController = $sourcesController;
         $this->sourcesDao = $sourcesDao;
         $this->tagsController = $tagsController;
         $this->tagsDao = $tagsDao;
@@ -64,7 +60,7 @@ class Stats {
             $stats['tagshtml'] = $this->tagsController->renderTags($tags);
         }
         if (array_key_exists('sources', $_GET) && $_GET['sources'] == 'true') {
-            $stats['sourceshtml'] = $this->sourcesController->renderSources($this->sourcesDao->getWithUnread());
+            $stats['sources'] = $this->sourcesDao->getWithUnread();
         }
 
         $this->view->jsonSuccess($stats);

--- a/src/controllers/Items/Sync.php
+++ b/src/controllers/Items/Sync.php
@@ -16,9 +16,6 @@ class Sync {
     /** @var \daos\Items items */
     private $itemsDao;
 
-    /** @var \controllers\Sources sources controller */
-    private $sourcesController;
-
     /** @var \daos\Sources sources */
     private $sourcesDao;
 
@@ -31,10 +28,9 @@ class Sync {
     /** @var View view helper */
     private $view;
 
-    public function __construct(Authentication $authentication, \daos\Items $itemsDao, \controllers\Sources $sourcesController, \daos\Sources $sourcesDao, \controllers\Tags $tagsController, \daos\Tags $tagsDao, View $view) {
+    public function __construct(Authentication $authentication, \daos\Items $itemsDao, \daos\Sources $sourcesDao, \controllers\Tags $tagsController, \daos\Tags $tagsDao, View $view) {
         $this->authentication = $authentication;
         $this->itemsDao = $itemsDao;
-        $this->sourcesController = $sourcesController;
         $this->sourcesDao = $sourcesDao;
         $this->tagsController = $tagsController;
         $this->tagsDao = $tagsDao;
@@ -117,7 +113,7 @@ class Sync {
                 $sync['tagshtml'] = $this->tagsController->renderTags($this->tagsDao->getWithUnread());
             }
             if (array_key_exists('sources', $params) && $_GET['sources'] == 'true') {
-                $sync['sourceshtml'] = $this->sourcesController->renderSources($this->sourcesDao->getWithUnread());
+                $sync['sources'] = $this->sourcesDao->getWithUnread();
             }
 
             $wantItemsStatuses = array_key_exists('itemsStatuses', $params) && $params['itemsStatuses'] == 'true';

--- a/src/controllers/Items/Sync.php
+++ b/src/controllers/Items/Sync.php
@@ -110,7 +110,7 @@ class Sync {
             $sync['stats'] = $this->itemsDao->stats();
 
             if (array_key_exists('tags', $params) && $_GET['tags'] == 'true') {
-                $sync['tagshtml'] = $this->tagsController->renderTags($this->tagsDao->getWithUnread());
+                $sync['tags'] = $this->tagsDao->getWithUnread();
             }
             if (array_key_exists('sources', $params) && $_GET['sources'] == 'true') {
                 $sync['sources'] = $this->sourcesDao->getWithUnread();

--- a/src/controllers/Sources.php
+++ b/src/controllers/Sources.php
@@ -104,54 +104,6 @@ class Sources {
     }
 
     /**
-     * return all Sources suitable for navigation panel
-     * html
-     *
-     * @param array $sources sources to render
-     *
-     * @return string htmltext
-     */
-    public function renderSources(array $sources) {
-        $html = '';
-        foreach ($sources as $source) {
-            $this->view->source = $source['title'];
-            $this->view->sourceid = $source['id'];
-            $this->view->unread = $source['unread'];
-            $html .= $this->view->render('src/templates/source-nav.phtml');
-        }
-
-        return $html;
-    }
-
-    /**
-     * load all available sources and return all Sources suitable
-     * for navigation panel
-     * html
-     *
-     * @return string htmltext
-     */
-    public function sourcesListAsString() {
-        $sources = $this->sourcesDao->getWithUnread();
-
-        return $this->renderSources($sources);
-    }
-
-    /**
-     * return source stats in HTML for nav update
-     * json
-     *
-     * @return void
-     */
-    public function sourcesStats() {
-        $this->authentication->needsLoggedInOrPublicMode();
-
-        $this->view->jsonSuccess([
-            'success' => true,
-            'sources' => $this->sourcesListAsString()
-        ]);
-    }
-
-    /**
      * delete source
      * json
      *

--- a/src/controllers/Sources/Write.php
+++ b/src/controllers/Sources/Write.php
@@ -18,9 +18,6 @@ class Write {
     /** @var ContentLoader content loader */
     private $contentLoader;
 
-    /** @var \controllers\Sources sources controller */
-    private $sourcesController;
-
     /** @var \daos\Sources sources */
     private $sourcesDao;
 
@@ -36,10 +33,9 @@ class Write {
     /** @var View view helper */
     private $view;
 
-    public function __construct(Authentication $authentication, ContentLoader $contentLoader, \controllers\Sources $sourcesController, \daos\Sources $sourcesDao, SpoutLoader $spoutLoader, \controllers\Tags $tagsController, \daos\Tags $tagsDao, View $view) {
+    public function __construct(Authentication $authentication, ContentLoader $contentLoader, \daos\Sources $sourcesDao, SpoutLoader $spoutLoader, \controllers\Tags $tagsController, \daos\Tags $tagsDao, View $view) {
         $this->authentication = $authentication;
         $this->contentLoader = $contentLoader;
-        $this->sourcesController = $sourcesController;
         $this->sourcesDao = $sourcesDao;
         $this->spoutLoader = $spoutLoader;
         $this->tagsController = $tagsController;
@@ -147,7 +143,7 @@ class Write {
             $return['tags'] = $this->tagsController->tagsListAsString();
 
             // get new sources list
-            $return['sources'] = $this->sourcesController->sourcesListAsString();
+            $return['sources'] = $this->sourcesDao->getWithUnread();
         }
 
         $this->view->jsonSuccess($return);

--- a/src/controllers/Sources/Write.php
+++ b/src/controllers/Sources/Write.php
@@ -24,21 +24,17 @@ class Write {
     /** @var SpoutLoader spout loader */
     private $spoutLoader;
 
-    /** @var \controllers\Tags tags controller */
-    private $tagsController;
-
     /** @var \daos\Tags tags */
     private $tagsDao;
 
     /** @var View view helper */
     private $view;
 
-    public function __construct(Authentication $authentication, ContentLoader $contentLoader, \daos\Sources $sourcesDao, SpoutLoader $spoutLoader, \controllers\Tags $tagsController, \daos\Tags $tagsDao, View $view) {
+    public function __construct(Authentication $authentication, ContentLoader $contentLoader, \daos\Sources $sourcesDao, SpoutLoader $spoutLoader, \daos\Tags $tagsDao, View $view) {
         $this->authentication = $authentication;
         $this->contentLoader = $contentLoader;
         $this->sourcesDao = $sourcesDao;
         $this->spoutLoader = $spoutLoader;
-        $this->tagsController = $tagsController;
         $this->tagsDao = $tagsDao;
         $this->view = $view;
     }
@@ -140,7 +136,7 @@ class Write {
         // only for selfoss ui (update stats in navigation)
         if ($f3->ajax()) {
             // get new tag list with updated count values
-            $return['tags'] = $this->tagsController->tagsListAsString();
+            $return['tags'] = $this->tagsDao->getWithUnread();
 
             // get new sources list
             $return['sources'] = $this->sourcesDao->getWithUnread();

--- a/src/controllers/Tags.php
+++ b/src/controllers/Tags.php
@@ -29,48 +29,6 @@ class Tags {
         $this->view = $view;
     }
 
-    /**
-     * returns all tags
-     * html
-     *
-     * @return void
-     */
-    public function tagslist() {
-        $this->authentication->needsLoggedInOrPublicMode();
-
-        echo $this->tagsListAsString();
-    }
-
-    /**
-     * returns all tags
-     * html
-     *
-     * @return string
-     */
-    public function tagsListAsString() {
-        return $this->renderTags($this->tagsDao->getWithUnread());
-    }
-
-    /**
-     * returns all tags
-     * html
-     *
-     * @param array $tags list of all tags to render
-     *
-     * @return string
-     */
-    public function renderTags(array $tags) {
-        $html = '';
-        foreach ($tags as $tag) {
-            $this->view->tag = $tag['tag'];
-            $this->view->color = $tag['color'];
-            $this->view->unread = $tag['unread'];
-            $html .= $this->view->render('src/templates/tag.phtml');
-        }
-
-        return $html;
-    }
-
     /* @var array cache of tags and associated colors */
     protected $tagsColors = null;
 

--- a/src/templates/source-nav.phtml
+++ b/src/templates/source-nav.phtml
@@ -1,6 +1,0 @@
-<li>
-    <a href="#" id="source<?= $this->sourceid; ?>" class="<?= ($this->unread > 0) ? 'unread' : '' ?>" data-source-id="<?= $this->sourceid; ?>">
-        <span class="nav-source"><?= $this->source; ?></span>
-        <span class="unread"><?= ($this->unread > 0) ? $this->unread : '' ?></span>
-    </a>
-</li>

--- a/src/templates/tag.phtml
+++ b/src/templates/tag.phtml
@@ -1,7 +1,0 @@
-<li>
-    <a href="#">
-        <span class="tag"><?= $this->tag; ?></span>
-        <span class="unread"><?= ($this->unread > 0) ? $this->unread : '' ?></span>
-        <span class="color" style="background-color:<?= $this->color; ?>"></span>
-    </a>
-</li>


### PR DESCRIPTION
Replaces #1064 

Instead of EJS, we now use JSX syntax so we can import the templates as a JavaScript modules and do not have to mess up with ejs loader.

This is a prerequisite for filtering entries by sources and tags offline.