### PR TITLE
helpers\ImageLazifier: set placeholder src

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1211,6 +1211,7 @@ body:not(.loggedin) .entry-unread {
         border-radius: 0;
         font-size: 0.8em;
         border-top: 1px solid #cccccc;
+        box-sizing: border-box;
     }
 
     .entry-author,

--- a/assets/js/lazy-image-loader.js
+++ b/assets/js/lazy-image-loader.js
@@ -6,7 +6,7 @@ import jQuery from 'jquery';
 (function($) {
     $.fn.lazyLoadImages = function() {
         $(this).find('img').each(function(i, self) {
-            $(self).attr('src', $(self).attr('ref'));
+            $(self).attr('src', $(self).attr('data-selfoss-src'));
         });
     };
 })(jQuery);

--- a/src/helpers/ViewHelper.php
+++ b/src/helpers/ViewHelper.php
@@ -36,7 +36,7 @@ class ViewHelper {
     }
 
     /**
-     * removes img src attribute and saves the value in ref for
+     * removes img src attribute and saves the value in data attribute for
      * loading it later
      *
      * @param string $content which contains img tags
@@ -68,7 +68,7 @@ class ViewHelper {
 
             $placeholder = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='$width' height='$height'><rect fill='%2395c9c5' width='100%' height='100%'/></svg>";
 
-            return "<img src=\"$placeholder\"{$matches['pre']}ref=\"{$matches['src']}\"{$matches['post']}>";
+            return "<img src=\"$placeholder\"{$matches['pre']}data-selfoss-src=\"{$matches['src']}\"{$matches['post']}>";
         }, $content);
     }
 

--- a/src/helpers/ViewHelper.php
+++ b/src/helpers/ViewHelper.php
@@ -19,7 +19,7 @@ class ViewHelper {
      *
      * @return string with highlited words
      */
-    public function highlight($content, $searchWords) {
+    public static function highlight($content, $searchWords) {
         if (strlen(trim($searchWords)) === 0) {
             return $content;
         }
@@ -43,7 +43,7 @@ class ViewHelper {
      *
      * @return string with replaced img tags
      */
-    public function lazyimg($content) {
+    public static function lazyimg($content) {
         return preg_replace("/<img([^<]+)src=(['\"])([^\"']*)(['\"])([^<]*)>/i", "<img$1ref='$3'$5>", $content);
     }
 
@@ -67,7 +67,7 @@ class ViewHelper {
      *
      * @return string          item content
      */
-    public function camoflauge($content) {
+    public static function camoflauge($content) {
         if (empty($content)) {
             return $content;
         }

--- a/src/templates/item.phtml
+++ b/src/templates/item.phtml
@@ -1,26 +1,29 @@
 <?php
+
+    use helpers\ViewHelper;
+
     $title = $this->item['title'];
     $author = $this->item['author'];
     //$content = html_entity_decode($this->item['content']);
     $content = str_replace('&#34;', '"', $this->item['content']);
     $sourcetitle = $this->item['sourcetitle'];
-    $this->viewHelper = new \helpers\ViewHelper();
+
     if (isset($this->search)) {
-        $sourcetitle = $this->viewHelper->highlight($sourcetitle, $this->search);
-        $title = $this->viewHelper->highlight($title, $this->search);
-        $content = $this->viewHelper->highlight($content, $this->search);
+        $sourcetitle = ViewHelper::highlight($sourcetitle, $this->search);
+        $title = ViewHelper::highlight($title, $this->search);
+        $content = ViewHelper::highlight($content, $this->search);
     }
 
     if (\F3::get('camo_key') != '') {
-        $content = $this->viewHelper->camoflauge($content);
+        $content = ViewHelper::camoflauge($content);
     }
 
-    $title = $this->viewHelper->lazyimg($title);
-    $content = $this->viewHelper->lazyimg($content);
+    $title = ViewHelper::lazyimg($title);
+    $content = ViewHelper::lazyimg($content);
 ?>
 <div data-entry-id="<?= $this->item['id']; ?>"
      data-entry-source="<?= $this->item['source']; ?>"
-     data-entry-datetime="<?= $this->viewHelper->date_iso8601($this->item['datetime']); ?>"
+     data-entry-datetime="<?= ViewHelper::date_iso8601($this->item['datetime']); ?>"
      data-entry-url="<?= $this->item['link']; ?>"
      class="entry <?= $this->item['unread'] == 1 ? 'unread' : ''; ?>" role="article">
 

--- a/tests/Helpers/ImageLazifierTest.php
+++ b/tests/Helpers/ImageLazifierTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Helpers;
+
+use helpers\ViewHelper;
+use PHPUnit\Framework\TestCase;
+
+final class ImageLazifierTest extends TestCase {
+    /**
+     * Check that src attribute is renamed, other attributes are preserved and a properly-sized placeholder is chosen.
+     */
+    public function testBasic() {
+        $input = <<<EOD
+<img foo bar src="https://example.org/example.jpg" alt="" width="900" height="400">
+EOD;
+        $expected = <<<EOD
+<img src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='900' height='400'><rect fill='%2395c9c5' width='100%' height='100%'/></svg>" foo bar ref="https://example.org/example.jpg" alt="" width="900" height="400">
+EOD;
+
+        $this->assertEquals(
+            $expected,
+            ViewHelper::lazyimg($input)
+        );
+    }
+
+    /**
+     * Check that width for the placeholder is calculated from height.
+     */
+    public function testWidthMissing() {
+        $input = <<<EOD
+<img src="https://example.org/example.jpg" height="300">
+EOD;
+        $expected = <<<EOD
+<img src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='300'><rect fill='%2395c9c5' width='100%' height='100%'/></svg>" ref="https://example.org/example.jpg" height="300">
+EOD;
+
+        $this->assertEquals(
+            $expected,
+            ViewHelper::lazyimg($input)
+        );
+    }
+
+    /**
+     * Check that height for the placeholder is calculated from width.
+     */
+    public function testHeightMissing() {
+        $input = <<<EOD
+<img src="https://example.org/example.jpg" width="400">
+EOD;
+        $expected = <<<EOD
+<img src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='300'><rect fill='%2395c9c5' width='100%' height='100%'/></svg>" ref="https://example.org/example.jpg" width="400">
+EOD;
+
+        $this->assertEquals(
+            $expected,
+            ViewHelper::lazyimg($input)
+        );
+    }
+
+    /**
+     * Check that placeholder dimensions are chosen even when the image does not specify any.
+     */
+    public function testDimensionsMissing() {
+        $input = <<<EOD
+<img src="https://example.org/example.jpg">
+EOD;
+        $expected = <<<EOD
+<img src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='800' height='600'><rect fill='%2395c9c5' width='100%' height='100%'/></svg>" ref="https://example.org/example.jpg">
+EOD;
+
+        $this->assertEquals(
+            $expected,
+            ViewHelper::lazyimg($input)
+        );
+    }
+}

--- a/tests/Helpers/ImageLazifierTest.php
+++ b/tests/Helpers/ImageLazifierTest.php
@@ -14,7 +14,7 @@ final class ImageLazifierTest extends TestCase {
 <img foo bar src="https://example.org/example.jpg" alt="" width="900" height="400">
 EOD;
         $expected = <<<EOD
-<img src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='900' height='400'><rect fill='%2395c9c5' width='100%' height='100%'/></svg>" foo bar ref="https://example.org/example.jpg" alt="" width="900" height="400">
+<img src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='900' height='400'><rect fill='%2395c9c5' width='100%' height='100%'/></svg>" foo bar data-selfoss-src="https://example.org/example.jpg" alt="" width="900" height="400">
 EOD;
 
         $this->assertEquals(
@@ -31,7 +31,7 @@ EOD;
 <img src="https://example.org/example.jpg" height="300">
 EOD;
         $expected = <<<EOD
-<img src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='300'><rect fill='%2395c9c5' width='100%' height='100%'/></svg>" ref="https://example.org/example.jpg" height="300">
+<img src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='300'><rect fill='%2395c9c5' width='100%' height='100%'/></svg>" data-selfoss-src="https://example.org/example.jpg" height="300">
 EOD;
 
         $this->assertEquals(
@@ -48,7 +48,7 @@ EOD;
 <img src="https://example.org/example.jpg" width="400">
 EOD;
         $expected = <<<EOD
-<img src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='300'><rect fill='%2395c9c5' width='100%' height='100%'/></svg>" ref="https://example.org/example.jpg" width="400">
+<img src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='300'><rect fill='%2395c9c5' width='100%' height='100%'/></svg>" data-selfoss-src="https://example.org/example.jpg" width="400">
 EOD;
 
         $this->assertEquals(
@@ -65,7 +65,7 @@ EOD;
 <img src="https://example.org/example.jpg">
 EOD;
         $expected = <<<EOD
-<img src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='800' height='600'><rect fill='%2395c9c5' width='100%' height='100%'/></svg>" ref="https://example.org/example.jpg">
+<img src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='800' height='600'><rect fill='%2395c9c5' width='100%' height='100%'/></svg>" data-selfoss-src="https://example.org/example.jpg">
 EOD;
 
         $this->assertEquals(


### PR DESCRIPTION
With lazy loading of images enabled, `img` tags did not have a `src` attribute, causing the browsers to render them as zero-height boxes. This made it impossible to determine the precise height of the article content, leading to articles sometimes being rendered in column view, even though they would not fit a single screen with images loaded.

In Firefox, it is possible to use broken non-image (e.g. about:blank page) and it will render a rectangle respecting the width and height ratio, there must be no alt attribute, though. And Chromium will not respect the aspect ratio either.

https://jsfiddle.net/jtojnar/yrdskx0n/5/

It is also possible to use a real image (e.g. 1×1 px dot) but then the `height: auto` in CSS causes the images to respect the size of the placeholder, not the specified dimensions. For that reason we need to use a placeholder of the same dimensions as the original image.

This will not help for images that do not specify dimensions but then again, we cannot know their dimension until they are loaded anyway, so let’s just fall back to 800×600 as a guess.

Closes: https://github.com/SSilence/selfoss/issues/1203