### PR TITLE
Controllers\Sources: Remove unused `GET /source` API endpoint

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,10 @@
 - [Prettier](https://prettier.io/) is now used for code formatting. ([#1493](https://github.com/fossar/selfoss/pull/1493))
 - Several `npm run` scripts were renamed for consistency: `analyse:server` → `check:server:phpstan`, `cs:server` → `check:server:cs`, `lint:server` → `check:server:lint`. ([#1494](https://github.com/fossar/selfoss/pull/1494))
 
+### API changes
+
+- *API 8.0.0*: Remove `GET /source` API, it was only used by us and was redundant with `GET /sources/spouts` ([#1539](https://github.com/fossar/selfoss/pull/1539))
+
 
 ## 2.19 – 2022-10-12
 **This version requires PHP ~~5.6~~ 7.2 (see known regressions section) or newer. It is also the last version to support PHP 7.**

--- a/client/js/requests/sources.js
+++ b/client/js/requests/sources.js
@@ -65,7 +65,9 @@ export function getAllSources(abortController) {
  * Gets list of supported spouts and their paramaters.
  */
 export function getSpouts() {
-    return ajax.get('source').promise.then((response) => response.json());
+    return ajax
+        .get('sources/spouts')
+        .promise.then((response) => response.json());
 }
 
 /**

--- a/client/js/templates/SourcesPage.jsx
+++ b/client/js/templates/SourcesPage.jsx
@@ -34,7 +34,7 @@ function handleAddSource({
     // Refresh the spout datea
     sourceRequests
         .getSpouts()
-        .then(({ spouts }) => {
+        .then((spouts) => {
             // Update spout data.
             setSpouts(spouts);
         })

--- a/docs/api-description.json
+++ b/docs/api-description.json
@@ -3,7 +3,7 @@
   "servers": [],
   "info": {
     "description": "You can access selfoss by using the same backend as selfoss user interface: The RESTful HTTP JSON API. There are a few urls where you can get information from selfoss and some for updating data. Assume you want all tags for rendering this in your own app. You have to make an HTTP GET call on the url /tags:\n\n```\nGET http://yourselfossurl.com/tags\n```\nThe result is following JSON formatted response (in this example two tags “blog” and “deviantart” are available:\n\n```\n[{\"tag\":\"blog\",\"color\":\"#251f10\",\"unread\":\"1\"},\n{\"tag\":\"deviantart\",\"color\":\"#e78e5c\",\"unread\":\"0\"}]\n```\n\nFollowing docs shows you which calls are possible and which response you can expect.",
-    "version": "7.0.0",
+    "version": "8.0.0",
     "title": "selfoss"
   },
   "tags": [

--- a/index.php
+++ b/index.php
@@ -109,10 +109,6 @@ $router->get('/sources', function() use ($container): void {
     // json
     $container->get(controllers\Sources::class)->show();
 });
-$router->get('/source', function() use ($container): void {
-    // json
-    $container->get(controllers\Sources::class)->add();
-});
 $router->get('/sources/list', function() use ($container): void {
     // json
     $container->get(controllers\Sources::class)->listSources();

--- a/src/constants.php
+++ b/src/constants.php
@@ -9,4 +9,4 @@ const SELFOSS_VERSION = '2.20-SNAPSHOT';
 // independent of selfoss version
 // needs to be bumped each time public API is changed (follows semver)
 // keep in sync with docs/api-description.json
-const SELFOSS_API_VERSION = '7.0.0';
+const SELFOSS_API_VERSION = '8.0.0';

--- a/src/controllers/Sources.php
+++ b/src/controllers/Sources.php
@@ -57,20 +57,6 @@ class Sources {
     }
 
     /**
-     * add new source
-     * json
-     */
-    public function add(): void {
-        $this->authentication->ensureIsPrivileged();
-
-        $spouts = $this->spoutLoader->all();
-
-        $this->view->jsonSuccess([
-            'spouts' => $spouts,
-        ]);
-    }
-
-    /**
      * render spouts params
      * json
      */


### PR DESCRIPTION
Initially, it was used to produce HTML fragment containing a form for adding new source.

In 767e667046591851ee17f108a0fb6043579d916b, it has been changed to return JSON with just the `spouts`, which is almost identical to `GET /sources/spouts`.

Let’s switch to that and drop the old API endpoint.

Bumping API version to 8.0.0.
