### PR TITLE
spouts\twitter: Add search

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - “Copy to clipboard” share button was added, you can enable it with `c`. ([#1142](https://github.com/SSilence/selfoss/pull/1142))
 - [Native sharer](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share) is available in secure contexts in browsers that support it. You can enable it by adding `a` to `share` key in your config. ([#1035](https://github.com/SSilence/selfoss/pull/1035))
 - Data directory can be configured ([#1043](https://github.com/SSilence/selfoss/pull/1043))
+- New spout for searching Twitter (e.g. following hashtags) was added. ([#1213](https://github.com/SSilence/selfoss/pull/1213))
 
 ### Bug fixes
 - Reddit spout allows wider range of URLs, including absolute URLs and searches ([#1033](https://github.com/SSilence/selfoss/pull/1033))

--- a/src/spouts/twitter/Search.php
+++ b/src/spouts/twitter/Search.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace spouts\twitter;
+
+/**
+ * Spout for fetching a Twitter search
+ *
+ * @author Jan Tojnar <jtojnar@gmail.com>
+ * @copyright Jan Tojnar <jtojnar@gmail.com>
+ * @license GPL-3.0-or-later
+ */
+class Search extends \spouts\twitter\usertimeline {
+    /** @var string name of source */
+    public $name = 'Twitter: search';
+
+    /** @var string description of this source type */
+    public $description = 'Fetch the search results for given query.';
+
+    /** @var array configurable parameters */
+    public $params = [
+        'consumer_key' => [
+            'title' => 'Consumer Key',
+            'type' => 'text',
+            'default' => '',
+            'required' => true,
+            'validation' => ['notempty']
+        ],
+        'consumer_secret' => [
+            'title' => 'Consumer Secret',
+            'type' => 'password',
+            'default' => '',
+            'required' => true,
+            'validation' => ['notempty']
+        ],
+        'access_token' => [
+            'title' => 'Access Token (optional)',
+            'type' => 'text',
+            'default' => '',
+            'required' => false,
+            'validation' => []
+        ],
+        'access_token_secret' => [
+            'title' => 'Access Token Secret (optional)',
+            'type' => 'password',
+            'default' => '',
+            'required' => false,
+            'validation' => []
+        ],
+        'query' => [
+            'title' => 'Search query',
+            'type' => 'text',
+            'default' => '',
+            'required' => true,
+            'validation' => ['notempty']
+        ],
+    ];
+
+    public function load(array $params) {
+        $this->client = $this->getHttpClient($params['consumer_key'], $params['consumer_secret'], $params['access_token'], $params['access_token_secret']);
+
+        $this->items = $this->fetchTwitterTimeline('search/tweets', [
+            'q' => $params['query'],
+            'result_type' => 'recent',
+        ]);
+
+        $this->htmlUrl = 'https://twitter.com/search?q=' . urlencode($params['query']);
+
+        $this->spoutTitle = "Search twitter for {$params['query']}";
+    }
+}

--- a/src/spouts/twitter/listtimeline.php
+++ b/src/spouts/twitter/listtimeline.php
@@ -10,54 +10,52 @@ namespace spouts\twitter;
  * @author     Nicola Malizia <unnikked@gmail.com>
  */
 class listtimeline extends \spouts\twitter\usertimeline {
-    public function __construct() {
-        $this->name = 'Twitter: list timeline';
-        $this->description = 'Fetch the timeline of a given list.';
-        $this->params = [
-            'consumer_key' => [
-                'title' => 'Consumer Key',
-                'type' => 'text',
-                'default' => '',
-                'required' => true,
-                'validation' => ['notempty']
-            ],
-            'consumer_secret' => [
-                'title' => 'Consumer Secret',
-                'type' => 'password',
-                'default' => '',
-                'required' => true,
-                'validation' => ['notempty']
-            ],
-            'access_token' => [
-                'title' => 'Access Token (optional)',
-                'type' => 'text',
-                'default' => '',
-                'required' => false,
-                'validation' => []
-            ],
-            'access_token_secret' => [
-                'title' => 'Access Token Secret (optional)',
-                'type' => 'password',
-                'default' => '',
-                'required' => false,
-                'validation' => []
-            ],
-            'slug' => [
-                'title' => 'List Slug',
-                'type' => 'text',
-                'default' => '',
-                'required' => true,
-                'validation' => ['notempty']
-            ],
-            'owner_screen_name' => [
-                'title' => 'Username',
-                'type' => 'text',
-                'default' => '',
-                'required' => true,
-                'validation' => ['notempty']
-            ]
-        ];
-    }
+    public $name = 'Twitter: list timeline';
+    public $description = 'Fetch the timeline of a given list.';
+    public $params = [
+        'consumer_key' => [
+            'title' => 'Consumer Key',
+            'type' => 'text',
+            'default' => '',
+            'required' => true,
+            'validation' => ['notempty']
+        ],
+        'consumer_secret' => [
+            'title' => 'Consumer Secret',
+            'type' => 'password',
+            'default' => '',
+            'required' => true,
+            'validation' => ['notempty']
+        ],
+        'access_token' => [
+            'title' => 'Access Token (optional)',
+            'type' => 'text',
+            'default' => '',
+            'required' => false,
+            'validation' => []
+        ],
+        'access_token_secret' => [
+            'title' => 'Access Token Secret (optional)',
+            'type' => 'password',
+            'default' => '',
+            'required' => false,
+            'validation' => []
+        ],
+        'slug' => [
+            'title' => 'List Slug',
+            'type' => 'text',
+            'default' => '',
+            'required' => true,
+            'validation' => ['notempty']
+        ],
+        'owner_screen_name' => [
+            'title' => 'Username',
+            'type' => 'text',
+            'default' => '',
+            'required' => true,
+            'validation' => ['notempty']
+        ]
+    ];
 
     public function load(array $params) {
         $this->client = $this->getHttpClient($params['consumer_key'], $params['consumer_secret'], $params['access_token'], $params['access_token_secret']);

--- a/src/spouts/twitter/usertimeline.php
+++ b/src/spouts/twitter/usertimeline.php
@@ -135,6 +135,10 @@ class usertimeline extends \spouts\spout {
 
             $timeline = json_decode((string) $response->getBody());
 
+            if (isset($timeline->statuses)) {
+                $timeline = $timeline->statuses;
+            }
+
             if (!is_array($timeline)) {
                 throw new \Exception('Invalid twitter response');
             }


### PR DESCRIPTION
This will allow following hashtags. 

See the Twitter docs for info about query:

https://developer.twitter.com/en/docs/tweets/search/guides/standard-operators

Closes: #1211 

----

WIP since:

- It only fetches the latest page, which might not be enough when there are many tweets in a short span of time. We would need to handle pagination.
- NEWS entry and docs need to be updated.
- I do not really like adding more core spouts but am not sure how to fix this.