### PR TITLE
common: Do not crash on PHP startup error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -78,6 +78,7 @@
 - RSS spout now prefers the feed logo to website favicon. ([#1152](https://github.com/SSilence/selfoss/pull/1152))
 - RSS spout now tries to use favicon from the feed domain when there is no logo or home page favicon. ([#1152](https://github.com/SSilence/selfoss/pull/1152))
 - Setting `DEBUG` to `1` in `src/common.php` no longer logs HTTP bodies, only headers. Set it to `2` if you need the bodies as well. ([#1152](https://github.com/SSilence/selfoss/pull/1152))
+- PHP startup errors are now logged, instead of having F3 crash with Error 500 ([#1195](https://github.com/SSilence/selfoss/pull/1195))
 
 
 ## 2.18 – 2018-03-05

--- a/src/common.php
+++ b/src/common.php
@@ -15,6 +15,14 @@ if ($autoloader === false) {
     exit;
 }
 
+$startup_error = error_get_last();
+
+// F3 crashes when there were PHP startups error even though
+// they might not affect the program (e.g. unable to load an extension).
+// It also sets its own error_reporting value and uses the previous one
+// as a signal to disable the initialization failure check.
+error_reporting(0);
+
 $f3 = Base::instance();
 
 $f3->set('DEBUG', 0);
@@ -185,6 +193,10 @@ if ($f3->get('logger_level') === 'NONE') {
     $handler->setFormatter($formatter);
 }
 $log->pushHandler($handler);
+
+if (isset($startup_error)) {
+    $log->warn('PHP likely encountered a startup error: ', [$startup_error]);
+}
 
 // init error handling
 $f3->set('ONERROR',


### PR DESCRIPTION
F3 crashes when there were PHP startups error even though they might not affect the program (e.g. unable to load an extension). It also sets its own error_reporting value and uses the previous one as a signal to disable the initialization failure check.

Let's use that to avoid the crash and log the error ourselves.

Fixes: https://github.com/SSilence/selfoss/issues/1192