### PR TITLE
Refactor image fetching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -57,6 +57,7 @@
   ```
 
   ([#1017](https://github.com/SSilence/selfoss/pull/1017), [#1035](https://github.com/SSilence/selfoss/pull/1035))
+- Spouts can now implement `getSourceIcon()` instead of `getIcon()` when icon is associated with the feed, not individual icons. ([#1190](https://github.com/SSilence/selfoss/pull/1190))
 - Some language files have been renamed to use correct [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag) and you might need to change the `language` key in your `config.ini`:
   * Simplified Chinese `zh-CN`
   * Traditional Chinese `zh-TW`

--- a/src/common.php
+++ b/src/common.php
@@ -157,6 +157,32 @@ $dice->addRule(DB\SQL::class, array_merge($shared, [
     'constructParams' => $dbParams
 ]));
 
+$dice->addRule('$iconStorageBackend', [
+    'instanceOf' => helpers\Storage\FileStorage::class,
+    'constructParams' => [
+        \F3::get('datadir') . '/favicons'
+    ],
+]);
+
+$dice->addRule(helpers\IconStore::class, array_merge($shared, [
+    'constructParams' => [
+        ['instance' => '$iconStorageBackend'],
+    ]
+]));
+
+$dice->addRule('$thumbnailStorageBackend', [
+    'instanceOf' => helpers\Storage\FileStorage::class,
+    'constructParams' => [
+        \F3::get('datadir') . '/thumbnails'
+    ],
+]);
+
+$dice->addRule(helpers\ThumbnailStore::class, array_merge($shared, [
+    'constructParams' => [
+        ['instance' => '$thumbnailStorageBackend'],
+    ]
+]));
+
 // Fallback rule
 $dice->addRule('*', $substitutions);
 

--- a/src/helpers/ContentLoader.php
+++ b/src/helpers/ContentLoader.php
@@ -135,6 +135,7 @@ class ContentLoader {
         $itemsFound = $this->itemsDao->findAll($itemsInFeed, $source['id']);
 
         $iconCache = [];
+        $sourceIconUrl = null;
         $itemsSeen = [];
         foreach ($spout as $item) {
             // item already in database?
@@ -218,8 +219,26 @@ class ContentLoader {
                         $iconCache[$iconUrl] = $this->fetchIcon($iconUrl) ?: '';
                     }
                     $newItem['icon'] = $iconCache[$iconUrl];
+                } elseif ($sourceIconUrl !== null) {
+                    $this->logger->debug('using the source icon');
+                    $newItem['icon'] = $sourceIconUrl;
                 } else {
-                    $this->logger->debug('no icon for this feed');
+                    try {
+                        // we do not want to run this more than once
+                        $sourceIconUrl = $item->getSourceIcon() ?: '';
+
+                        if (strlen(trim($sourceIconUrl)) > 0) {
+                            // save source icon
+                            $sourceIconUrl = $this->fetchIcon($sourceIconUrl) ?: '';
+                            $newItem['icon'] = $sourceIconUrl;
+                        } else {
+                            $this->logger->debug('no icon for this item or source');
+                        }
+                    } catch (\Exception $e) {
+                        // cache failure
+                        $sourceIconUrl = '';
+                        $this->logger->error('feed icon: error', ['exception' => $e]);
+                    }
                 }
             } catch (\Exception $e) {
                 // cache failure

--- a/src/helpers/ContentLoader.php
+++ b/src/helpers/ContentLoader.php
@@ -317,8 +317,9 @@ class ContentLoader {
      */
     protected function fetchThumbnail($thumbnail, array $newItem) {
         if (strlen(trim($thumbnail)) > 0) {
-            $extension = 'jpg';
-            $thumbnailAsJpg = $this->imageHelper->loadImage($thumbnail, $extension, 500, 500);
+            $format = Image::FORMAT_JPEG;
+            $extension = Image::getExtension($format);
+            $thumbnailAsJpg = $this->imageHelper->loadImage($thumbnail, $format, 500, 500);
             if ($thumbnailAsJpg !== null) {
                 $written = file_put_contents(
                     \F3::get('datadir') . '/thumbnails/' . md5($thumbnail) . '.' . $extension,
@@ -350,12 +351,13 @@ class ContentLoader {
      */
     protected function fetchIcon($icon, array $newItem, &$lasticon) {
         if (strlen(trim($icon)) > 0) {
-            $extension = 'png';
+            $format = Image::FORMAT_PNG;
+            $extension = Image::getExtension($format);
             if ($icon === $lasticon) {
                 $this->logger->debug('use last icon: ' . $lasticon);
                 $newItem['icon'] = md5($lasticon) . '.' . $extension;
             } else {
-                $iconAsPng = $this->imageHelper->loadImage($icon, $extension, 30, null);
+                $iconAsPng = $this->imageHelper->loadImage($icon, $format, 30, null);
                 if ($iconAsPng !== null) {
                     $written = file_put_contents(
                         \F3::get('datadir') . '/favicons/' . md5($icon) . '.' . $extension,

--- a/src/helpers/ContentLoader.php
+++ b/src/helpers/ContentLoader.php
@@ -361,10 +361,10 @@ class ContentLoader {
         try {
             $data = $this->webClient->request($url);
             $format = self::THUMBNAIL_FORMAT;
-            $thumbnailAsJpg = $this->imageHelper->loadImage($data, $format, 500, 500);
+            $image = $this->imageHelper->loadImage($data, $format, 500, 500);
 
-            if ($thumbnailAsJpg !== null) {
-                return $this->thumbnailStore->store($url, $thumbnailAsJpg);
+            if ($image !== null) {
+                return $this->thumbnailStore->store($url, $image->getData());
             } else {
                 $this->logger->error('thumbnail generation error: ' . $url);
             }
@@ -388,10 +388,10 @@ class ContentLoader {
         try {
             $data = $this->webClient->request($url);
             $format = Image::FORMAT_PNG;
-            $iconAsPng = $this->imageHelper->loadImage($data, $format, 30, null);
+            $image = $this->imageHelper->loadImage($data, $format, 30, null);
 
-            if ($iconAsPng !== null) {
-                return $this->iconStore->store($url, $iconAsPng);
+            if ($image !== null) {
+                return $this->iconStore->store($url, $image->getData());
             } else {
                 $this->logger->error('icon generation error: ' . $url);
             }

--- a/src/helpers/IconStore.php
+++ b/src/helpers/IconStore.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace helpers;
+
+use helpers\Storage\FileStorage;
+use Monolog\Logger;
+
+/**
+ * Icon storage.
+ */
+class IconStore {
+    /** @var Logger */
+    private $logger;
+
+    /** @var FileStorage */
+    private $storage;
+
+    public function __construct(FileStorage $storage, Logger $logger) {
+        $this->storage = $storage;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Store given blob as URL.
+     *
+     * @param string $url
+     * @param string $blob
+     *
+     * @return ?string
+     */
+    public function store($url, $blob) {
+        $extension = Image::getExtension(ContentLoader::ICON_FORMAT);
+        $this->logger->debug('Storing icon: ' . $url);
+
+        return $this->storage->store($url, $extension, $blob);
+    }
+
+    /**
+     * Delete all icons except for requested ones.
+     *
+     * @param callable(string):bool $shouldKeep
+     *
+     * @return void
+     */
+    public function cleanup($shouldKeep) {
+        $this->storage->cleanup($shouldKeep);
+    }
+}

--- a/src/helpers/Image.php
+++ b/src/helpers/Image.php
@@ -85,7 +85,7 @@ class Image {
     public function fetchFavicon($url, $isHtmlUrl = false, $width = null, $height = null) {
         // try given url
         if ($isHtmlUrl === false) {
-            $faviconAsPng = $this->loadImage($url, $width, $height);
+            $faviconAsPng = $this->loadImage($url, self::FORMAT_PNG, $width, $height);
             if ($faviconAsPng !== null) {
                 return [$url, $faviconAsPng];
             }
@@ -102,7 +102,7 @@ class Image {
             $effectiveUrl = new Uri(WebClient::getEffectiveUrl($url, $response));
 
             if ($response->getStatusCode() !== 200) {
-                throw new Exception(substr($html, 0, 512));
+                throw new \Exception(substr($html, 0, 512));
             }
         } catch (\Exception $e) {
             $this->logger->debug('icon: failed to get html page: ', ['exception' => $e]);
@@ -113,7 +113,7 @@ class Image {
             foreach ($shortcutIcons as $shortcutIcon) {
                 $shortcutIconUrl = (string) UriResolver::resolve($effectiveUrl, new Uri($shortcutIcon));
 
-                $faviconAsPng = $this->loadImage($shortcutIconUrl, $width, $height);
+                $faviconAsPng = $this->loadImage($shortcutIconUrl, self::FORMAT_PNG, $width, $height);
                 if ($faviconAsPng !== null) {
                     return [$shortcutIconUrl, $faviconAsPng];
                 }
@@ -123,7 +123,7 @@ class Image {
         // search domain/favicon.ico
         if (isset($urlElements['scheme']) && isset($urlElements['host'])) {
             $url = $urlElements['scheme'] . '://' . $urlElements['host'] . '/favicon.ico';
-            $faviconAsPng = $this->loadImage($url, $width, $height);
+            $faviconAsPng = $this->loadImage($url, self::FORMAT_PNG, $width, $height);
             if ($faviconAsPng !== null) {
                 return [$url, $faviconAsPng];
             }

--- a/src/helpers/Image.php
+++ b/src/helpers/Image.php
@@ -19,9 +19,6 @@ class Image {
     const FORMAT_JPEG = 'jpeg';
     const FORMAT_PNG = 'png';
 
-    /** @var ?string url of last fetched favicon */
-    private $faviconUrl = null;
-
     private static $extensions = [
         self::FORMAT_JPEG => 'jpg',
         self::FORMAT_PNG => 'png',
@@ -83,16 +80,14 @@ class Image {
      * @param ?int $width
      * @param ?int $height
      *
-     * @return ?string
+     * @return ?array{string, string} pair of URL and blob containing the image data
      */
     public function fetchFavicon($url, $isHtmlUrl = false, $width = null, $height = null) {
         // try given url
         if ($isHtmlUrl === false) {
             $faviconAsPng = $this->loadImage($url, $width, $height);
             if ($faviconAsPng !== null) {
-                $this->faviconUrl = $url;
-
-                return $faviconAsPng;
+                return [$url, $faviconAsPng];
             }
         }
 
@@ -120,9 +115,7 @@ class Image {
 
                 $faviconAsPng = $this->loadImage($shortcutIconUrl, $width, $height);
                 if ($faviconAsPng !== null) {
-                    $this->faviconUrl = $shortcutIconUrl;
-
-                    return $faviconAsPng;
+                    return [$shortcutIconUrl, $faviconAsPng];
                 }
             }
         }
@@ -132,9 +125,7 @@ class Image {
             $url = $urlElements['scheme'] . '://' . $urlElements['host'] . '/favicon.ico';
             $faviconAsPng = $this->loadImage($url, $width, $height);
             if ($faviconAsPng !== null) {
-                $this->faviconUrl = $url;
-
-                return $faviconAsPng;
+                return [$url, $faviconAsPng];
             }
         }
 
@@ -263,15 +254,6 @@ class Image {
         }
 
         return $data;
-    }
-
-    /**
-     * get favicon url
-     *
-     * @return ?string
-     */
-    public function getFaviconUrl() {
-        return $this->faviconUrl;
     }
 
     /**

--- a/src/helpers/Image.php
+++ b/src/helpers/Image.php
@@ -181,11 +181,10 @@ class Image {
         if ($type === 'svg') {
             $image = new \Imagick();
             $image->readImageBlob($data);
-            if ($width === null || $height === null) {
-                $width = $height = 256;
+            if ($width !== null && $height !== null) {
+                $image->resizeImage($width, $height, \Imagick::FILTER_LANCZOS, 1, true);
             }
 
-            $image->resizeImage($width, $height, \Imagick::FILTER_LANCZOS, 1);
             if ($format === self::FORMAT_JPEG) {
                 $image->setImageFormat('jpeg');
                 $image->setImageCompression(\Imagick::COMPRESSION_JPEG);

--- a/src/helpers/Image.php
+++ b/src/helpers/Image.php
@@ -109,7 +109,7 @@ class Image {
         }
 
         if ($html !== null) {
-            $shortcutIcons = self::parseShortcutIcons($html);
+            $shortcutIcons = ImageUtils::parseShortcutIcons($html);
             foreach ($shortcutIcons as $shortcutIcon) {
                 $shortcutIconUrl = (string) UriResolver::resolve($effectiveUrl, new Uri($shortcutIcon));
 
@@ -257,123 +257,5 @@ class Image {
         }
 
         return $data;
-    }
-
-    /**
-     * removes $startString, $endString and everything in between from $subject
-     *
-     * @param string $startString
-     * @param string $endString
-     * @param string $subject
-     *
-     * @return string
-     */
-    public static function cleanString($startString, $endString, $subject) {
-        while (false !== $p1 = stripos($subject, $startString)) {
-            $block = substr($subject, $p1);
-            $subject = substr($subject, 0, $p1);
-            if (false !== $p2 = stripos($block, $endString)) {
-                $subject .= substr($block, $p2 + strlen($endString));
-            }
-        }
-
-        return $subject;
-    }
-
-    /**
-     * parse shortcut icons from given html
-     * If icons are found, their URLs are returned in an array ordered by size
-     * if given or by likely size of not, with the biggest one first.
-     *
-     * @param string $html
-     *
-     * @return array
-     */
-    public static function parseShortcutIcons($html) {
-        $end = strripos($html, '</head>');
-        if ($end > 1) {
-            $html = substr($html, 0, $end);
-        }
-
-        // $html= preg_replace('/<!--.*-->/sU', '', preg_replace('#<(script|style)\b[^>]*>.*</\1>#sU', '', $html));
-        // should to the same, but doesn't always.
-        $html = self::cleanString('<script', '</script>', $html);
-        $html = self::cleanString('<style', '</style>', $html);
-        $html = self::cleanString('<!--', '-->', $html);
-
-        // This is only very rough approximation of HTML tag as described by
-        // https://www.w3.org/TR/2012/WD-html-markup-20120329/syntax.html#syntax-start-tags
-        // Ideally, we would use a HTML parser but even the streaming parsers I tried
-        // were several orders of magnitude slower than this mess.
-        if (preg_match_all('#<link\b[^>]*\srel=("|\'|)(?P<rel>apple-touch-icon|apple-touch-icon-precomposed|shortcut icon|icon)\1[^>]*>#iU', $html, $links, PREG_SET_ORDER) < 1) {
-            return [];
-        }
-
-        $icons = [];
-        $i = 0;
-        foreach ($links as $link) {
-            if (preg_match('#\shref=(?:("|\')(?P<url>.+)\1|(?P<uq_url>[^\s"\'=><`]+?))#iU', $link[0], $href)) {
-                $icons[] = [
-                    // Unmatched group should return an empty string but they are missing.
-                    // https://bugs.php.net/bug.php?id=50887
-                    'url' => isset($href['uq_url']) && $href['uq_url'] !== '' ? $href['uq_url'] : $href['url'],
-                    // Sizes are only used by Apple.
-                    // https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html
-                    'sizes' => preg_match('#\ssizes=("|\'|)(?P<sizes>[0-9\.]+)x\2\1#i', $link[0], $sizes)
-                        ? $sizes['sizes']
-                        : 0,
-                    'rel' => $link['rel'],
-                    'order' => $i++,
-                ];
-            }
-        }
-        if (count($icons) === 0) {
-            return $icons;
-        }
-
-        usort($icons, Misc::compareBy(
-            // largest icons first
-            [function($val) {
-                return (int) $val['sizes'];
-            }, Misc::ORDER_DESC],
-
-            // then by rel priority
-            [function($val) {
-                return self::$iconRelWeights[$val['rel']];
-            }, Misc::ORDER_DESC],
-
-            // and finally by order to make the sorting stable
-            'order'
-        ));
-
-        return array_map(function($i) {
-            return $i['url'];
-        }, $icons);
-    }
-
-    /**
-     * taken from: http://zytzagoo.net/blog/2008/01/23/extracting-images-from-html-using-regular-expressions/
-     * Searches for the first occurence of an html <img> element in a string
-     * and extracts the src if it finds it. Returns null in case an <img>
-     * element is not found.
-     *
-     * @param string $html An HTML string
-     *
-     * @return ?string content of the src attribute of the first image
-     */
-    public static function findFirstImageSource($html) {
-        if (stripos($html, '<img') !== false) {
-            $imgsrc_regex = '#<\s*img [^\>]*src\s*=\s*(["\'])(.*?)\1#im';
-            preg_match($imgsrc_regex, $html, $matches);
-            unset($imgsrc_regex);
-            unset($html);
-            if (is_array($matches) && !empty($matches)) {
-                return $matches[2];
-            } else {
-                return null;
-            }
-        } else {
-            return null;
-        }
     }
 }

--- a/src/helpers/Image.php
+++ b/src/helpers/Image.php
@@ -167,7 +167,11 @@ class Image {
         }
 
         if ($imgInfo === null) {
-            $imgInfo = @getimagesizefromstring($data);
+            $imgInfo = getimagesizefromstring($data);
+            if ($imgInfo[0] === 0 || $imgInfo[1] === 0) {
+                // unable to determine dimensions
+                return null;
+            }
         }
 
         $mimeType = isset($imgInfo['mime']) ? strtolower($imgInfo['mime']) : null;

--- a/src/helpers/Image.php
+++ b/src/helpers/Image.php
@@ -16,8 +16,16 @@ use WideImage\WideImage;
  * @author     Tobias Zeising <tobias.zeising@aditu.de>
  */
 class Image {
+    const FORMAT_JPEG = 'jpeg';
+    const FORMAT_PNG = 'png';
+
     /** @var ?string url of last fetched favicon */
     private $faviconUrl = null;
+
+    private static $extensions = [
+        self::FORMAT_JPEG => 'jpg',
+        self::FORMAT_PNG => 'png',
+    ];
 
     private static $imageTypes = [
         // IANA assigned type
@@ -54,6 +62,17 @@ class Image {
     public function __construct(Logger $logger, WebClient $webClient) {
         $this->logger = $logger;
         $this->webClient = $webClient;
+    }
+
+    /**
+     * Get preferred extension for the format.
+     *
+     * @param self::FORMAT_* $format
+     *
+     * @return string
+     */
+    public static function getExtension($format) {
+        return self::$extensions[$format];
     }
 
     /**
@@ -123,16 +142,16 @@ class Image {
     }
 
     /**
-     * load image
+     * Load image from URL, optionally resize it and convert it to desired format.
      *
      * @param string $url source url
-     * @param string $extension file extension of output file
-     * @param ?int $width
-     * @param ?int $height
+     * @param self::FORMAT_JPEG|self::FORMAT_PNG $format file format of output file
+     * @param ?int $width target width
+     * @param ?int $height target height
      *
-     * @return ?string
+     * @return ?string blob containing the processed image
      */
-    public function loadImage($url, $extension = 'png', $width = null, $height = null) {
+    public function loadImage($url, $format = self::FORMAT_PNG, $width = null, $height = null) {
         // load image
         try {
             $data = $this->webClient->request($url);
@@ -176,7 +195,7 @@ class Image {
             }
 
             $image->resizeImage($width, $height, \Imagick::FILTER_LANCZOS, 1);
-            if ($extension === 'jpg') {
+            if ($format === self::FORMAT_JPEG) {
                 $image->setImageFormat('jpeg');
                 $image->setImageCompression(\Imagick::COMPRESSION_JPEG);
                 $image->setImageCompressionQuality(75);
@@ -237,7 +256,7 @@ class Image {
         }
 
         // return image as jpg or png
-        if ($extension === 'jpg') {
+        if ($format === self::FORMAT_JPEG) {
             $data = $wideImage->asString('jpg', 75);
         } else {
             $data = $wideImage->asString('png', 4, PNG_NO_FILTER);

--- a/src/helpers/Image.php
+++ b/src/helpers/Image.php
@@ -165,7 +165,7 @@ class Image {
                 $data = $d;
             }
 
-            if (preg_match('#<svg[\s>]#si', $data)) {
+            if (ImageUtils::detectSvg($data)) {
                 $imgInfo = ['mime' => 'image/svg+xml'];
             }
         }

--- a/src/helpers/ImageHolder.php
+++ b/src/helpers/ImageHolder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace helpers;
+
+/**
+ * Class holding image data and accompanying metadata.
+ */
+class ImageHolder {
+    /** @var string */
+    private $data;
+    /** @var Image::FORMAT_JPEG|Image::FORMAT_PNG */
+    private $format;
+    /** @var int */
+    private $width;
+    /** @var int */
+    private $height;
+
+    public function __construct($data, $format, $width, $height) {
+        $this->data = $data;
+        $this->format = $format;
+        $this->width = $width;
+        $this->height = $height;
+    }
+
+    public function getData() {
+        return $this->data;
+    }
+
+    public function getFormat() {
+        return $this->format;
+    }
+
+    public function getWidth() {
+        return $this->width;
+    }
+
+    public function getHeight() {
+        return $this->height;
+    }
+}

--- a/src/helpers/ImageUtils.php
+++ b/src/helpers/ImageUtils.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace helpers;
+
+/**
+ * Helper class for loading images
+ *
+ * @copyright  Copyright (c) Tobias Zeising (http://www.aditu.de)
+ * @license    GPLv3 (https://www.gnu.org/licenses/gpl-3.0.html)
+ * @author     Tobias Zeising <tobias.zeising@aditu.de>
+ */
+class ImageUtils {
+    private static $iconRelWeights = [
+        'apple-touch-icon-precomposed' => 3,
+        'apple-touch-icon' => 2,
+        'shortcut icon' => 1,
+        'icon' => 1,
+    ];
+
+    /**
+     * removes $startString, $endString and everything in between from $subject
+     *
+     * @param string $startString
+     * @param string $endString
+     * @param string $subject
+     *
+     * @return string
+     */
+    public static function cleanString($startString, $endString, $subject) {
+        while (false !== $p1 = stripos($subject, $startString)) {
+            $block = substr($subject, $p1);
+            $subject = substr($subject, 0, $p1);
+            if (false !== $p2 = stripos($block, $endString)) {
+                $subject .= substr($block, $p2 + strlen($endString));
+            }
+        }
+
+        return $subject;
+    }
+
+    /**
+     * parse shortcut icons from given html
+     * If icons are found, their URLs are returned in an array ordered by size
+     * if given or by likely size of not, with the biggest one first.
+     *
+     * @param string $html
+     *
+     * @return array
+     */
+    public static function parseShortcutIcons($html) {
+        $end = strripos($html, '</head>');
+        if ($end > 1) {
+            $html = substr($html, 0, $end);
+        }
+
+        // $html= preg_replace('/<!--.*-->/sU', '', preg_replace('#<(script|style)\b[^>]*>.*</\1>#sU', '', $html));
+        // should to the same, but doesn't always.
+        $html = self::cleanString('<script', '</script>', $html);
+        $html = self::cleanString('<style', '</style>', $html);
+        $html = self::cleanString('<!--', '-->', $html);
+
+        // This is only very rough approximation of HTML tag as described by
+        // https://www.w3.org/TR/2012/WD-html-markup-20120329/syntax.html#syntax-start-tags
+        // Ideally, we would use a HTML parser but even the streaming parsers I tried
+        // were several orders of magnitude slower than this mess.
+        if (preg_match_all('#<link\b[^>]*\srel=("|\'|)(?P<rel>apple-touch-icon|apple-touch-icon-precomposed|shortcut icon|icon)\1[^>]*>#iU', $html, $links, PREG_SET_ORDER) < 1) {
+            return [];
+        }
+
+        $icons = [];
+        $i = 0;
+        foreach ($links as $link) {
+            if (preg_match('#\shref=(?:("|\')(?P<url>.+)\1|(?P<uq_url>[^\s"\'=><`]+?))#iU', $link[0], $href)) {
+                $icons[] = [
+                    // Unmatched group should return an empty string but they are missing.
+                    // https://bugs.php.net/bug.php?id=50887
+                    'url' => isset($href['uq_url']) && $href['uq_url'] !== '' ? $href['uq_url'] : $href['url'],
+                    // Sizes are only used by Apple.
+                    // https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html
+                    'sizes' => preg_match('#\ssizes=("|\'|)(?P<sizes>[0-9\.]+)x\2\1#i', $link[0], $sizes)
+                        ? $sizes['sizes']
+                        : 0,
+                    'rel' => $link['rel'],
+                    'order' => $i++,
+                ];
+            }
+        }
+        if (count($icons) === 0) {
+            return $icons;
+        }
+
+        usort($icons, Misc::compareBy(
+            // largest icons first
+            [function($val) {
+                return (int) $val['sizes'];
+            }, Misc::ORDER_DESC],
+
+            // then by rel priority
+            [function($val) {
+                return self::$iconRelWeights[$val['rel']];
+            }, Misc::ORDER_DESC],
+
+            // and finally by order to make the sorting stable
+            'order'
+        ));
+
+        return array_map(function($i) {
+            return $i['url'];
+        }, $icons);
+    }
+
+    /**
+     * taken from: http://zytzagoo.net/blog/2008/01/23/extracting-images-from-html-using-regular-expressions/
+     * Searches for the first occurence of an html <img> element in a string
+     * and extracts the src if it finds it. Returns null in case an <img>
+     * element is not found.
+     *
+     * @param string $html An HTML string
+     *
+     * @return ?string content of the src attribute of the first image
+     */
+    public static function findFirstImageSource($html) {
+        if (stripos($html, '<img') !== false) {
+            $imgsrc_regex = '#<\s*img [^\>]*src\s*=\s*(["\'])(.*?)\1#im';
+            preg_match($imgsrc_regex, $html, $matches);
+            unset($imgsrc_regex);
+            unset($html);
+            if (is_array($matches) && !empty($matches)) {
+                return $matches[2];
+            } else {
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/helpers/ImageUtils.php
+++ b/src/helpers/ImageUtils.php
@@ -134,4 +134,15 @@ class ImageUtils {
             return null;
         }
     }
+
+    /**
+     * Detect if given data is an SVG file and not just a HTML document with SVG embedded.
+     *
+     * @param string $blob
+     *
+     * @return bool true when it is a SVG
+     */
+    public static function detectSvg($blob) {
+        return preg_match('#<svg[\s>]#si', $blob) && !preg_match('#<((!doctype )?html|body)[\s>]#si', $blob);
+    }
 }

--- a/src/helpers/Storage/FileStorage.php
+++ b/src/helpers/Storage/FileStorage.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace helpers\Storage;
+
+use Monolog\Logger;
+
+/**
+ * Simple file storage.
+ */
+class FileStorage {
+    /** @var Logger */
+    private $logger;
+
+    /** @var string Directory where the files will be stored */
+    private $directory;
+
+    /**
+     * @param string $directory
+     */
+    public function __construct(Logger $logger, $directory) {
+        $this->logger = $logger;
+        $this->directory = $directory;
+    }
+
+    /**
+     * Store given blob with type $extension as URL.
+     *
+     * @param string $url
+     * @param string $extension
+     * @param string $blob
+     *
+     * @return ?string
+     */
+    public function store($url, $extension, $blob) {
+        $filename = md5($url) . '.' . $extension;
+        $path = $this->directory . '/' . $filename;
+        $written = file_put_contents($path, $blob);
+
+        if ($written !== false) {
+            return $filename;
+        } else {
+            $this->logger->warning('Unable to store file: ' . $url . '. Please check permissions of ' . $this->directory);
+
+            return null;
+        }
+    }
+
+    /**
+     * Delete all files except for requested ones.
+     *
+     * @param callable(string):bool $shouldKeep
+     *
+     * @return ?string
+     */
+    public function cleanup($shouldKeep) {
+        $itemPath = $this->directory . '/';
+        foreach (scandir($itemPath) as $file) {
+            if (is_file($itemPath . $file) && $file !== '.htaccess') {
+                if (!$shouldKeep($file)) {
+                    unlink($itemPath . $file);
+                }
+            }
+        }
+    }
+}

--- a/src/helpers/ThumbnailStore.php
+++ b/src/helpers/ThumbnailStore.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace helpers;
+
+use helpers\Storage\FileStorage;
+use Monolog\Logger;
+
+/**
+ * Thumbnail storage.
+ */
+class ThumbnailStore {
+    /** @var Logger */
+    private $logger;
+
+    /** @var FileStorage */
+    private $storage;
+
+    public function __construct(Logger $logger, FileStorage $storage) {
+        $this->storage = $storage;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Store given blob as URL.
+     *
+     * @param string $url
+     * @param string $blob
+     *
+     * @return ?string
+     */
+    public function store($url, $blob) {
+        $extension = Image::getExtension(ContentLoader::THUMBNAIL_FORMAT);
+        $this->logger->debug('Storing thumbnail: ' . $url);
+
+        return $this->storage->store($url, $extension, $blob);
+    }
+
+    /**
+     * Delete all icons except for requested ones.
+     *
+     * @param callable(string):bool $shouldKeep
+     *
+     * @return void
+     */
+    public function cleanup($shouldKeep) {
+        $this->storage->cleanup($shouldKeep);
+    }
+}

--- a/src/spouts/reddit/reddit2.php
+++ b/src/spouts/reddit/reddit2.php
@@ -158,8 +158,8 @@ class reddit2 extends \spouts\spout {
 
     public function getIcon() {
         $htmlUrl = $this->getHtmlUrl();
-        if ($htmlUrl && $this->imageHelper->fetchFavicon($htmlUrl)) {
-            $this->faviconUrl = $this->imageHelper->getFaviconUrl();
+        if ($htmlUrl && ($iconData = $this->imageHelper->fetchFavicon($htmlUrl)) !== null) {
+            list($this->faviconUrl, $iconBlob) = $iconData;
         }
 
         return $this->faviconUrl;

--- a/src/spouts/reddit/reddit2.php
+++ b/src/spouts/reddit/reddit2.php
@@ -54,9 +54,6 @@ class reddit2 extends \spouts\spout {
     /** @var string the reddit_session cookie */
     private $reddit_session = '';
 
-    /** @var string favicon url */
-    private $faviconUrl = '';
-
     /** @var Image image helper */
     private $imageHelper;
 
@@ -159,10 +156,10 @@ class reddit2 extends \spouts\spout {
     public function getIcon() {
         $htmlUrl = $this->getHtmlUrl();
         if ($htmlUrl && ($iconData = $this->imageHelper->fetchFavicon($htmlUrl)) !== null) {
-            list($this->faviconUrl, $iconBlob) = $iconData;
+            list($faviconUrl, $iconBlob) = $iconData;
         }
 
-        return $this->faviconUrl;
+        return $faviconUrl;
     }
 
     public function getLink() {

--- a/src/spouts/reddit/reddit2.php
+++ b/src/spouts/reddit/reddit2.php
@@ -89,7 +89,9 @@ class reddit2 extends \spouts\spout {
             throw new \Exception($json['message']);
         }
 
-        $this->items = $json['data']['children'];
+        if (isset($json['data']) && isset($json['data']['children'])) {
+            $this->items = $json['data']['children'];
+        }
     }
 
     public function getId() {

--- a/src/spouts/rss/feed.php
+++ b/src/spouts/rss/feed.php
@@ -36,9 +36,6 @@ class feed extends \spouts\spout {
     /** @var ?string URL of the source */
     protected $htmlUrl = null;
 
-    /** @var ?string URL of the favicon */
-    protected $faviconUrl = null;
-
     /** @var Logger */
     private $logger;
 
@@ -103,35 +100,35 @@ class feed extends \spouts\spout {
     }
 
     public function getIcon() {
-        if ($this->faviconUrl !== null) {
-            return $this->faviconUrl;
-        }
+        return null;
+    }
 
+    public function getSourceIcon() {
         // Try to use feed logo first
         $feedLogoUrl = $this->feed->getImageUrl();
         if ($feedLogoUrl && ($iconData = $this->imageHelper->fetchFavicon($feedLogoUrl)) !== null) {
-            list($this->faviconUrl, $iconBlob) = $iconData;
-            $this->logger->debug('icon: using feed logo: ' . $this->faviconUrl);
+            list($faviconUrl, $iconBlob) = $iconData;
+            $this->logger->debug('icon: using feed logo: ' . $faviconUrl);
 
-            return $this->faviconUrl;
+            return $faviconUrl;
         }
 
         // else fallback to the favicon of the associated web page
         $htmlUrl = $this->getHtmlUrl();
         if ($htmlUrl && ($iconData = $this->imageHelper->fetchFavicon($htmlUrl, true)) !== null) {
-            list($this->faviconUrl, $iconBlob) = $iconData;
-            $this->logger->debug('icon: using feed homepage favicon: ' . $this->faviconUrl);
+            list($faviconUrl, $iconBlob) = $iconData;
+            $this->logger->debug('icon: using feed homepage favicon: ' . $faviconUrl);
 
-            return $this->faviconUrl;
+            return $faviconUrl;
         }
 
         // else fallback to the favicon of the feed effective domain
         $feedUrl = $this->feed->getFeedUrl();
         if ($feedUrl && ($iconData = $this->imageHelper->fetchFavicon($feedUrl, true)) !== null) {
-            list($this->faviconUrl, $iconBlob) = $iconData;
-            $this->logger->debug('icon: using feed homepage favicon: ' . $this->faviconUrl);
+            list($faviconUrl, $iconBlob) = $iconData;
+            $this->logger->debug('icon: using feed homepage favicon: ' . $faviconUrl);
 
-            return $this->faviconUrl;
+            return $faviconUrl;
         }
 
         return null;

--- a/src/spouts/rss/feed.php
+++ b/src/spouts/rss/feed.php
@@ -109,8 +109,8 @@ class feed extends \spouts\spout {
 
         // Try to use feed logo first
         $feedLogoUrl = $this->feed->getImageUrl();
-        if ($feedLogoUrl && $this->imageHelper->fetchFavicon($feedLogoUrl)) {
-            $this->faviconUrl = $this->imageHelper->getFaviconUrl();
+        if ($feedLogoUrl && ($iconData = $this->imageHelper->fetchFavicon($feedLogoUrl)) !== null) {
+            list($this->faviconUrl, $iconBlob) = $iconData;
             $this->logger->debug('icon: using feed logo: ' . $this->faviconUrl);
 
             return $this->faviconUrl;
@@ -118,8 +118,8 @@ class feed extends \spouts\spout {
 
         // else fallback to the favicon of the associated web page
         $htmlUrl = $this->getHtmlUrl();
-        if ($htmlUrl && $this->imageHelper->fetchFavicon($htmlUrl, true)) {
-            $this->faviconUrl = $this->imageHelper->getFaviconUrl();
+        if ($htmlUrl && ($iconData = $this->imageHelper->fetchFavicon($htmlUrl, true)) !== null) {
+            list($this->faviconUrl, $iconBlob) = $iconData;
             $this->logger->debug('icon: using feed homepage favicon: ' . $this->faviconUrl);
 
             return $this->faviconUrl;
@@ -127,8 +127,8 @@ class feed extends \spouts\spout {
 
         // else fallback to the favicon of the feed effective domain
         $feedUrl = $this->feed->getFeedUrl();
-        if ($feedUrl && $this->imageHelper->fetchFavicon($feedUrl, true)) {
-            $this->faviconUrl = $this->imageHelper->getFaviconUrl();
+        if ($feedUrl && ($iconData = $this->imageHelper->fetchFavicon($feedUrl, true)) !== null) {
+            list($this->faviconUrl, $iconBlob) = $iconData;
             $this->logger->debug('icon: using feed homepage favicon: ' . $this->faviconUrl);
 
             return $this->faviconUrl;

--- a/src/spouts/rss/feed.php
+++ b/src/spouts/rss/feed.php
@@ -108,9 +108,16 @@ class feed extends \spouts\spout {
         $feedLogoUrl = $this->feed->getImageUrl();
         if ($feedLogoUrl && ($iconData = $this->imageHelper->fetchFavicon($feedLogoUrl)) !== null) {
             list($faviconUrl, $iconBlob) = $iconData;
-            $this->logger->debug('icon: using feed logo: ' . $faviconUrl);
 
-            return $faviconUrl;
+            $aspectRatio = $iconBlob->getWidth() / $iconBlob->getHeight();
+
+            if (0.8 < $aspectRatio && $aspectRatio < 1.3) {
+                $this->logger->debug('icon: using feed logo: ' . $faviconUrl);
+
+                return $faviconUrl;
+            } else {
+                $this->logger->debug('icon: feed logo “' . $faviconUrl . '” not square enough with aspect ratio ' . $aspectRatio . '. Not using it.');
+            }
         }
 
         // else fallback to the favicon of the associated web page

--- a/src/spouts/rss/images.php
+++ b/src/spouts/rss/images.php
@@ -35,7 +35,7 @@ class images extends feed {
                 return @$item->get_enclosure(0)->get_link();
             }
         } else { // no enclosures: search image link in content
-            $image = \helpers\Image::findFirstImageSource(@$item->get_content());
+            $image = \helpers\ImageUtils::findFirstImageSource(@$item->get_content());
             if ($image !== null) {
                 return $image;
             }

--- a/src/spouts/spout.php
+++ b/src/spouts/spout.php
@@ -86,6 +86,15 @@ abstract class spout implements \Iterator {
     }
 
     /**
+     * Returns the icon common to this source.
+     *
+     * @return ?string icon as URL
+     */
+    public function getSourceIcon() {
+        return null;
+    }
+
+    /**
      * returns an unique id for this item
      *
      * @return string id as hash
@@ -122,11 +131,13 @@ abstract class spout implements \Iterator {
     }
 
     /**
-     * returns the icon of this item
+     * Returns the icon of this item.
      *
-     * @return string icon as url
+     * @return ?string icon as url
      */
-    abstract public function getIcon();
+    public function getIcon() {
+        return null;
+    }
 
     /**
      * returns the link of this item

--- a/src/spouts/youtube/youtube.php
+++ b/src/spouts/youtube/youtube.php
@@ -72,7 +72,7 @@ class youtube extends \spouts\rss\feed {
                 return @$item->get_enclosure(0)->get_link();
             }
         } else { // no enclosures: search image link in content
-            $image = \helpers\Image::findFirstImageSource(@$item->get_content());
+            $image = \helpers\ImageUtils::findFirstImageSource(@$item->get_content());
             if ($image !== null) {
                 return $image;
             }

--- a/tests/Helpers/DetectSvgTest.php
+++ b/tests/Helpers/DetectSvgTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Helpers;
+
+use helpers\ImageUtils;
+use PHPUnit\Framework\TestCase;
+
+final class DetectSvgTest extends TestCase {
+    /**
+     * Detects a basic SVG file correctly.
+     */
+    public function testBasic() {
+        $blob = <<<EOD
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300"><rect fill="%2395c9c5" width="100%" height="100%"/></svg>
+EOD;
+
+        $this->assertTrue(
+            ImageUtils::detectSvg($blob)
+        );
+    }
+
+    /**
+     * Detects a SVG file with XML directives correctly.
+     */
+    public function testDirectives() {
+        $blob = <<<EOD
+<?xml version="1.0"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+ "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300"><rect fill="%2395c9c5" width="100%" height="100%"/></svg>
+EOD;
+
+        $this->assertTrue(
+            ImageUtils::detectSvg($blob)
+        );
+    }
+
+    /**
+     * Detects a SVG embedded in HTML file correctly.
+     */
+    public function testInHtml() {
+        $blob = <<<EOD
+<html>
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300"><rect fill="%2395c9c5" width="100%" height="100%"/></svg>
+EOD;
+
+        $this->assertFalse(
+            ImageUtils::detectSvg($blob)
+        );
+    }
+
+    /**
+     * Detects a SVG embedded in HTML file with a doctype correctly.
+     */
+    public function testInHtmlWithDoctype() {
+        $blob = <<<EOD
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "//www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html class="article-page"><head><title>Foo</title></head><svg xmlns="http://www.w3.org/2000/svg" width="400" height="300"><rect fill="%2395c9c5" width="100%" height="100%"/></svg>
+EOD;
+
+        $this->assertFalse(
+            ImageUtils::detectSvg($blob)
+        );
+    }
+
+    /**
+     * Detects a SVG embedded in HTML file with just a body correctly.
+     */
+    public function testInHtmlWithBody() {
+        $blob = <<<EOD
+<body><svg xmlns="http://www.w3.org/2000/svg" width="400" height="300"><rect fill="%2395c9c5" width="100%" height="100%"/></svg>
+EOD;
+
+        $this->assertFalse(
+            ImageUtils::detectSvg($blob)
+        );
+    }
+}

--- a/tests/Helpers/IconExtractorTest.php
+++ b/tests/Helpers/IconExtractorTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Helpers;
 
-use helpers\Image;
+use helpers\ImageUtils;
 use PHPUnit\Framework\TestCase;
 
 final class IconExtractorTest extends TestCase {
@@ -24,7 +24,7 @@ EOD;
             [
                 'https://www.example.com/images/apple-touch-114x114.png',
             ],
-            Image::parseShortcutIcons($page)
+            ImageUtils::parseShortcutIcons($page)
         );
     }
 
@@ -46,7 +46,7 @@ EOD;
             [
                 'https://www.example.com/images/apple-touch-precomposed-114x114.png',
             ],
-            Image::parseShortcutIcons($page)
+            ImageUtils::parseShortcutIcons($page)
         );
     }
 
@@ -68,7 +68,7 @@ EOD;
             [
                 'https://www.example.com/images/apple-touch-114x114.png',
             ],
-            Image::parseShortcutIcons($page)
+            ImageUtils::parseShortcutIcons($page)
         );
     }
 
@@ -90,7 +90,7 @@ EOD;
             [
                 'https://www.example.com/favicon.ico',
             ],
-            Image::parseShortcutIcons($page)
+            ImageUtils::parseShortcutIcons($page)
         );
     }
 
@@ -112,7 +112,7 @@ EOD;
             [
                 'https://www.example.com/favicon.ico',
             ],
-            Image::parseShortcutIcons($page)
+            ImageUtils::parseShortcutIcons($page)
         );
     }
 
@@ -138,7 +138,7 @@ EOD;
                 '/favicon.ico',
                 '/favicon.svg',
             ],
-            Image::parseShortcutIcons($page)
+            ImageUtils::parseShortcutIcons($page)
         );
     }
 
@@ -162,7 +162,7 @@ EOD;
                 'https://www.example.com/images/apple-touch-114x114.png',
                 '/favicon.ico',
             ],
-            Image::parseShortcutIcons($page)
+            ImageUtils::parseShortcutIcons($page)
         );
     }
 
@@ -186,7 +186,7 @@ EOD;
                 'https://www.example.com/images/apple-touch-114x114.png',
                 'https://www.example.com/images/apple-touch-precomposed-87x87.png',
             ],
-            Image::parseShortcutIcons($page)
+            ImageUtils::parseShortcutIcons($page)
         );
     }
 
@@ -210,7 +210,7 @@ EOD;
                 'https://www.example.com/images/apple-touch-precomposed-114x114.png',
                 'https://www.example.com/images/apple-touch-114x114.png',
             ],
-            Image::parseShortcutIcons($page)
+            ImageUtils::parseShortcutIcons($page)
         );
     }
 
@@ -228,7 +228,7 @@ EOD;
                 '//www.example.com/favicons/apple-touch-icon-152x152.png',
                 '//www.example.com/favicons/favicon.ico',
             ],
-            Image::parseShortcutIcons($page)
+            ImageUtils::parseShortcutIcons($page)
         );
     }
 
@@ -247,7 +247,7 @@ EOD;
 
         $this->assertEquals(
             [],
-            Image::parseShortcutIcons($page)
+            ImageUtils::parseShortcutIcons($page)
         );
     }
 
@@ -267,7 +267,7 @@ EOD;
 
         $this->assertEquals(
             [],
-            Image::parseShortcutIcons($page)
+            ImageUtils::parseShortcutIcons($page)
         );
     }
 
@@ -289,7 +289,7 @@ EOD;
 
         $this->assertEquals(
             [],
-            Image::parseShortcutIcons($page)
+            ImageUtils::parseShortcutIcons($page)
         );
     }
 }


### PR DESCRIPTION
Avoid repeating requests and clean up the old spaghetti.

### Customization changes

To allow distinguishing between an icon coming from the feed item and one from the feed itself, we added a new optional `getSourceIcon()` method. When the `getIcon()` method returns `null` for an item or the item icon cannot be fetched, the source icon will be used as a fallback.

Both `getSourceIcon()` and `getIcon()` can return `null` now when an icon is not available.
