### PR TITLE
spouts\rss: Provide unencoded link

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 - Set 60 second timeout to spout HTTP requests to prevent a single feed blocking other updates ([#1104](https://github.com/SSilence/selfoss/issues/1104))
 - Significantly improved accessibility ([#1133](https://github.com/SSilence/selfoss/pull/1133), [#1134](https://github.com/SSilence/selfoss/pull/1134) and [#1141](https://github.com/SSilence/selfoss/pull/1141))
 - Fixed marking more than 1000 items as read at the same time ([#1182](https://github.com/SSilence/selfoss/issues/1182))
+- Fixed loading full text on pages containing ampersands in URLs ([#1188](https://github.com/SSilence/selfoss/pull/1188))
 
 ### API changes
 - `tags` attribute is now consistently array of strings, numbers are numbers and booleans are booleans. **This might break third-party clients that have not updated yet.** ([#948](https://github.com/SSilence/selfoss/pull/948))

--- a/src/helpers/FeedReader.php
+++ b/src/helpers/FeedReader.php
@@ -61,7 +61,7 @@ class FeedReader {
         return [
             // save fetched items
             'items' => $this->simplepie->get_items(),
-            'htmlUrl' => @$this->simplepie->get_link(),
+            'htmlUrl' => htmlspecialchars_decode($this->simplepie->get_link(), ENT_COMPAT), // SimplePie sanitizes URLs
             'spoutTitle' => $this->simplepie->get_title(),
         ];
     }
@@ -72,7 +72,7 @@ class FeedReader {
      * @return ?string
      */
     public function getImageUrl() {
-        return $this->simplepie->get_image_url();
+        return htmlspecialchars_decode($this->simplepie->get_image_url(), ENT_COMPAT); // SimplePie sanitizes URLs
     }
 
     /**
@@ -81,6 +81,10 @@ class FeedReader {
      * @return ?string
      */
     public function getFeedUrl() {
+        // SimplePie sanitizes URLs but it unescapes ampersands here.
+        // Since double quotes and angle brackets are excluded from URIs,
+        // we need not worry about them and consider this unescaped.
+        // https://tools.ietf.org/html/rfc2396#section-2.4.3
         return $this->simplepie->subscribe_url();
     }
 

--- a/src/spouts/reddit/reddit2.php
+++ b/src/spouts/reddit/reddit2.php
@@ -118,7 +118,8 @@ class reddit2 extends \spouts\spout {
 
     public function getHtmlUrl() {
         if ($this->items !== null && $this->valid()) {
-            return @current($this->items)['data']['url'];
+            // Reddit escapes HTML, we can get away with just ampersands, since quotes and angle brackets are excluded from URLs.
+            return htmlspecialchars_decode(current($this->items)['data']['url'], ENT_NOQUOTES);
         }
 
         return null;

--- a/src/spouts/rss/feed.php
+++ b/src/spouts/rss/feed.php
@@ -141,7 +141,7 @@ class feed extends \spouts\spout {
         if ($this->items !== null && $this->valid()) {
             $link = @current($this->items)->get_link();
 
-            return $link;
+            return htmlspecialchars_decode($link, ENT_COMPAT); // SimplePie sanitizes URLs
         }
 
         return null;


### PR DESCRIPTION
Fixes: #1185 
Replaces: #1187 

SimplePie returns links escaped with htmlspecialchars but we might want to use the URL to fetch additional data so we need to unescape it first.
ContentLoader will escape it again before saving it to database.