### PR TITLE
helpers\FeedReader: Disable SimplePie cache in tests

### DIFF
--- a/src/helpers/FeedReader.php
+++ b/src/helpers/FeedReader.php
@@ -22,6 +22,8 @@ final readonly class FeedReader {
         // initialize simplepie feed loader
         if ($cache !== null) {
             $this->simplepie->set_cache($cache);
+        } else {
+            $this->simplepie->enable_cache(false);
         }
 
         $this->simplepie->set_http_client(


### PR DESCRIPTION
Fixes the following warning from SimplePie in YouTubeTest:

    ./cache is not writable. Make sure you've set the correct relative or absolute path, and that the location is server-writable.
