### PR TITLE
feat(docker): add basic docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,50 @@
+documentation
+.dockerignore
+Dockerfile
+.git
+.git*
+*.md
+
+# compiled output
+/dist
+/tmp
+/out-tsc
+# Only exists if Bazel was run
+/bazel-out
+
+# dependencies
+/node_modules
+
+# profiling files
+chrome-profiler-events.json
+speed-measure-plugin.json
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+.history/*
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+# System Files
+.DS_Store
+Thumbs.db
+
+# testing
+junit.xml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,50 +1,28 @@
-documentation
+# Taken from .gitignore
+/assets/.parcel-cache
+/data/favicons/*.png
+/data/favicons/*.jpg
+/data/thumbnails/*.png
+/data/thumbnails/*.jpg
+/data/cache/*.spc
+/data/logs/*.log
+/data/sqlite/*.db
+/public
+docs/public/
+docs/static/processed_images/
+user.css
+user.js
+*.ini
+node_modules
+.env
+vendor/
+.php_cs.cache
+__pycache__
+
+# Regular docker ignore
 .dockerignore
 Dockerfile
 .git
-.git*
+.github
+.gitignore
 *.md
-
-# compiled output
-/dist
-/tmp
-/out-tsc
-# Only exists if Bazel was run
-/bazel-out
-
-# dependencies
-/node_modules
-
-# profiling files
-chrome-profiler-events.json
-speed-measure-plugin.json
-
-# IDEs and editors
-/.idea
-.project
-.classpath
-.c9/
-*.launch
-.settings/
-*.sublime-workspace
-
-# IDE - VSCode
-.vscode/*
-.history/*
-
-# misc
-/.sass-cache
-/connect.lock
-/coverage
-/libpeerconnection.log
-npm-debug.log
-yarn-error.log
-testem.log
-/typings
-
-# System Files
-.DS_Store
-Thumbs.db
-
-# testing
-junit.xml

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,46 @@
+# According to https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-ghcrio
+name: Create and publish a Container image
+
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - master
+      - docker
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          file: Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+### Stage 1: build client
+FROM node:18 as client-builder
+WORKDIR /client-builder
+
+# Install node packages
+COPY package.json .
+COPY client/package.json client/
+COPY client/package-lock.json client/
+RUN npm run install-dependencies:client
+
+# Build client
+COPY client/ client/
+RUN npm run build
+
+
+### Stage 2: final container
+FROM php:8.2-apache
+RUN apt-get update \
+    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y cron unzip libjpeg62-turbo-dev libpng-dev libpq-dev libonig-dev libtidy-dev \
+    && update-ca-certificates --fresh \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-configure gd \
+    && docker-php-ext-install gd mbstring pdo_pgsql pdo_mysql tidy
+
+RUN a2enmod headers rewrite
+
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php composer-setup.php \
+    && php -r "unlink('composer-setup.php');" \
+    && mv composer.phar /usr/local/bin/composer
+
+# Install dependencies
+COPY composer.json .
+COPY composer.lock .
+RUN COMPOSER_ALLOW_SUPERUSER=1 composer install --optimize-autoloader --no-dev
+
+# Setup cron
+RUN echo '* * * * * curl http://localhost/update' | tee /etc/cron.d/selfoss \
+    && chmod 0644 /etc/cron.d/selfoss \
+    && crontab /etc/cron.d/selfoss
+
+WORKDIR /var/www/html
+
+COPY . .
+
+COPY --from=client-builder /client-builder/public /var/www/html/public
+
+RUN chown -R www-data:www-data /var/www/html/data
+
+# Overload default command to run cron in the background
+RUN sed -i 's/^exec /service cron start\n\nexec /' /usr/local/bin/apache2-foreground
+
+VOLUME /var/www/html/data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,51 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.9@sha256:5510f694edfe648d961b59dcf217026485e560d2663c73e45067b8c8d7a6d247
 
 ### Stage 1: build client
-FROM node:20 as client-builder
+FROM node:20 AS client-builder
 WORKDIR /client-builder
 
 # Install node packages
-COPY package.json .
-COPY client/package.json client/
-COPY client/package-lock.json client/
-RUN npm run install-dependencies:client
+RUN --mount=type=bind,source=package.json,target=package.json \
+  --mount=type=bind,source=client/package.json,target=client/package.json \
+  --mount=type=bind,source=client/package-lock.json,target=client/package-lock.json \
+  --mount=type=cache,sharing=locked,id=npmcache,mode=0777,target=/root/.npm \
+  npm run install-dependencies-ci:client
 
 # Build client
 COPY client/ client/
-RUN npm run build
+RUN --mount=type=bind,source=package.json,target=package.json \
+  --mount=type=bind,source=client/package.json,target=client/package.json \
+  --mount=type=bind,source=client/package-lock.json,target=client/package-lock.json \
+  --mount=type=cache,sharing=locked,id=npmcache,mode=0777,target=/root/.npm \
+  npm run build
 
 
 ### Stage 2: final container
-FROM php:8.2-apache
+FROM php:8.3-apache
 # Install runtime & development package dependencies & php extensions
 # then clean-up dev package dependencies
 RUN export DEBIAN_FRONTEND=noninteractive \
-    && apt update \
-    && apt install -y --no-install-recommends \
-      unzip \
-      libjpeg62-turbo libpng16-16 libpq5 libonig5 libtidy5deb1 \
-      libjpeg62-turbo-dev libpng-dev libpq-dev libonig-dev libtidy-dev \
-    && update-ca-certificates --fresh \
-    && docker-php-ext-configure gd --with-jpeg \
-    && docker-php-ext-install gd mbstring pdo_pgsql pdo_mysql tidy \
-    && apt remove -y libjpeg62-turbo-dev libpng-dev libpq-dev libonig-dev libtidy-dev \
-    && apt autoremove -y \
-    && apt clean \
-    && rm -rf /var/lib/apt/lists/*
+  && apt update \
+  && apt install -y --no-install-recommends \
+  unzip \
+  libjpeg62-turbo libpng16-16 libpq5 libonig5 libtidy5deb1 \
+  libjpeg62-turbo-dev libpng-dev libpq-dev libonig-dev libtidy-dev \
+  && update-ca-certificates --fresh \
+  && docker-php-ext-configure gd --with-jpeg \
+  && docker-php-ext-install -j$(nproc) gd mbstring pdo_pgsql pdo_mysql tidy \
+  && apt remove -y libjpeg62-turbo-dev libpng-dev libpq-dev libonig-dev libtidy-dev \
+  && apt autoremove -y \
+  && apt clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install Apache modules
 RUN a2enmod headers rewrite
 
 # Install Selfoss PHP dependencies
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
-COPY composer.json .
-COPY composer.lock .
-RUN COMPOSER_ALLOW_SUPERUSER=1 composer install --optimize-autoloader --no-dev
-RUN rm /usr/bin/composer
+RUN --mount=type=bind,source=composer.json,target=composer.json \
+  --mount=type=bind,source=composer.lock,target=composer.lock \
+  --mount=type=bind,from=composer:2,source=/usr/bin/composer,target=/usr/bin/composer \
+  COMPOSER_ALLOW_SUPERUSER=1 composer install --optimize-autoloader --no-dev
 
 # Install Selfoss and copy frontend from the first stage
 WORKDIR /var/www/html

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "fix:helpers:cs": "black utils/ tests/",
     "install-dependencies": "npm run install-dependencies:client && npm run install-dependencies:server",
     "install-dependencies:client": "npm install --production=false --prefix client/",
-    "install-dependencies-ci:client": "npm ci --production=false --prefix client/",
+    "install-dependencies-ci:client": "npm ci --prefix client/",
     "install-dependencies:server": "composer install --dev",
     "test:server": "composer run-script test",
     "test:integration": "python3 tests/integration/run.py",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "fix:helpers:cs": "black utils/ tests/",
     "install-dependencies": "npm run install-dependencies:client && npm run install-dependencies:server",
     "install-dependencies:client": "npm install --production=false --prefix client/",
+    "install-dependencies-ci:client": "npm ci --production=false --prefix client/",
     "install-dependencies:server": "composer install --dev",
     "test:server": "composer run-script test",
     "test:integration": "python3 tests/integration/run.py",


### PR DESCRIPTION
Here is a first try of https://github.com/fossar/selfoss/issues/1350 as a simpler alternative / first step than https://github.com/fossar/selfoss/pull/1170

Here are some notes:
- Scope is much smaller than #1170: only having a production container image
- It's a two-stages image, instead of the separated "composer" stage of #1170. ~~If you think this could easily be done, feel free to point me to the right direction, but I was not able to properly separate build from serve (due to always needing to build extensions...)~~ edit: https://hub.docker.com/_/composer/ recommends doing what is done in this pr, so everything seems ok, and I now delete development packages.
- cron in included within the container, which seems to be a very good compromise but may not be ideal in some rare situations
- I'm assuming that SQLite is used and a data volume is mounted and config can be customized (mounted as volume). I haven't tried with external database.
- It's not using fpm but ol' good apache. I'm assuming this is ok for now.

What do you think?

Potential next steps if this gets merged:
- image building & hosting automation to GitHub Container Registry using Github Actions (I can do)
- Kubernetes compatibility through Helm Chart with dedicated database (I can do)
- dev-container
- profit and glory