### PR TITLE
spouts/rss/enclosures: Link enclosed audio file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - Source filters can be negated, or limited to only title or only content. ([#1423](https://github.com/fossar/selfoss/pull/1423))
 - Sources can be filtered based on item’s author, URL or categories. ([#1423](https://github.com/fossar/selfoss/pull/1423), [#1424](https://github.com/fossar/selfoss/pull/1424))
 - Source filter expression is now validated whenever a source is modified. ([#1423](https://github.com/fossar/selfoss/pull/1423))
+- RSS with enclosures spout now links audio enclosures (e.g. podcasts). ([#1574](https://github.com/fossar/selfoss/pull/1574))
 - Garbage collection can be completely disabled by setting `items_lifetime=0`.
 - Tamil (`ta`) translation was added.
 

--- a/src/spouts/rss/enclosures.php
+++ b/src/spouts/rss/enclosures.php
@@ -40,13 +40,32 @@ class enclosures extends feed {
         $newContent = $content->getRaw();
 
         foreach ($enclosures as $enclosure) {
-            $newContent .= match ($enclosure->get_medium()) {
+            $newContent .= match (self::mediaKind($enclosure)) {
                 'image' => self::formatImage($enclosure),
+                'audio' => self::formatAudio($enclosure),
                 default => '',
             };
         }
 
         return HtmlString::fromRaw($newContent);
+    }
+
+    private static function mediaKind(Enclosure $enclosure): ?string {
+        $medium = $enclosure->get_medium();
+
+        if ($medium !== null) {
+            return $medium;
+        }
+
+        $type = $enclosure->get_type();
+
+        if ($type !== null) {
+            [$medium] = explode('/', $type, 2);
+
+            return $medium;
+        }
+
+        return null;
     }
 
     private static function formatImage(Enclosure $enclosure): string {
@@ -60,5 +79,27 @@ class enclosures extends feed {
         $url = htmlspecialchars_decode($url, ENT_COMPAT); // SimplePie sanitizes URLs
 
         return '<img src="' . htmlspecialchars($url, ENT_QUOTES) . '" alt="' . $title . '" title="' . $title . '" />';
+    }
+
+    private static function formatAudio(Enclosure $enclosure): string {
+        $url = $enclosure->get_link();
+
+        if ($url === null) {
+            return '';
+        }
+
+        $title = htmlspecialchars(strip_tags((string) $enclosure->get_title()), ENT_QUOTES);
+        $url = htmlspecialchars_decode($url, ENT_COMPAT); // SimplePie sanitizes URLs
+
+        $linkLabel = 'Download';
+
+        $duration = $enclosure->get_duration(true);
+        if ($duration !== null) {
+            $linkLabel .= ' (' . $duration . ')';
+        }
+
+        $link = '<a href="' . htmlspecialchars($url, ENT_QUOTES) . '">' . $linkLabel . '</a>';
+
+        return "\n" . $link;
     }
 }

--- a/src/spouts/rss/enclosures.php
+++ b/src/spouts/rss/enclosures.php
@@ -6,6 +6,7 @@ namespace spouts\rss;
 
 use Selfoss\helpers\HtmlString;
 use SimplePie;
+use SimplePie\Enclosure;
 use spouts\Item;
 
 /**
@@ -39,13 +40,19 @@ class enclosures extends feed {
         $newContent = $content->getRaw();
 
         foreach ($enclosures as $enclosure) {
-            if ($enclosure->get_medium() === 'image') {
-                $title = htmlspecialchars(strip_tags((string) $enclosure->get_title()), ENT_QUOTES);
-                $url = htmlspecialchars_decode($enclosure->get_link() ?? '', ENT_COMPAT); // SimplePie sanitizes URLs
-                $newContent .= '<img src="' . htmlspecialchars($url, ENT_QUOTES) . '" alt="' . $title . '" title="' . $title . '" />';
-            }
+            $newContent .= match ($enclosure->get_medium()) {
+                'image' => self::formatImage($enclosure),
+                default => '',
+            };
         }
 
         return HtmlString::fromRaw($newContent);
+    }
+
+    private static function formatImage(Enclosure $enclosure): string {
+        $title = htmlspecialchars(strip_tags((string) $enclosure->get_title()), ENT_QUOTES);
+        $url = htmlspecialchars_decode($enclosure->get_link() ?? '', ENT_COMPAT); // SimplePie sanitizes URLs
+
+        return '<img src="' . htmlspecialchars($url, ENT_QUOTES) . '" alt="' . $title . '" title="' . $title . '" />';
     }
 }

--- a/src/spouts/rss/enclosures.php
+++ b/src/spouts/rss/enclosures.php
@@ -50,8 +50,14 @@ class enclosures extends feed {
     }
 
     private static function formatImage(Enclosure $enclosure): string {
+        $url = $enclosure->get_link();
+
+        if ($url === null) {
+            return '';
+        }
+
         $title = htmlspecialchars(strip_tags((string) $enclosure->get_title()), ENT_QUOTES);
-        $url = htmlspecialchars_decode($enclosure->get_link() ?? '', ENT_COMPAT); // SimplePie sanitizes URLs
+        $url = htmlspecialchars_decode($url, ENT_COMPAT); // SimplePie sanitizes URLs
 
         return '<img src="' . htmlspecialchars($url, ENT_QUOTES) . '" alt="' . $title . '" title="' . $title . '" />';
     }

--- a/tests/Spouts/RssEnclosuresTest.php
+++ b/tests/Spouts/RssEnclosuresTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Spouts;
+
+use Generator;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Selfoss\helpers\HtmlString;
+use Slince\Di\Container;
+use spouts\rss\enclosures;
+
+final class RssEnclosuresTest extends TestCase {
+    /**
+     * @dataProvider dataProvider
+     *
+     * @param array{url: string, fileName: string, contentType: string}[] $urls
+     */
+    public function testBasic(array $urls, string $feedTitle, HtmlString $firstItemTitle, HtmlString $firstItemContent): void {
+        $mock = new MockHandler(
+            array_map(
+                function(array $remoteFile): Response {
+                    ['fileName' => $fileName, 'contentType' => $contentType] = $remoteFile;
+
+                    return new Response(200, ['Content-Type' => $contentType], @file_get_contents($fileName) ?: "Unable to open  {$fileName}.");
+                },
+                $urls
+            )
+        );
+        $stack = HandlerStack::create($mock);
+        $httpClient = new Client(['handler' => $stack]);
+
+        $container = new Container();
+        $container->setDefaults(['shared' => false]);
+
+        $container
+            ->register(Logger::class)
+            ->setArgument('name', 'selfoss')
+            ->setShared(true)
+        ;
+        $container
+            ->register(ClientInterface::class, $httpClient);
+
+        $yt = $container->get(enclosures::class);
+
+        $params = [
+            'url' => $urls[0]['url'],
+        ];
+
+        $yt->load($params);
+
+        $this->assertEquals($feedTitle, $yt->getTitle());
+        $this->assertEquals($firstItemTitle, $yt->getItems()->current()->getTitle());
+        $this->assertEquals($firstItemContent, $yt->getItems()->current()->getContent());
+    }
+
+    /**
+     * @return Generator<array{urls: array{url: string, fileName: string, contentType: string}[], feedTitle: string, firstItemTitle: HtmlString, firstItemContent: HtmlString}>
+     */
+    public function dataProvider(): Generator {
+        yield [
+            'urls' => [
+                self::makeRemoteFile('https://escapepod.org/feed/podcast/', 'application/rss+xml', '.xml'),
+            ],
+            'feedTitle' => 'Escape Pod',
+            'firstItemTitle' => HtmlString::fromPlainText('Escape Pod 1055: Impossibility Crow (Flashback Friday)'),
+            'firstItemContent' => HtmlString::fromRaw(
+                <<<HTML
+                    Author : Remy Nakamura Narrator : Roberto Suarez Hosts : Valerie Valdes and Alasdair Stuart Audio Producer : Adam Pracht Impossibility Crow was originally published as Escape Pod episode 557 on January 5, 2017. Includes violence and swears. Impossibility Crow By Remy Nakamura The Kingdom Coffee Missionary Handbook tells Paulo that he should always put […]
+                    <p><a href="https://escapepod.org/2026/07/23/escape-pod-1055-impossibility-crow-flashback-friday/" rel="nofollow">Source</a></p>
+                    <a href="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1055_Impossibility_Crow_Flashback_Friday.mp3">Download (34:30)</a>
+                    HTML
+            ),
+        ];
+
+        yield [
+            'urls' => [
+                self::makeRemoteFile('https://rss.art19.com/humans', 'application/rss+xml', '.xml'),
+            ],
+            'feedTitle' => 'Humans',
+            'firstItemTitle' => HtmlString::fromPlainText('Vicky Holmes: Finding Humanity in Feral Cats'),
+            'firstItemContent' => HtmlString::fromRaw(
+                <<<HTML
+                    <p>The original author of the Warrior Cats book series has contributed to over 70 books about feral felines, all while not liking cats. Hank and Vicky discuss following your “still, small voice of calm,” the delicacy and respect with which she approaches her young audience, and how the series is autobiographical.\u{a0}</p><p>Got a question or a comment? You can reach us at humans@hankgreen.com</p><p>Find us on social media @humanswithhank</p>
+                    <a href="https://rss.art19.com/episodes/9a4c20f1-a792-4b54-81b7-51bef5708bef.mp3?rss_browser=BAhJIgljdXJsBjoGRVQ%3D--435795d5c850773aaa4739d968bd77a1dfd6f301">Download (1:04:13)</a>
+                    HTML
+            ),
+        ];
+    }
+
+    public static function getResourcePath(string $url): string {
+        $fileName = str_replace([':', '/', '?', '=', '@'], '_', $url);
+
+        return __DIR__ . '/resources/Feed/' . $fileName;
+    }
+
+    /**
+     * @return array{url: string, fileName: string, contentType: string}
+     */
+    public static function makeRemoteFile(string $url, string $contentType, string $extension = ''): array {
+        return [
+            'url' => $url,
+            'fileName' => self::getResourcePath($url) . $extension,
+            'contentType' => $contentType,
+        ];
+    }
+}

--- a/tests/Spouts/YouTubeTest.php
+++ b/tests/Spouts/YouTubeTest.php
@@ -16,23 +16,6 @@ use Selfoss\helpers\HtmlString;
 use Slince\Di\Container;
 use spouts\youtube\youtube;
 
-function getResourcePath(string $url): string {
-    $fileName = str_replace([':', '/', '?', '=', '@'], '_', $url);
-
-    return __DIR__ . '/resources/YouTube/' . $fileName;
-}
-
-/**
- * @return array{url: string, fileName: string, contentType: string}
- */
-function makeRemoteFile(string $url, string $contentType, string $extension = ''): array {
-    return [
-        'url' => $url,
-        'fileName' => getResourcePath($url) . $extension,
-        'contentType' => $contentType,
-    ];
-}
-
 final class YouTubeTest extends TestCase {
     /**
      * @dataProvider dataProvider
@@ -114,7 +97,7 @@ final class YouTubeTest extends TestCase {
 
         yield [
             'urls' => [
-                makeRemoteFile('https://www.youtube.com/user/ZoggFromBetelgeuse', 'application/rss+xml', '.xml'),
+                self::makeRemoteFile('https://www.youtube.com/user/ZoggFromBetelgeuse', 'application/rss+xml', '.xml'),
             ],
             'feedTitle' => 'Zogg from Betelgeuse',
             'firstItemTitle' => HtmlString::fromPlainText('No Edge 3: The Shape of the Universe (What do we know?)'),
@@ -123,7 +106,7 @@ final class YouTubeTest extends TestCase {
 
         yield [
             'urls' => [
-                makeRemoteFile('https://www.youtube.com/channel/UCKY00CSQo1MoC27bdGd-w_g', 'application/rss+xml', '.xml'),
+                self::makeRemoteFile('https://www.youtube.com/channel/UCKY00CSQo1MoC27bdGd-w_g', 'application/rss+xml', '.xml'),
             ],
             'feedTitle' => 'Zogg from Betelgeuse',
             'firstItemTitle' => HtmlString::fromPlainText('No Edge 3: The Shape of the Universe (What do we know?)'),
@@ -132,7 +115,7 @@ final class YouTubeTest extends TestCase {
 
         yield [
             'urls' => [
-                makeRemoteFile('https://www.youtube.com/ZoggFromBetelgeuse', 'application/rss+xml', '.xml'),
+                self::makeRemoteFile('https://www.youtube.com/ZoggFromBetelgeuse', 'application/rss+xml', '.xml'),
             ],
             'feedTitle' => 'Zogg from Betelgeuse',
             'firstItemTitle' => HtmlString::fromPlainText('No Edge 3: The Shape of the Universe (What do we know?)'),
@@ -141,7 +124,7 @@ final class YouTubeTest extends TestCase {
 
         yield [
             'urls' => [
-                makeRemoteFile('ZoggFromBetelgeuse', 'application/rss+xml', '.xml'),
+                self::makeRemoteFile('ZoggFromBetelgeuse', 'application/rss+xml', '.xml'),
             ],
             'feedTitle' => 'Zogg from Betelgeuse',
             'firstItemTitle' => HtmlString::fromPlainText('No Edge 3: The Shape of the Universe (What do we know?)'),
@@ -150,7 +133,7 @@ final class YouTubeTest extends TestCase {
 
         yield [
             'urls' => [
-                makeRemoteFile('https://www.youtube.com/playlist?list=PLKhDkilF5o6_pFucn5JHd6xy7muHLK6pS', 'application/rss+xml', '.xml'),
+                self::makeRemoteFile('https://www.youtube.com/playlist?list=PLKhDkilF5o6_pFucn5JHd6xy7muHLK6pS', 'application/rss+xml', '.xml'),
             ],
             'feedTitle' => 'BeeKeeping',
             'firstItemTitle' => HtmlString::fromPlainText('Year of BeeKeeping Episode 15, Finding Queen'),
@@ -165,8 +148,8 @@ final class YouTubeTest extends TestCase {
 
         yield [
             'urls' => [
-                makeRemoteFile('https://www.youtube.com/@BreakingTaps', 'text/html', '.html'),
-                makeRemoteFile('https://www.youtube.com/feeds/videos.xml?channel_id=UC06HVrkOL33D5lLnCPjr6NQ', 'application/rss+xml', '.xml'),
+                self::makeRemoteFile('https://www.youtube.com/@BreakingTaps', 'text/html', '.html'),
+                self::makeRemoteFile('https://www.youtube.com/feeds/videos.xml?channel_id=UC06HVrkOL33D5lLnCPjr6NQ', 'application/rss+xml', '.xml'),
             ],
             'feedTitle' => 'Breaking Taps',
             'firstItemTitle' => HtmlString::fromPlainText('Slow Motion Tuning Fork'),
@@ -179,6 +162,23 @@ final class YouTubeTest extends TestCase {
                     #shorts
                     HTML
             ),
+        ];
+    }
+
+    public static function getResourcePath(string $url): string {
+        $fileName = str_replace([':', '/', '?', '=', '@'], '_', $url);
+
+        return __DIR__ . '/resources/YouTube/' . $fileName;
+    }
+
+    /**
+     * @return array{url: string, fileName: string, contentType: string}
+     */
+    public static function makeRemoteFile(string $url, string $contentType, string $extension = ''): array {
+        return [
+            'url' => $url,
+            'fileName' => self::getResourcePath($url) . $extension,
+            'contentType' => $contentType,
         ];
     }
 }

--- a/tests/Spouts/resources/Feed/https___escapepod.org_feed_podcast_.xml
+++ b/tests/Spouts/resources/Feed/https___escapepod.org_feed_podcast_.xml
@@ -1,0 +1,8288 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+	xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd"
+xmlns:podcast="https://podcastindex.org/namespace/1.0"
+xmlns:rawvoice="https://blubrry.com/developer/rawvoice-rss/"
+>
+<channel>
+	<title>Escape Pod</title>
+	<atom:link href="https://escapepod.org/feed/podcast/" rel="self" type="application/rss+xml" />
+	<link>https://escapepod.org</link>
+	<description>The Original Science Fiction Podcast</description>
+	<lastBuildDate>Thu, 23 Jul 2026 21:00:41 +0000</lastBuildDate>
+	<language>en-US</language>
+	<sy:updatePeriod>hourly</sy:updatePeriod>
+	<sy:updateFrequency>1</sy:updateFrequency>
+		
+
+<image>
+	<url>https://escapepod.org/wp-content/uploads/2018/03/cropped-Escape-Pod-chip-2-32x32.png</url>
+	<title>Escape Pod</title>
+	<link>https://escapepod.org</link>
+	<width>32</width>
+	<height>32</height>
+</image> 
+	<atom:link rel="hub" href="https://pubsubhubbub.appspot.com/" />
+	<itunes:author>Escape Artists Foundation</itunes:author>
+	<itunes:explicit>false</itunes:explicit>
+	<itunes:image href="https://escapepod.org/wp-content/uploads/powerpress/EscapePod_3000px.jpg" />
+	<itunes:type>episodic</itunes:type>
+	<copyright>Copyright 2005-2026</copyright>
+	<podcast:license>Copyright 2005-2026</podcast:license>
+	<podcast:medium>podcast</podcast:medium>
+	<image>
+		<title>Escape Pod</title>
+		<url>https://escapepod.org/wp-content/uploads/powerpress/EscapePod_3000px.jpg</url>
+		<link>https://escapepod.org</link>
+	</image>
+	<itunes:category text="Fiction">
+		<itunes:category text="Science Fiction" />
+	</itunes:category>
+	<itunes:category text="Fiction">
+		<itunes:category text="Drama" />
+	</itunes:category>
+	<itunes:category text="Fiction" />
+	<rawvoice:rating>TV-PG</rawvoice:rating>
+	<rawvoice:donate href="https://www.patreon.com/EAPodcasts"></rawvoice:donate>
+	<podcast:funding url="https://www.patreon.com/EAPodcasts"></podcast:funding>
+	<podcast:podping usesPodping="true" />
+	<podcast:guid>ff78e646-5299-530d-a858-7fc3e0ffb0fe</podcast:guid>
+	<rawvoice:subscribe feed="https://escapepod.org/feed/podcast/" itunes="https://podcasts.apple.com/us/podcast/escape-pod/id73329293" tunein="https://tunein.com/podcasts/Science/Escape-Pod-p118933/" spotify="https://open.spotify.com/show/6G8vOC5f6ZuhWmeW4cmgUG" iheart="https://www.iheart.com/podcast/256-escape-pod-30992684/" pandora="https://www.pandora.com/podcast/escape-pod/PC:1793" podchaser="https://www.podchaser.com/podcasts/escape-pod-10191"></rawvoice:subscribe>
+	<item>
+		<title>Escape Pod 1055: Impossibility Crow (Flashback Friday)</title>
+		<link>https://escapepod.org/2026/07/23/escape-pod-1055-impossibility-crow-flashback-friday/</link>
+		<pubDate>Thu, 23 Jul 2026 21:00:41 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=16106</guid>
+		<comments>https://escapepod.org/2026/07/23/escape-pod-1055-impossibility-crow-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/07/23/escape-pod-1055-impossibility-crow-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[assassin]]></category>
+		<category><![CDATA[augmented reality]]></category>
+		<category><![CDATA[coffee]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[goddess]]></category>
+		<category><![CDATA[guns]]></category>
+		<category><![CDATA[podcast]]></category>
+		<category><![CDATA[redemption]]></category>
+		<category><![CDATA[religion]]></category>
+		<category><![CDATA[Remy Nakamura]]></category>
+		<category><![CDATA[Roberto Suarez]]></category>
+		<category><![CDATA[sex]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[Violence]]></category>
+		<category><![CDATA[virtual reality]]></category>
+		<description>Author : Remy Nakamura Narrator : Roberto Suarez Hosts : Valerie Valdes and Alasdair Stuart Audio Producer : Adam Pracht Impossibility Crow was originally published as Escape Pod episode 557 on January 5, 2017. Includes violence and swears. Impossibility Crow By Remy Nakamura The Kingdom Coffee Missionary Handbook tells Paulo that he should always put […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/07/23/escape-pod-1055-impossibility-crow-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1055_Impossibility_Crow_Flashback_Friday.mp3" length="50179004" type="audio/mpeg" />
+		<itunes:author>Remy Nakamura (Author); Roberto Suarez (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>34:30</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1054: Takahata-fudo</title>
+		<link>https://escapepod.org/2026/07/16/escape-pod-1054-takahata-fudo/</link>
+		<pubDate>Thu, 16 Jul 2026 21:00:06 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=16093</guid>
+		<comments>https://escapepod.org/2026/07/16/escape-pod-1054-takahata-fudo/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/07/16/escape-pod-1054-takahata-fudo/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[farm]]></category>
+		<category><![CDATA[food]]></category>
+		<category><![CDATA[genetic engineering]]></category>
+		<category><![CDATA[Japan]]></category>
+		<category><![CDATA[plants]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[tree]]></category>
+		<description>Author : Meridel Newton Narrator : Alexandra Rose Host : Tina Connolly Audio Producer : Summer Brooks Escape Pod 1054: Takahata-fudo is an Escape Pod original. Takahata-fudo by Meridel Newton If you walk far enough along the old Keio line rail tracks to the west of the crumbling city, you eventually reach a steep hillside […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/07/16/escape-pod-1054-takahata-fudo/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1054-Takahata-fudo.mp3" length="64814248" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>44:40</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1053: The Game of Possibilities</title>
+		<link>https://escapepod.org/2026/07/09/escape-pod-1053-the-game-of-possibilities/</link>
+		<pubDate>Thu, 09 Jul 2026 21:00:22 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=16089</guid>
+		<comments>https://escapepod.org/2026/07/09/escape-pod-1053-the-game-of-possibilities/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/07/09/escape-pod-1053-the-game-of-possibilities/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[alien]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[Elie Hirschman]]></category>
+		<category><![CDATA[Ethan Ham]]></category>
+		<category><![CDATA[game]]></category>
+		<category><![CDATA[games]]></category>
+		<category><![CDATA[YA / Young Adult]]></category>
+		<description>Author : Ethan Ham Narrator : Elie Hirschman Host : Alasdair Stuart Audio Producer : Adam Pracht Escape Pod 1053: The Game of Possibilities is an Escape Pod original. Ethan Ham https://www.ethanham.com/index.html?second-edition Elie Hirschman https://eliehirschman.com/ Adam Pracht https://escapepod.org/people/adam-pracht/ Alasdair Stuart https://escapepod.org/people/alasdair-stuart/ Reiner Knizia https://boardgamegeek.com/boardgamedesigner/2/reiner-knizia SleepPhones https://www.sleepphones.co.uk/ Voidmerch store https://voidmerch.threadless.com/collections/escape-artists-inc-x-voidmerch-1 The Game of Possibilities By Ethan […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/07/09/escape-pod-1053-the-game-of-possibilities/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1053_The_Game_of_Possibilities.mp3" length="34514214" type="audio/mpeg" />
+		<itunes:author>Ethan Ham (Author); Elie Hirschman (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>23:37</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1052: When We Fall (Flashback Friday)</title>
+		<link>https://escapepod.org/2026/07/02/escape-pod-1052-when-we-fall-flashback-friday/</link>
+		<pubDate>Thu, 02 Jul 2026 21:00:38 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=16084</guid>
+		<comments>https://escapepod.org/2026/07/02/escape-pod-1052-when-we-fall-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/07/02/escape-pod-1052-when-we-fall-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[emergency]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[Hugo Winner]]></category>
+		<category><![CDATA[Ibba Armancas]]></category>
+		<category><![CDATA[Kameron Hurley]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[space ship]]></category>
+		<category><![CDATA[war]]></category>
+		<description>Author : Kameron Hurley Narrator : Ibba Armancas Host : Mur Lafferty Audio Producer : Summer Brooks “When We Fall” was originally published on Kameron Hurley’s Patreon, and also featured in Escape Pod 611 in January 2018. Intense, life-threatening situation. When We Fall by Kameron Hurley I don’t remember the first time I was abandoned […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/07/02/escape-pod-1052-when-we-fall-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1052-WhenWeFall-FlashbackFriday.mp3" length="56999457" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:14</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1051: You Have Arrived at Your Destination</title>
+		<link>https://escapepod.org/2026/06/25/escape-pod-1051-you-have-arrived-at-your-destination/</link>
+		<pubDate>Thu, 25 Jun 2026 21:00:43 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=16073</guid>
+		<comments>https://escapepod.org/2026/06/25/escape-pod-1051-you-have-arrived-at-your-destination/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/06/25/escape-pod-1051-you-have-arrived-at-your-destination/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[cars]]></category>
+		<category><![CDATA[Jo Miles]]></category>
+		<category><![CDATA[Julia Rios]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : Jo Miles Narrator : Julia Rios Host : Tina Connolly Audio Producer : Adam Pracht Escape Pod 1051: You Have Arrived at Your Destination is an Escape Pod original. You Have Arrived at Your Destination By Jo Miles It starts with an accident. A dreary day, the road slick with rain. Emily’s letting […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/06/25/escape-pod-1051-you-have-arrived-at-your-destination/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1051_You_Have_Arrived_at_Your_Destination.mp3" length="73595311" type="audio/mpeg" />
+		<itunes:author>Jo Miles (Author); Julia Rios (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>50:46</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1050: Freebooter</title>
+		<link>https://escapepod.org/2026/06/18/escape-pod-1050-freebooter/</link>
+		<pubDate>Thu, 18 Jun 2026 21:00:29 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=16052</guid>
+		<comments>https://escapepod.org/2026/06/18/escape-pod-1050-freebooter/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/06/18/escape-pod-1050-freebooter/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[caregiver]]></category>
+		<category><![CDATA[dystopian]]></category>
+		<category><![CDATA[robots]]></category>
+		<description>Author : Sylvie Althoff Narrator : Jess Lewis Host : Valerie Valdes Audio Producer : Summer Brooks Escape Pod 1050: Freebooter is an Escape Pod original. Moderate use of harsh language. Freebooter by Sylvie Althoff The pirate bot was easy to miss. Squatting against a wall on the periphery of the Saint-Denis Heritage Market, it […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/06/18/escape-pod-1050-freebooter/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1050-Freebooter.mp3" length="65412348" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>45:05</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1049: Amrit</title>
+		<link>https://escapepod.org/2026/06/11/escape-pod-1049-amrit/</link>
+		<pubDate>Thu, 11 Jun 2026 21:00:51 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=16044</guid>
+		<comments>https://escapepod.org/2026/06/11/escape-pod-1049-amrit/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/06/11/escape-pod-1049-amrit/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[Kaushik Narasimhan]]></category>
+		<category><![CDATA[Kiran Kaur Saini]]></category>
+		<category><![CDATA[old]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>Author : Kiran Kaur Saini Narrator : Kaushik Narasimhan Host : Alasdair Stuart Audio Producer : Adam Pracht Amrit originally appeared in The Magazine of Fantasy &amp; Science Fiction, May/June 2023. Kiran Kaur Saini https://kirankaursaini.com/ Kaushik Narasimhan https://www.castofwonders.org/people/kaushik-narasimhan/ Alasdair Stuart https://escapepod.org/people/alasdair-stuart/ Robot and Frank https://en.wikipedia.org/wiki/Robot_%26_Frank Void Merch https://voidmerch.threadless.com/collections/escape-artists-inc-x-voidmerch-1 Amrit By Kiran Kaur Saini The doorbell rang […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/06/11/escape-pod-1049-amrit/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1049_Amrit.mp3" length="83980934" type="audio/mpeg" />
+		<itunes:author>Kiran Kaur Saini (Author); Kaushik Narasimhan (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>57:59</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1048: The Library of the Apocalypse</title>
+		<link>https://escapepod.org/2026/06/04/escape-pod-1048-the-library-of-the-apocalypse/</link>
+		<pubDate>Thu, 04 Jun 2026 21:00:52 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=16033</guid>
+		<comments>https://escapepod.org/2026/06/04/escape-pod-1048-the-library-of-the-apocalypse/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/06/04/escape-pod-1048-the-library-of-the-apocalypse/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[apocalypse]]></category>
+		<category><![CDATA[apocalyptic]]></category>
+		<category><![CDATA[cyberpunk]]></category>
+		<category><![CDATA[Joe Moran]]></category>
+		<category><![CDATA[Library]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[Rati Mehrotra]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[robot]]></category>
+		<description>Author : Rati Mehrotra Narrator : Joe Moran Host : Mur Lafferty Audio Producer : Adam Pracht The Library of the Apocalypse was first published in Clarkesworld, May 2025, Issue 224. Includes death and cursing. The Library of the Apocalypse By Rati Mehrotra Hunter’s Moon rises fat and golden over the burned-out husk of the […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/06/04/escape-pod-1048-the-library-of-the-apocalypse/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1048_The_Library_of_the_Apocalypse.mp3" length="42867543" type="audio/mpeg" />
+		<itunes:author>Rati Mehrotra (Author); Joe Moran (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>29:26</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1047: EDIE (Part 2 of 2)</title>
+		<link>https://escapepod.org/2026/05/28/escape-pod-1047-edie-part-2-of-2/</link>
+		<pubDate>Thu, 28 May 2026 21:00:04 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=16016</guid>
+		<comments>https://escapepod.org/2026/05/28/escape-pod-1047-edie-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/05/28/escape-pod-1047-edie-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Abra Staffin-Wiebe]]></category>
+		<category><![CDATA[europa]]></category>
+		<category><![CDATA[Jupiter]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[science]]></category>
+		<category><![CDATA[space exploration]]></category>
+		<description>Author : James Dick Narrator : Abra Staffin-Wiebe Host : Tina Connolly Audio Producer : Summer Brooks “EDIE” was first published in Analog Science Fiction &amp; Fact (January/February 2023) Don’t miss Part 1: Escape Pod 1046: EDIE (Part 1 of 2) EDIE (Part 2) by James Dick EDIE was a smart machine, but every machine, […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/05/28/escape-pod-1047-edie-part-2-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1047-EDIE-Pt2.mp3" length="48423341" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>33:38</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1046: EDIE (Part 1 of 2)</title>
+		<link>https://escapepod.org/2026/05/21/escape-pod-1046-edie-part-1-of-2/</link>
+		<pubDate>Thu, 21 May 2026 21:00:52 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=16012</guid>
+		<comments>https://escapepod.org/2026/05/21/escape-pod-1046-edie-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/05/21/escape-pod-1046-edie-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Abra Staffin-Wiebe]]></category>
+		<category><![CDATA[europa]]></category>
+		<category><![CDATA[Jupiter]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[science]]></category>
+		<category><![CDATA[space exploration]]></category>
+		<category><![CDATA[spaceship]]></category>
+		<description>Author : James Dick Narrator : Abra Staffin-Wiebe Host : Tina Connolly Audio Producer : Summer Brooks “EDIE” was previously published in Analog Science Fiction &amp; Fact (January/February 2023) EDIE (Part 1) by James Dick High above Europa, a lonely traveller reached the end of her journey. A spacecraft the size of a school bus, […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/05/21/escape-pod-1046-edie-part-1-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1046-EDIE-Pt1.mp3" length="51197765" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>35:13</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1045: The Graduates of Formost 891c</title>
+		<link>https://escapepod.org/2026/05/14/escape-pod-1045-the-graduates-of-formost-891c/</link>
+		<pubDate>Thu, 14 May 2026 21:00:41 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=16001</guid>
+		<comments>https://escapepod.org/2026/05/14/escape-pod-1045-the-graduates-of-formost-891c/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/05/14/escape-pod-1045-the-graduates-of-formost-891c/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Children]]></category>
+		<category><![CDATA[Colony]]></category>
+		<category><![CDATA[Frank Baird Hughes]]></category>
+		<category><![CDATA[Jairus Durnett]]></category>
+		<category><![CDATA[school]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[spaceship]]></category>
+		<category><![CDATA[teacher]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[whale]]></category>
+		<description>Author : Frank Baird Hughes Narrator : Jairus Durnett Host : Valerie Valdes Audio Producer : Adam Pracht Escape Pod 1045: The Graduates of Formost 891c is an Escape Pod original. Contains examples of animal surgical modification. The Graduates of Formost 891c By Frank Baird Hughes They say that in Texas, the best jobs go […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/05/14/escape-pod-1045-the-graduates-of-formost-891c/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1045_The_Graduates_of_Formost_891c.mp3" length="61076670" type="audio/mpeg" />
+		<itunes:author>Frank Baird Hughes (Author); Jairus Durnett (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>42:04</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1044: Rhona&#8217;s Tavern and Spacetime Portal</title>
+		<link>https://escapepod.org/2026/05/07/escape-pod-1044-rhonas-tavern-and-spacetime-portal/</link>
+		<pubDate>Thu, 07 May 2026 21:00:56 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15990</guid>
+		<comments>https://escapepod.org/2026/05/07/escape-pod-1044-rhonas-tavern-and-spacetime-portal/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/05/07/escape-pod-1044-rhonas-tavern-and-spacetime-portal/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[alternate timelines]]></category>
+		<category><![CDATA[Dani Daly]]></category>
+		<category><![CDATA[time loop]]></category>
+		<category><![CDATA[time travel]]></category>
+		<description>Author : S. L. Myers Narrator : Dani Daly Host : Alasdair Stuart Audio Producer : Summer Brooks Escape Pod 1044: Rhona’s Tavern and Spacetime Portal is an Escape Pod original. Occasional use of harsh language Escape Pod is proud to say that we have partnered with Sleepphones headphones to provide a special Escape Pod […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/05/07/escape-pod-1044-rhonas-tavern-and-spacetime-portal/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1044-RhonasTavernandSpacetimePortal.mp3" length="53406470" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>36:45</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1043: The Smokejumpers</title>
+		<link>https://escapepod.org/2026/04/30/escape-pod-1043-the-smokejumpers/</link>
+		<pubDate>Thu, 30 Apr 2026 21:00:37 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15974</guid>
+		<comments>https://escapepod.org/2026/04/30/escape-pod-1043-the-smokejumpers/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/04/30/escape-pod-1043-the-smokejumpers/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[climate]]></category>
+		<category><![CDATA[exo suit]]></category>
+		<category><![CDATA[exoskeleton]]></category>
+		<category><![CDATA[fire fighter]]></category>
+		<category><![CDATA[Laurice White]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[marriage]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[romance]]></category>
+		<category><![CDATA[Sierra Bibi]]></category>
+		<description>Author : Sierra Bibi Narrator : Laurice White Host : Mur Lafferty Audio Producer : Adam Pracht Escape Pod 1043: The Smokejumpers is an Escape Pod original. Includes wildfires and peril. The Smokejumpers By Sierra Bibi When Fern jumps from the plane into the smoke for the very first time, she believes she has nothing […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/04/30/escape-pod-1043-the-smokejumpers/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1043_The_Smokejumpers.mp3" length="86852511" type="audio/mpeg" />
+		<itunes:author>Sierra Bibi (Author); Laurice White (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>59:53</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1042: More Tomorrow (Flashback Friday)</title>
+		<link>https://escapepod.org/2026/04/23/escape-pod-1042-more-tomorrow-flashback-friday/</link>
+		<pubDate>Thu, 23 Apr 2026 21:00:19 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15954</guid>
+		<comments>https://escapepod.org/2026/04/23/escape-pod-1042-more-tomorrow-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/04/23/escape-pod-1042-more-tomorrow-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Dani Daly]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[Premee Mohamed]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[time travel]]></category>
+		<description>Author : Premee Mohamed Narrator : Dani Daly Host : Mur Lafferty Audio Producer : Summer Brooks “More Tomorrow” was first published in Automata Review, March 2018, and previously published as Escape Pod 713, in January 2020. A few grade-A curses. More Tomorrow By Premee Mohamed DAY 5 Anyway, it turns out trilobites aren’t very […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/04/23/escape-pod-1042-more-tomorrow-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1042-MoreTomorrow-FlashbackFriday.mp3" length="52508067" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>36:07</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1041: Love in the Time of Dust and Venom</title>
+		<link>https://escapepod.org/2026/04/16/escape-pod-1041-love-in-the-time-of-dust-and-venom/</link>
+		<pubDate>Thu, 16 Apr 2026 21:00:22 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15932</guid>
+		<comments>https://escapepod.org/2026/04/16/escape-pod-1041-love-in-the-time-of-dust-and-venom/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/04/16/escape-pod-1041-love-in-the-time-of-dust-and-venom/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[apocalyptic]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[future]]></category>
+		<category><![CDATA[Japan]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Sharon Joss]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[time travel]]></category>
+		<category><![CDATA[Torin Andrus]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Author : Sharon Joss Narrator : Torin Andrus Host : Valerie Valdes Audio Producer : Adam Pracht Love in the Time of Dust and Venom originally appeared in 2013 Fiction River – Time Travelers. Includes a form of assisted suicide. Sponsored by Mixtape Stories Love in the Time of Dust and Venom By Sharon Joss Using […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/04/16/escape-pod-1041-love-in-the-time-of-dust-and-venom/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1041_Love_in_the_Time_of_Dust_and_Venom.mp3" length="44530104" type="audio/mpeg" />
+		<itunes:author>Sharon Joss (Author); Torin Andrus (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:35</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1040: Gods and Spirits Our Witnesses</title>
+		<link>https://escapepod.org/2026/04/09/escape-pod-1040-gods-and-spirits-our-witnesses/</link>
+		<pubDate>Thu, 09 Apr 2026 21:00:18 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15903</guid>
+		<comments>https://escapepod.org/2026/04/09/escape-pod-1040-gods-and-spirits-our-witnesses/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/04/09/escape-pod-1040-gods-and-spirits-our-witnesses/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[alternate realities]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[Reincarnation]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>Author : S. C. Mills Narrator : Hugo Jackson Host : Valerie Valdes Audio Producer : Summer Brooks Escape Pod 1040: Gods and Spirits Our Witnesses is an Escape Pod original. Loss of an infant Sponsored by Mixtape Stories Gods and Spirits Our Witnesses by S. C. Mills We met in a public-access data booth […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/04/09/escape-pod-1040-gods-and-spirits-our-witnesses/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1040-GodsandSpiritsOurWitnesses.mp3" length="38577898" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>26:47</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1039: The Many Rebirths of Karina Morita</title>
+		<link>https://escapepod.org/2026/04/02/escape-pod-1039-the-many-rebirths-of-karina-morita/</link>
+		<pubDate>Thu, 02 Apr 2026 21:00:46 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15901</guid>
+		<comments>https://escapepod.org/2026/04/02/escape-pod-1039-the-many-rebirths-of-karina-morita/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/04/02/escape-pod-1039-the-many-rebirths-of-karina-morita/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Reincarnation]]></category>
+		<description>Author : Tim Pratt Narrator : Isabel J. Kim Host : Tina Connolly Audio Producer : Summer Brooks “The Many Rebirths of Karina Morita” first appeared in 2025 on Tim’s Patreon Sponsored by Mixtape Stories The Many Rebirths of Karina Morita by Tim Pratt My problems all started when I died. People didn’t die too […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/04/02/escape-pod-1039-the-many-rebirths-of-karina-morita/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1039-TheManyRebirthsofKarinaMorita.mp3" length="46454758" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>32:16</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1038: Meet the Mets</title>
+		<link>https://escapepod.org/2026/03/26/escape-pod-1038-meet-the-mets/</link>
+		<pubDate>Thu, 26 Mar 2026 21:00:26 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15899</guid>
+		<comments>https://escapepod.org/2026/03/26/escape-pod-1038-meet-the-mets/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/03/26/escape-pod-1038-meet-the-mets/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[baseball]]></category>
+		<category><![CDATA[gender]]></category>
+		<category><![CDATA[radio]]></category>
+		<description>Author : ace tilton ratcliff Narrator : Jordan Kurella Host : Mur Lafferty Audio Producer : Summer Brooks Escape Pod 1038: Meet the Mets is an Escape Pod original. Contains brief moments of violence and bigotry towards a transgender character Sponsored by Mixtape Stories Meet the Mets by Ace Tilton Ratcliff 1964 Bobby didn’t know […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/03/26/escape-pod-1038-meet-the-mets/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1038-MeettheMets.mp3" length="63437902" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>44:03</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1037: We Who Live in the Heart (Part 3 of 3)</title>
+		<link>https://escapepod.org/2026/03/19/escape-pod-1037-we-who-live-in-the-heart-part-3-of-3/</link>
+		<pubDate>Thu, 19 Mar 2026 21:00:37 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15892</guid>
+		<comments>https://escapepod.org/2026/03/19/escape-pod-1037-we-who-live-in-the-heart-part-3-of-3/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/03/19/escape-pod-1037-we-who-live-in-the-heart-part-3-of-3/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[future]]></category>
+		<category><![CDATA[Ibba Armancas]]></category>
+		<category><![CDATA[Kelly Robson]]></category>
+		<category><![CDATA[novella]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>Author : Kelly Robson Narrator : Ibba Armancas Host : Alasdair Stuart Audio Producer : Adam Pracht We Who Live in the Heart originally appeared in Clarkesworld, May 1, 2017. Quantum Superposition https://en.wikipedia.org/wiki/Quantum_superposition Cloudward Ho https://dimension20.fandom.com/wiki/Category:Cloudward,_Ho! Void Merch https://voidmerch.threadless.com/collections/escape-artists-inc-x-voidmerch-1 We Who Live in the Heart (Part 3 of 3) By Kelly Robson (…Continued from Part […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/03/19/escape-pod-1037-we-who-live-in-the-heart-part-3-of-3/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1037_We_Who_Live_in_the_Heart_Part_3.mp3" length="53940850" type="audio/mpeg" />
+		<itunes:author>Kelly Robson (Author); Ibba Armancas (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>37:02</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1036: We Who Live in the Heart (Part 2 of 3)</title>
+		<link>https://escapepod.org/2026/03/12/escape-pod-1036-we-who-live-in-the-heart-part-2-of-3/</link>
+		<pubDate>Thu, 12 Mar 2026 21:00:46 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15883</guid>
+		<comments>https://escapepod.org/2026/03/12/escape-pod-1036-we-who-live-in-the-heart-part-2-of-3/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/03/12/escape-pod-1036-we-who-live-in-the-heart-part-2-of-3/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[future]]></category>
+		<category><![CDATA[Ibba Armancas]]></category>
+		<category><![CDATA[Kelly Robson]]></category>
+		<category><![CDATA[novella]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>Author : Kelly Robson Narrator : Ibba Armancas Host : Alasdair Stuart Audio Producer : Adam Pracht We Who Live in the Heart originally appeared in Clarkesworld, May 1, 2017. We Who Live in the Heart (Part 2 of 3) By Kelly Robson (…Continued from Part 2) Ricci got into my notes. I don’t keep […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/03/12/escape-pod-1036-we-who-live-in-the-heart-part-2-of-3/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1036_We_Who_Live_in_the_Heart_Part_2.mp3" length="56159832" type="audio/mpeg" />
+		<itunes:author>Kelly Robson (Author); Ibba Armancas (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>38:39</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1035: We Who Live in the Heart (Part 1 of 3)</title>
+		<link>https://escapepod.org/2026/03/05/escape-pod-1035-we-who-live-in-the-heart-part-1-of-3/</link>
+		<pubDate>Thu, 05 Mar 2026 22:00:51 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15874</guid>
+		<comments>https://escapepod.org/2026/03/05/escape-pod-1035-we-who-live-in-the-heart-part-1-of-3/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/03/05/escape-pod-1035-we-who-live-in-the-heart-part-1-of-3/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[future]]></category>
+		<category><![CDATA[Ibba Armancas]]></category>
+		<category><![CDATA[Kelly Robson]]></category>
+		<category><![CDATA[novella]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>Author : Kelly Robson Narrator : Ibba Armancas Host : Alasdair Stuart Audio Producer : Adam Pracht We Who Live in the Heart originally appeared in Clarkesworld, May 1, 2017. We Who Live in the Heart By Kelly Robson Ricci slipped in and out of consciousness as we carried her to the anterior sinus and […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/03/05/escape-pod-1035-we-who-live-in-the-heart-part-1-of-3/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1035_We_Who_Live_in_the_Heart_Part_1.mp3" length="56763121" type="audio/mpeg" />
+		<itunes:author>Kelly Robson (Author); Ibba Armancas (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:00</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1034: &#8220;An Honour to be Nominated&#8230;&#8221;</title>
+		<link>https://escapepod.org/2026/02/26/escape-pod-1034-an-honour-to-be-nominated/</link>
+		<pubDate>Thu, 26 Feb 2026 22:00:40 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15865</guid>
+		<comments>https://escapepod.org/2026/02/26/escape-pod-1034-an-honour-to-be-nominated/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/02/26/escape-pod-1034-an-honour-to-be-nominated/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[awards]]></category>
+		<category><![CDATA[Elie Hirschman]]></category>
+		<description>Author : Jacob Seinemeier Narrator : Elie Hirschman Host : Mur Lafferty Audio Producer : Summer Brooks Escape Pod 1034: “An Honour to be Nominated…” is an Escape Pod original. Mild profanity “An Honour to be Nominated…” by Jacob Seinemeier TRANSGALACTIC NEWS- straight from the feed to your screed! “…and how exciting to be gathered […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/02/26/escape-pod-1034-an-honour-to-be-nominated/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1034-AnHonourToBeNominated.mp3" length="52637844" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>36:13</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1033: The Automatic Grocery Store</title>
+		<link>https://escapepod.org/2026/02/19/escape-pod-1033-the-automatic-grocery-store/</link>
+		<pubDate>Thu, 19 Feb 2026 22:00:02 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15853</guid>
+		<comments>https://escapepod.org/2026/02/19/escape-pod-1033-the-automatic-grocery-store/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/02/19/escape-pod-1033-the-automatic-grocery-store/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[Christiana Ellis]]></category>
+		<category><![CDATA[dog]]></category>
+		<category><![CDATA[G. M. Paniccia]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[robots]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Author : G. M. Paniccia Narrator : Christiana Ellis Host : Valerie Valdes Audio Producer : Adam Pracht Escape Pod 1033: The Automatic Grocery Store is an Escape Pod original. The Automatic Grocery Store By G. M. Paniccia It took thirty-six days, four hours, twelve minutes, and fifty-five seconds after the Glorious Revolution for Automatic […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/02/19/escape-pod-1033-the-automatic-grocery-store/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1033_The_Automatic_Grocery_Store.mp3" length="59148442" type="audio/mpeg" />
+		<itunes:author>G. M. Paniccia (Author); Christiana Ellis (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>40:44</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1032: milt</title>
+		<link>https://escapepod.org/2026/02/12/escape-pod-1032-milt/</link>
+		<pubDate>Thu, 12 Feb 2026 22:00:15 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15833</guid>
+		<comments>https://escapepod.org/2026/02/12/escape-pod-1032-milt/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/02/12/escape-pod-1032-milt/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[mad scientist]]></category>
+		<category><![CDATA[ocean]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[research]]></category>
+		<category><![CDATA[Tatiana Grey]]></category>
+		<category><![CDATA[undersea]]></category>
+		<description>Author : Victoria N. Shi Narrator : Tatiana Grey Host : Tina Connolly Audio Producer : Summer Brooks “milt” first apeared in Fission #5 by the British Science Fiction Association (June 2025) Contains Injury/body horror, climate grief, implied sexual behavior milt by Victoria N. Shi The others believe there’s no pulling Yobé out of his […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/02/12/escape-pod-1032-milt/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1032-milt.mp3" length="48110719" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>33:04</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1031: The Anatomy of Miracles (Flashback Friday)</title>
+		<link>https://escapepod.org/2026/02/05/escape-pod-1031-the-anatomy-of-miracles-flashback-friday/</link>
+		<pubDate>Thu, 05 Feb 2026 22:00:23 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15820</guid>
+		<comments>https://escapepod.org/2026/02/05/escape-pod-1031-the-anatomy-of-miracles-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/02/05/escape-pod-1031-the-anatomy-of-miracles-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[David D. Levine]]></category>
+		<category><![CDATA[Filip Hajdar Drnovšek Zorko]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[home]]></category>
+		<category><![CDATA[multi dimensional]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<category><![CDATA[teleportation]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : Filip Hajdar Drnovšek Zorko Narrators : David D. Levine and S.B. Divya Hosts : Alasdair Stuart and Tina Connolly Audio Producers : Summer Brooks and Adam Pracht Escape Pod 1031: The Anatomy of Miracles (Flashback Friday) is an Escape Pod original. Escape Pod branded SleepPhones Kameron Hurley – The Last Few Years Broke […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/02/05/escape-pod-1031-the-anatomy-of-miracles-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1031_The_Anatomy_of_Miracles_Flashback_Friday.mp3" length="75155652" type="audio/mpeg" />
+		<itunes:author>Filip Hajdar Drnovšek Zorko (Author); S.B. Divya and David D. Levine (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>51:46</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1030: The Smell of the Planet I Was Born On</title>
+		<link>https://escapepod.org/2026/01/29/escape-pod-1030-the-smell-of-the-planet-i-was-born-on/</link>
+		<pubDate>Thu, 29 Jan 2026 22:00:05 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15807</guid>
+		<comments>https://escapepod.org/2026/01/29/escape-pod-1030-the-smell-of-the-planet-i-was-born-on/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/01/29/escape-pod-1030-the-smell-of-the-planet-i-was-born-on/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[colonization]]></category>
+		<category><![CDATA[generation ship]]></category>
+		<category><![CDATA[genetic engineering]]></category>
+		<category><![CDATA[Julia Rios]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Rodrigo Culagovski]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>Author : Rodrigo Culagovski Narrator : Julia Rios Host : Mur Lafferty Audio Producer : Adam Pracht Escape Pod 1030: The Smell of the Planet I Was Born On is an Escape Pod original. The Smell of the Planet I Was Born On By Rodrigo Culagovski There are two moons visible, a large one right […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/01/29/escape-pod-1030-the-smell-of-the-planet-i-was-born-on/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1030_The_Smell_of_the_Planet_I_Was_Born_On.mp3" length="45718990" type="audio/mpeg" />
+		<itunes:author>Rodrigo Culagovski (Author); Julia Rios (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>31:20</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1029: Graduated Justice: An Amelia Li Mystery</title>
+		<link>https://escapepod.org/2026/01/22/escape-pod-1029-graduated-justice-an-amelia-li-mystery/</link>
+		<pubDate>Thu, 22 Jan 2026 22:00:31 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15799</guid>
+		<comments>https://escapepod.org/2026/01/22/escape-pod-1029-graduated-justice-an-amelia-li-mystery/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/01/22/escape-pod-1029-graduated-justice-an-amelia-li-mystery/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Amanda Ching]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[disability]]></category>
+		<category><![CDATA[money]]></category>
+		<category><![CDATA[Myna Chang]]></category>
+		<category><![CDATA[mystery]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Author : Myna Chang Narrator : Amanda Ching Host : Valerie Valdes Audio Producer : Adam Pracht Graduated Justice originally appeared in Translunar Travelers Lounge, February 2025. Graduated Justice: An Amelia Li Mystery By Myna Chang I was leaning against my desk in the Mars Dome cop shop, rubbing nano-repair gel on my prosthetic leg, when […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/01/22/escape-pod-1029-graduated-justice-an-amelia-li-mystery/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1029_Graduated_Justice_An_Amelia_Li_Mystery.mp3" length="44951448" type="audio/mpeg" />
+		<itunes:author>Myna Chang (Author); Amanda Ching (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:52</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1028: What Any Dead Thing Wants (Part 3 of 3)</title>
+		<link>https://escapepod.org/2026/01/15/escape-pod-1028-what-any-dead-thing-wants-part-3-of-3/</link>
+		<pubDate>Thu, 15 Jan 2026 22:00:10 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15775</guid>
+		<comments>https://escapepod.org/2026/01/15/escape-pod-1028-what-any-dead-thing-wants-part-3-of-3/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/01/15/escape-pod-1028-what-any-dead-thing-wants-part-3-of-3/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Aimee Ogden]]></category>
+		<category><![CDATA[alien planet]]></category>
+		<category><![CDATA[ecosystem]]></category>
+		<category><![CDATA[exorcism]]></category>
+		<category><![CDATA[ghosts]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : Aimee Ogden Narrator : Isaac Harwood Host : Tina Connolly Audio Producer : Summer Brooks Copious helpings of harsh language descriptors found here. Don’t miss Parts 1 and 2: Escape Pod 1026: What Any Dead Thing Wants (Part 1 of 3), Escape Pod 1027: What Any Dead Thing Wants (Part 2 of 3) […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/01/15/escape-pod-1028-what-any-dead-thing-wants-part-3-of-3/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1028-WhatAnyDeadThingWants-Part3.mp3" length="53370108" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>36:43</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1027: What Any Dead Thing Wants (Part 2 of 3)</title>
+		<link>https://escapepod.org/2026/01/08/escape-pod-1027-what-any-dead-thing-wants-part-2-of-3/</link>
+		<pubDate>Thu, 08 Jan 2026 22:00:32 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15773</guid>
+		<comments>https://escapepod.org/2026/01/08/escape-pod-1027-what-any-dead-thing-wants-part-2-of-3/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/01/08/escape-pod-1027-what-any-dead-thing-wants-part-2-of-3/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Aimee Ogden]]></category>
+		<category><![CDATA[alien planet]]></category>
+		<category><![CDATA[ecosystem]]></category>
+		<category><![CDATA[exorcism]]></category>
+		<category><![CDATA[ghosts]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : Aimee Ogden Narrator : Isaac Harwood Host : Tina Connolly Audio Producer : Summer Brooks Copious helpings of harsh language descriptors found here. Don’t miss Part 1: Escape Pod 1026: What Any Dead Thing Wants (Part 1 of 3) What Any Dead Thing Wants (Part 2) by Aimee Ogden Quiet is a rare […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/01/08/escape-pod-1027-what-any-dead-thing-wants-part-2-of-3/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1027-WhatAnyDeadThingWants-Part2.mp3" length="59904691" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>41:15</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1026: What Any Dead Thing Wants (Part 1 of 3)</title>
+		<link>https://escapepod.org/2026/01/01/escape-pod-1026-what-any-dead-thing-wants-part-1-of-3/</link>
+		<pubDate>Thu, 01 Jan 2026 22:00:39 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15771</guid>
+		<comments>https://escapepod.org/2026/01/01/escape-pod-1026-what-any-dead-thing-wants-part-1-of-3/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2026/01/01/escape-pod-1026-what-any-dead-thing-wants-part-1-of-3/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Aimee Ogden]]></category>
+		<category><![CDATA[alien planet]]></category>
+		<category><![CDATA[ecosystem]]></category>
+		<category><![CDATA[exorcism]]></category>
+		<category><![CDATA[ghosts]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : Aimee Ogden Narrator : Isaac Harwood Host : Tina Connolly Audio Producer : Summer Brooks “What Any Dead Thing Wants” originally appeared in Psychopomp (February 2024) Copious helpings of harsh language descriptors found here. What Any Dead Thing Wants (Part 1) by Aimee Ogden The third week of a planetary exorcism is the […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2026/01/01/escape-pod-1026-what-any-dead-thing-wants-part-1-of-3/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1026-WhatAnyDeadThingWants-Part1.mp3" length="53138141" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>36:33</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1025: Samantha&#8217;s Diary (Flashback Friday)</title>
+		<link>https://escapepod.org/2025/12/25/escape-pod-1025-samanthas-diary-flashback-friday/</link>
+		<pubDate>Thu, 25 Dec 2025 22:00:49 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15768</guid>
+		<comments>https://escapepod.org/2025/12/25/escape-pod-1025-samanthas-diary-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/12/25/escape-pod-1025-samanthas-diary-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[OK for Kids]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[Christmas]]></category>
+		<category><![CDATA[Diana Wynne Jones]]></category>
+		<category><![CDATA[Emma Newman]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[holiday]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[xmas]]></category>
+		<description>Author : Diana Wynne Jones Narrator : Emma Newman Hosts : Mur Lafferty and Alasdair Stuart Audio Producers : Adam Pracht and Mat Weller Samantha’s Diary originally appeared in Stories: All-New Tales Edited by Neil Gaiman and Al Sarrantonio and on Escape Pod, episode 427 on December 22, 2013. Samantha’s Diary By Diana Wynne Jones Recorded on BSQ SpeekEasi […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/12/25/escape-pod-1025-samanthas-diary-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1025_Samanthas_Diary_Flashback_Friday.mp3" length="67469450" type="audio/mpeg" />
+		<itunes:author>Diana Wynne Jones (Author); Emma Newman (Narrators)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>46:26</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1024: Some Things I Should Probably Have Mentioned Earlier (LIVE) (Flashback)</title>
+		<link>https://escapepod.org/2025/12/18/escape-pod-1024-some-things-i-should-probably-have-mentioned-earlier-live-flashback/</link>
+		<pubDate>Thu, 18 Dec 2025 22:00:07 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15755</guid>
+		<comments>https://escapepod.org/2025/12/18/escape-pod-1024-some-things-i-should-probably-have-mentioned-earlier-live-flashback/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/12/18/escape-pod-1024-some-things-i-should-probably-have-mentioned-earlier-live-flashback/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[horror]]></category>
+		<category><![CDATA[Laura Pearlman]]></category>
+		<description>Author : Laura Pearlman Narrator : Laura Pearlman Hosts : Alasdair Stuart and Summer Fletcher Audio Producer : Summer Brooks This story was originally published in Mothership Zeta, May 2016, and republished in Escape Pod 650: Some Things I Probably Should Have Mentioned Earlier (LIVE) This is a live reading from Worldcon 2018. Some Things […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/12/18/escape-pod-1024-some-things-i-should-probably-have-mentioned-earlier-live-flashback/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1024-SomeThings-FlashbackFriday.mp3" length="39623349" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>27:10</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1023: Mackson&#8217;s Mardi Gras Moon Race</title>
+		<link>https://escapepod.org/2025/12/11/escape-pod-1023-macksons-mardi-gras-moon-race/</link>
+		<pubDate>Thu, 11 Dec 2025 22:00:26 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15737</guid>
+		<comments>https://escapepod.org/2025/12/11/escape-pod-1023-macksons-mardi-gras-moon-race/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/12/11/escape-pod-1023-macksons-mardi-gras-moon-race/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[holiday]]></category>
+		<category><![CDATA[Moon]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : David DeGraff Narrator : Brian Lieberman Host : Tina Connolly Audio Producer : Summer Brooks “Mackson’s Mardi Gras Moon Race” originally appeared in the Winter 2024 issue of The Magazine of Fantasy and Science Fiction. Mackson’s Mardi Gras Moon Race by David DeGraff Turtles were built for short-haul Lunar prospecting, not treks across […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/12/11/escape-pod-1023-macksons-mardi-gras-moon-race/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1023-MacksonsMardiGrasMoonRace.mp3" length="47484407" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>32:38</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1022: Butter Side Down (Part 2 of 2)</title>
+		<link>https://escapepod.org/2025/12/04/escape-pod-1022-butter-side-down-part-2-of-2/</link>
+		<pubDate>Thu, 04 Dec 2025 22:00:14 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15739</guid>
+		<comments>https://escapepod.org/2025/12/04/escape-pod-1022-butter-side-down-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/12/04/escape-pod-1022-butter-side-down-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[Dominick Rabrun]]></category>
+		<category><![CDATA[Eric Valdes]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[Kal M]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Author : Kal M Narrators : Valerie Valdes, Eric Valdes, Dominick Rabrun and Alasdair Stuart Host : Valerie Valdes Audio Producer : Adam Pracht Butter Side Down originally appeared in Writers of the Future (volume 40) – May 2024. Butter Side Down (Part 2 of 2) By Kal M   (…Continued from Part 1)   […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/12/04/escape-pod-1022-butter-side-down-part-2-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1022_Butter_Side_Down_Part_2.mp3" length="80816977" type="audio/mpeg" />
+		<itunes:author>Kal M (Author); Valerie Valdes, Eric Valdes, Dominick Rabrun, Alasdair Stuart (Narrators)</itunes:author>
+		<itunes:episode>1022</itunes:episode>
+		<podcast:episode>1022</podcast:episode>
+		<itunes:title>Escape Pod 1022: Butter Side Down (Part 2 of 2)</itunes:title>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>55:42</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1021: Butter Side Down (Part 1 of 2)</title>
+		<link>https://escapepod.org/2025/11/27/escape-pod-1021-butter-side-down-part-1-of-2/</link>
+		<pubDate>Thu, 27 Nov 2025 22:00:11 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15718</guid>
+		<comments>https://escapepod.org/2025/11/27/escape-pod-1021-butter-side-down-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/11/27/escape-pod-1021-butter-side-down-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[Dominick Rabrun]]></category>
+		<category><![CDATA[Eric Valdes]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[Kal M]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Author : Kal M Narrators : Valerie Valdes, Eric Valdes, Dominick Rabrun and Alasdair Stuart Host : Valerie Valdes Audio Producer : Adam Pracht Butter Side Down originally appeared in Writers of the Future (volume 40) – May 2024. Butter Side Down (Part 1 of 2) By Kal M DEPARTMENT OF LAW ENFORCEMENT CASE FILE […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/11/27/escape-pod-1021-butter-side-down-part-1-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/secure/escapepod/Escape_Pod_1021_Butter_Side_Down_Part_1.mp3" length="72587597" type="audio/mpeg" />
+		<itunes:author>Kal M (Author); Valerie Valdes, Eric Valdes, Dominick Rabrun, Alasdair Stuart (Narrators)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>50:04</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1020: When They Come Back (Flashback Friday)</title>
+		<link>https://escapepod.org/2025/11/20/escape-pod-1020-when-they-come-back-flashback-friday/</link>
+		<pubDate>Thu, 20 Nov 2025 22:00:54 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15712</guid>
+		<comments>https://escapepod.org/2025/11/20/escape-pod-1020-when-they-come-back-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/11/20/escape-pod-1020-when-they-come-back-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[stone]]></category>
+		<description>Author : Natalia Theodoridou Narrator : Ibba Armancas Host : Alasdair Stuart Audio Producer : Summer Brooks When They Come Back was originally published in Crossed Genres (Issue 22), in October 2014, and in Escape Pod Episode 550 Frank though not explicit reference to human sexual anatomy When They Come Back by Natalia Theodoridou They […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/11/20/escape-pod-1020-when-they-come-back-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/secure/escapepod/Escape_Pod_1020-WhenTheyComeBack-FlashbackFriday.mp3" length="44419687" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:51</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1019: Baron Quits The Payloaders</title>
+		<link>https://escapepod.org/2025/11/13/escape-pod-1019-baron-quits-the-payloaders/</link>
+		<pubDate>Thu, 13 Nov 2025 22:00:13 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15701</guid>
+		<comments>https://escapepod.org/2025/11/13/escape-pod-1019-baron-quits-the-payloaders/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/11/13/escape-pod-1019-baron-quits-the-payloaders/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[band]]></category>
+		<category><![CDATA[Ben Gideon]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[music]]></category>
+		<category><![CDATA[Renan Bernardo]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<category><![CDATA[transhumanism]]></category>
+		<description>Baron Quits The Payloaders
+By Renan Bernardo
+
+This story starts with a gig. Half a million people from all corners of the galaxy, hands in the air, heads banging to our vibrant noise. You probably saw the venue on some feed already. It’s the Amplitude, our spaceship, stage #3, the one with an enormous radiation-shielding dome over our heads. Right now, the glass glistens with Marzanna’s tannish and gaseous massiveness outside.
+
+This is also how the story ends for me. How I want it to end. With a blast and nothing more.</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/secure/escapepod/Escape_Pod_1019_Baron_Quits_The_Payloaders.mp3" length="72435155" type="audio/mpeg" />
+		<itunes:author>Renan Bernardo (Author); Ben Gideon (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>49:57</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1018: Knit Three, Save Four</title>
+		<link>https://escapepod.org/2025/11/06/escape-pod-1018-knit-three-save-four/</link>
+		<pubDate>Thu, 06 Nov 2025 22:00:04 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15695</guid>
+		<comments>https://escapepod.org/2025/11/06/escape-pod-1018-knit-three-save-four/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/11/06/escape-pod-1018-knit-three-save-four/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Marie Vibbert]]></category>
+		<category><![CDATA[space station]]></category>
+		<category><![CDATA[spaceship]]></category>
+		<description>Author : Marie Vibbert Narrator : Isabel J. Kim Host : Mur Lafferty Audio Producer : Summer Brooks “Knit Three, Save Four” first appeared in Fantasy &amp; Science Fiction (November 2019) Knit Three, Save Four by Marie Vibbert The ship was two days overdue for docking, more or less. As a stowaway, I didn’t have […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/11/06/escape-pod-1018-knit-three-save-four/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1018-KnitThreeSaveFour.mp3" length="53241586" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>36:38</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1017: The Love Pyramid: A Rocky Cornelius Consultancy</title>
+		<link>https://escapepod.org/2025/10/30/escape-pod-1017-the-love-pyramid-a-rocky-cornelius-consultancy/</link>
+		<pubDate>Thu, 30 Oct 2025 21:00:08 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15689</guid>
+		<comments>https://escapepod.org/2025/10/30/escape-pod-1017-the-love-pyramid-a-rocky-cornelius-consultancy/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/10/30/escape-pod-1017-the-love-pyramid-a-rocky-cornelius-consultancy/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Andrew Dana Hudson]]></category>
+		<category><![CDATA[fandom]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Rocky Cornelius Consultancy]]></category>
+		<category><![CDATA[sex]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>The Love Pyramid: A Rocky Cornelius Consultancy
+By Andrew Dana Hudson
+
+“What do you mean you aren’t fucking?” Rocky Cornelius demanded. “That’s terrible! This is going to throw your whole value prop out of whack!”
+
+The trio of button-cute narrative design prodigies glared back at her across the private jet with the anxious entitlement unique to twenty-two-year-old Bosto-Californian private school kids.
+
+“It’s not like it was intentional,” Edna pouted. “It just hasn’t come up.”</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/secure/escapepod/Escape_Pod_1017_The_Love_Pyramid_A_Rocky_Cornelius_Consultancy.mp3" length="68086763" type="audio/mpeg" />
+		<itunes:author>Andrew Dana Hudson (Author); Valerie Valdes (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>46:56</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1016: Valedictorian (Flashback Friday)</title>
+		<link>https://escapepod.org/2025/10/23/escape-pod-1016-valedictorian-flashback-friday/</link>
+		<pubDate>Thu, 23 Oct 2025 21:00:52 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15670</guid>
+		<comments>https://escapepod.org/2025/10/23/escape-pod-1016-valedictorian-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/10/23/escape-pod-1016-valedictorian-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[Education]]></category>
+		<category><![CDATA[N.K. Jemisin]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[rebellion]]></category>
+		<category><![CDATA[Stephanie Malia Morris]]></category>
+		<description>Author : N.K. Jemisin Narrator : Stephanie Malia Morris Host : Alasdair Stuart Audio Producer : Summer Brooks “Valedictorian” was originally published in After: Nineteen Stories of Apocalypse and Dystopia. It then appeared in Escape Pod 450, and in a Flashback Friday episode in Escape Pod 677 Valedictorian by N. K. Jemisin There are three […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/10/23/escape-pod-1016-valedictorian-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1016-Valedictorian-FlashbackFriday.mp3" length="72682604" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>48:48</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1015: Space Pirate Queen of the Ten Billion Utopias</title>
+		<link>https://escapepod.org/2025/10/16/escape-pod-1015-space-pirate-queen-of-the-ten-billion-utopias/</link>
+		<pubDate>Thu, 16 Oct 2025 21:00:16 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15668</guid>
+		<comments>https://escapepod.org/2025/10/16/escape-pod-1015-space-pirate-queen-of-the-ten-billion-utopias/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/10/16/escape-pod-1015-space-pirate-queen-of-the-ten-billion-utopias/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Christiana Ellis]]></category>
+		<category><![CDATA[Elly Bangs]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[multiverse]]></category>
+		<category><![CDATA[pirates]]></category>
+		<category><![CDATA[trains]]></category>
+		<description>Author : Elly Bangs Narrator : Christiana Ellis Host : Mur Lafferty Audio Producer : Summer Brooks “Space Pirate Queen of the Ten Billion Utopias” was first published in Lightspeed Magazine in November 2021 Copious amounts of casual strong language. This story was written in the summer of 2020, while the police were rioting and […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/10/16/escape-pod-1015-space-pirate-queen-of-the-ten-billion-utopias/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/escapepod/Escape_Pod_1015-SpacePirateQueenTenBillionUtopias.mp3" length="59356746" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>40:53</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1014: Here Instead of There (Part 2 of 2)</title>
+		<link>https://escapepod.org/2025/10/09/escape-pod-1014-here-instead-of-there-part-2-of-2/</link>
+		<pubDate>Thu, 09 Oct 2025 21:00:26 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15661</guid>
+		<comments>https://escapepod.org/2025/10/09/escape-pod-1014-here-instead-of-there-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/10/09/escape-pod-1014-here-instead-of-there-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[corporations]]></category>
+		<category><![CDATA[cyberpunk]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[Elizabeth Bear]]></category>
+		<category><![CDATA[Jess Lewis]]></category>
+		<category><![CDATA[punks]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[smart tech]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[weather]]></category>
+		<description>Here Instead of There (Part 2 of 2)
+By Elizabeth Bear
+
+(... Continued from Part 1)
+
+With the launch gone, there was just one rubber dinghy with an outboard motor stowed under the floor of the hangar, along with two kayaks, a sailboard, and a jet ski in an abjectly terrifying state of disrepair. There were twenty-three human souls on the pod, plus Henry.
+
+Doc and her wife went up and down the steads alerting our neighbors that they needed to clear out. By the time they came back, we’d gotten the fugs organized into evacuation groups. We packed six people into Doc’s boat, in a space meant for four. Four more into the dinghy with one girl who was sober enough to steer and seemed competent to run the motor.
+
+That left Kai, Miriam, Henry, me, and ten dirtbags. I didn’t even suggest that we give the Filth Is A Protest girl one of the kayaks and turn her loose, a level of self-restraint I was smugly proud of.</description>
+		<enclosure url="https://dts.podtrac.com/redirect.mp3/traffic.libsyn.com/secure/escapepod/Escape_Pod_1014_Here_Instead_of_There_Part_2_of_2.mp3" length="49949389" type="audio/mpeg" />
+		<itunes:author>Elizabeth Bear (Author); Jess Lewis (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>34:21</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1013: Here Instead of There (Part 1 of 2)</title>
+		<link>https://escapepod.org/2025/10/02/escape-pod-1013-here-instead-of-there-part-1-of-2/</link>
+		<pubDate>Thu, 02 Oct 2025 21:00:29 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15652</guid>
+		<comments>https://escapepod.org/2025/10/02/escape-pod-1013-here-instead-of-there-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/10/02/escape-pod-1013-here-instead-of-there-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[corporations]]></category>
+		<category><![CDATA[cyberpunk]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[Elizabeth Bear]]></category>
+		<category><![CDATA[Jess Lewis]]></category>
+		<category><![CDATA[punks]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[smart tech]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[weather]]></category>
+		<description>Here Instead of There
+By Elizabeth Bear
+
+Waking up sick in a punk house shouldn’t be a surprise to anybody so I don’t know why it always came as a surprise to me. My head throbbed so bad I couldn’t tell the difference between the hangover, my sinus headache, and Kai pummeling their drumset over in the yacht hangar.
+
+The Kai part also wasn’t unusual. The Crash’s drummer is our early riser. That’s the Devil’s pre-Hell punishment on us all. But even hungover, I never woke up with a head this full of pain.
+
+Henry must have seen me twitch, because five people racked out between me and the galley all said “Oof!” in a row. Suddenly my arms were full of wriggling beagle mutt and stank. At least the sov-cit types who left this pod a wreck before we squatted in it didn’t leave it full of fleas as well as trash and feces. (I choose to believe that the feces were from a dog rather than a toddler.) And there aren’t any ticks this far from shore.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_1013_Here_Instead_of_There_Part_1_of_2.mp3" length="45079956" type="audio/mpeg" />
+		<itunes:author>Elizabeth Bear (Author); Jess Lewis (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:58</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1012: Hot Bot Summer</title>
+		<link>https://escapepod.org/2025/09/25/escape-pod-1012-hot-bot-summer/</link>
+		<pubDate>Thu, 25 Sep 2025 21:00:03 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15642</guid>
+		<comments>https://escapepod.org/2025/09/25/escape-pod-1012-hot-bot-summer/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/09/25/escape-pod-1012-hot-bot-summer/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Rebecca Wei Hsieh]]></category>
+		<category><![CDATA[robots]]></category>
+		<description>Author : J. R. Dewitt Narrator : Rebecca Wei Hsieh Host : Tina Connolly Audio Producer : Summer Brooks Escape Pod 1012: Hot Bot Summer is an Escape Pod original. Contains depictions of war violence. Hot Bot Summer by J. R. Dewitt “God, these bots are gorgeous,” says Sergei as he snaps another photo. And even though […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/09/25/escape-pod-1012-hot-bot-summer/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_1012-HotBotSummer.mp3" length="65502000" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>45:09</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1011: Once Upon a Planet</title>
+		<link>https://escapepod.org/2025/09/18/escape-pod-1011-once-upon-a-planet/</link>
+		<pubDate>Thu, 18 Sep 2025 21:00:39 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15632</guid>
+		<comments>https://escapepod.org/2025/09/18/escape-pod-1011-once-upon-a-planet/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/09/18/escape-pod-1011-once-upon-a-planet/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[apocalypse]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[fairy tale]]></category>
+		<category><![CDATA[Kat Day]]></category>
+		<category><![CDATA[Kelsey Hutton]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[mythology]]></category>
+		<category><![CDATA[planet]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<description>Once Upon a Planet
+By Kelsey Hutton
+
+Once upon a time, there were three boring, totally normal planets lazily circling their sun.
+
+One was too hot. It spewed out venomous flames like a firebreather with something pokey stuck in her teeth—dangerously unpredictable, even for the daring.
+
+One was too cold. It was so cold even the ghosts got trapped there, growing more and more sluggish as their memories turned to ice. The lucky ones escaped off-planet into the relatively warm, radioactive embrace of space before they completely lost what made them cling to this mortal coil in the first place.
+
+The last one, as they say, was juuuuuuuuuust right.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_1011_Once_Upon_a_Planet.mp3" length="36493026" type="audio/mpeg" />
+		<itunes:author>Kelsey Hutton (Author); Kat Day (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>25:00</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1010: Grifting the Zaxonite</title>
+		<link>https://escapepod.org/2025/09/11/escape-pod-1010-grifting-the-zaxonite/</link>
+		<pubDate>Thu, 11 Sep 2025 21:00:12 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15604</guid>
+		<comments>https://escapepod.org/2025/09/11/escape-pod-1010-grifting-the-zaxonite/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/09/11/escape-pod-1010-grifting-the-zaxonite/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[alien invasion]]></category>
+		<description>Author : Cooper C. Wilms Narrator : Eric Valdes Host : Valerie Valdes Audio Producer : Summer Brooks Escape Pod 1010: Grifting the Zaxonite is an Escape Pod original. Grifting the Zaxonite by Cooper C. Wilms Of all the cons in his little black book, Trevor McKay liked his current grift the best. Small-fish stunts […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/09/11/escape-pod-1010-grifting-the-zaxonite/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_1010-GriftingtheZaxonite.mp3" length="26033070" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>17:44</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1009: The Combat Pilot&#8217;s Dictionary</title>
+		<link>https://escapepod.org/2025/09/04/escape-pod-1009-the-combat-pilots-dictionary/</link>
+		<pubDate>Thu, 04 Sep 2025 21:00:34 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15596</guid>
+		<comments>https://escapepod.org/2025/09/04/escape-pod-1009-the-combat-pilots-dictionary/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/09/04/escape-pod-1009-the-combat-pilots-dictionary/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Arden Baker]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[Jess Lewis]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[Mars]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[spaceship]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[war]]></category>
+		<description>The Combat Pilot&#039;s Dictionary
+By Arden Baker
+
+Boot
+
+Rookie pilot. See also - nugget.
+
+You called us ‘boots’ when we turned up to the flight deck that first morning I laid eyes on you.
+
+The halogen lighting shone down onto the makeshift parade ground with a harsh insistence matched only by your loud drill calls.
+
+You looked the part. Milspec features matched with an impeccably pressed grey uniform. Hair shorn close to the scalp to fit the Z94-OptiGuard Quiklok Aerospace Aviation Helmet that you wore in combat. Broad shoulders and piercing eyes. Tall and built like a true Martian. Rust in your blood.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_1009_The_Combat_Pilots_Dictionary.mp3" length="45913514" type="audio/mpeg" />
+		<itunes:author>Arden Baker (Author); Jess Lewis (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>31:32</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1008: Observer Effects (Flashback Friday)</title>
+		<link>https://escapepod.org/2025/08/28/escape-pod-1008-observer-effects-flashback-friday/</link>
+		<pubDate>Thu, 28 Aug 2025 21:00:40 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15584</guid>
+		<comments>https://escapepod.org/2025/08/28/escape-pod-1008-observer-effects-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/08/28/escape-pod-1008-observer-effects-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[A Kovacs]]></category>
+		<category><![CDATA[privacy]]></category>
+		<category><![CDATA[superheroes]]></category>
+		<category><![CDATA[surveillance]]></category>
+		<category><![CDATA[Tim Pratt]]></category>
+		<description>Author : Tim Pratt Narrator : A Kovacs Host : Alasdair Stuart Audio Producer : Summer Brooks “Observer Effects” originally appeared in Diet Soap (2007), and was originally presented in Escape Pod 350 Contains harsh language Escape Pod is proud to say that we have partnered with Sleepphones headphones to provide a special Escape Pod […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/08/28/escape-pod-1008-observer-effects-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_1008-ObserverEffects-FlashbackFriday.mp3" length="45250624" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>31:05</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1007: 35 / F / Lane&#8217;s Creek, Oklahoma</title>
+		<link>https://escapepod.org/2025/08/21/escape-pod-1007-35-f-lanes-creek-oklahoma/</link>
+		<pubDate>Thu, 21 Aug 2025 21:00:07 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15578</guid>
+		<comments>https://escapepod.org/2025/08/21/escape-pod-1007-35-f-lanes-creek-oklahoma/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/08/21/escape-pod-1007-35-f-lanes-creek-oklahoma/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[drone]]></category>
+		<category><![CDATA[Hans Ege Wenger]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Queer]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[robots]]></category>
+		<category><![CDATA[romance]]></category>
+		<category><![CDATA[Sevatividam]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>35 / F / Lane&#039;s Creek, Oklahoma
+By Hans Ege Wenger
+
+Sandra loaded. Boxes and pallets, mostly. Full of avocados, computer chips, plastic toys, etc. All carefully placed by her rubber-faced grippers into the trucks that darted in and out of the warehouse bays.
+
+On a good day, Sandra loaded something interesting. A heavy, oddly shaped package, requiring her to adjust her first person view goggles and sit forward in her chair, lips pursed in concentration. Or a tantalizing, vacuum-packed parcel bound for near Earth orbit. Once, an opaque tank, filled with flickering red-black fish. It brought a little variety to a day viewed through the cameras of a four-foot-tall, yellow robot.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_1007_35_F_Lanes_Creek_Oklahoma.mp3" length="49356282" type="audio/mpeg" />
+		<itunes:author>Hans Ege Wenger (Author); Sevatividam (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>33:56</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1006: When the Oracle Speaks (Part 2 of 2)</title>
+		<link>https://escapepod.org/2025/08/14/escape-pod-1006-when-the-oracle-speaks-part-2-of-2/</link>
+		<pubDate>Thu, 14 Aug 2025 21:00:42 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15560</guid>
+		<comments>https://escapepod.org/2025/08/14/escape-pod-1006-when-the-oracle-speaks-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/08/14/escape-pod-1006-when-the-oracle-speaks-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[espionage]]></category>
+		<category><![CDATA[Hugo Jackson]]></category>
+		<category><![CDATA[interplanetary politics]]></category>
+		<category><![CDATA[space]]></category>
+		<description>Author : Albert Chu Narrator : Hugo Jackson Host : Valerie Valdes Audio Producer : Summer Brooks “When the Oracle Speaks” was first published in Metaphororsis, July 2023 When the Oracle Speaks (Part 2) by Albert Chu Outside the warehouse, the rain fell in sheets. It whipped the Azure River into a frenzy, and the […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/08/14/escape-pod-1006-when-the-oracle-speaks-part-2-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_1006-WhentheOracleSpeaks-Pt2.mp3" length="53543770" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>36:50</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1005: When the Oracle Speaks (Part 1 of 2)</title>
+		<link>https://escapepod.org/2025/08/07/escape-pod-1005-when-the-oracle-speaks-part-1-of-2/</link>
+		<pubDate>Thu, 07 Aug 2025 21:00:35 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15558</guid>
+		<comments>https://escapepod.org/2025/08/07/escape-pod-1005-when-the-oracle-speaks-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/08/07/escape-pod-1005-when-the-oracle-speaks-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[espionage]]></category>
+		<category><![CDATA[Hugo Jackson]]></category>
+		<category><![CDATA[interplanetary politics]]></category>
+		<category><![CDATA[space]]></category>
+		<description>Author : Albert Chu Narrator : Hugo Jackson Host : Valerie Valdes Audio Producer : Summer Brooks “When the Oracle Speaks” was first published in Metaphororsis, July 2023 When the Oracle Speaks (Part 1) by Albert Chu One year after the war’s end, the royal court welcomed a hundred orphan boys into our ranks. They […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/08/07/escape-pod-1005-when-the-oracle-speaks-part-1-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_1005-WhentheOracleSpeaks-Pt1.mp3" length="45444975" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>31:13</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1004: The Girl Who Came Before</title>
+		<link>https://escapepod.org/2025/07/31/escape-pod-1004-the-girl-who-came-before/</link>
+		<pubDate>Thu, 31 Jul 2025 21:00:34 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15547</guid>
+		<comments>https://escapepod.org/2025/07/31/escape-pod-1004-the-girl-who-came-before/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/07/31/escape-pod-1004-the-girl-who-came-before/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[cloning]]></category>
+		<category><![CDATA[David von Allmen]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[medical]]></category>
+		<category><![CDATA[Pine Gonzalez]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>The Girl Who Came Before
+By David von Allmen
+
+When me and my family pulled into our driveway, my five best friends were waiting in our front yard, waving glittery poster-board signs that read “Welcome Home Sam!!!” and jumping around with full-on 13 year-old girl dorkiness.
+
+It should have made me happy.
+
+And it did. For the most part. It was all I’d wanted for the last year: to hang out with my friends somewhere other than a hospital room and go to school and talk without an oxygen tube in my nose.
+
+But they weren’t my friends. Not really. They were her friends. The old Sam, the girl my body had been cloned from, the girl whose memories had been printed onto my brain. The girl whose life I was now supposed to live.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_1004_The_Girl_Who_Came_Before.mp3" length="43641106" type="audio/mpeg" />
+		<itunes:author>David von Allmen (Author); Pine Gonzalez (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>29:58</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1003: Billionaire&#8217;s Tears</title>
+		<link>https://escapepod.org/2025/07/24/escape-pod-1003-billionaires-tears/</link>
+		<pubDate>Thu, 24 Jul 2025 21:00:57 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15540</guid>
+		<comments>https://escapepod.org/2025/07/24/escape-pod-1003-billionaires-tears/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/07/24/escape-pod-1003-billionaires-tears/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[disease]]></category>
+		<category><![CDATA[economics]]></category>
+		<category><![CDATA[money]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[Vanessa Ricci-Thode]]></category>
+		<description>Billionaire&#039;s Tears
+By Vanessa Ricci-Thode
+
+I wake up to the sound of screaming, and know I’m going to die.
+
+I shoot out of bed, calling for my mother. First thing I’ve spoken clearly in two days.
+
+“Maria!” My mother bursts into my room. “Baby, what’s wrong?”
+
+“S-sorry, Mamma,” I whisper, frantically searching for the right syllables so I don’t trip over them and give it all away. I can’t let Mamma suspect I’m dying—or how soon it’ll happen. “Nightmares.”
+
+Mamma’s smile is sad. The world’s finally getting better, but not for everyone. For us, still struggling, it’s like it’s only getting worse. Everyone in the family has been having nightmares. But when Mamma accepts my explanation and doesn’t seem bothered by the screaming that surrounds us and has not stopped, to me, anyway, that’s when I know. I have a week tops if I’m lucky.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_1003_Billionaires_Tears.mp3" length="50537082" type="audio/mpeg" />
+		<itunes:author>Vanessa Ricci-Thode (Author); Valerie Valdes (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>34:45</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1002: Tigers for Sale</title>
+		<link>https://escapepod.org/2025/07/17/escape-pod-1002-tigers-for-sale/</link>
+		<pubDate>Thu, 17 Jul 2025 21:00:44 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15530</guid>
+		<comments>https://escapepod.org/2025/07/17/escape-pod-1002-tigers-for-sale/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/07/17/escape-pod-1002-tigers-for-sale/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space station]]></category>
+		<description>Author : Risa Wolf Narrator : Julia Rios Host : Tina Connolly Audio Producer : Summer Brooks Tigers for Sale was first published in Clarkesworld Magazine in July 2023 Content warnings: colonialism, implied genocide, psychological manipulation Tigers for Sale by Risa Wolf Past the sparrow-dark dust fields of Far Euniply, at the edge of the […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/07/17/escape-pod-1002-tigers-for-sale/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_1002-TigersforSale.mp3" length="87165243" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>1:00:11</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1001: Death by Pink in the Lollipop Apocalypse</title>
+		<link>https://escapepod.org/2025/07/10/escape-pod-1001-death-by-pink-in-the-lollipop-apocalypse/</link>
+		<pubDate>Thu, 10 Jul 2025 21:00:09 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15526</guid>
+		<comments>https://escapepod.org/2025/07/10/escape-pod-1001-death-by-pink-in-the-lollipop-apocalypse/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/07/10/escape-pod-1001-death-by-pink-in-the-lollipop-apocalypse/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[apocalypse]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[Ryan Cole]]></category>
+		<category><![CDATA[Tatiana Grey]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<category><![CDATA[YA / Young Adult]]></category>
+		<description>Death by Pink in the Lollipop Apocalypse
+By Ryan Cole
+
+In the dark of her bed, curled up in her sheets, Susie tried to hide from the next few days and the reckoning they’d bring: of prom and graduation and the dozens of goodbyes she’d have to force herself to say, wishing she could follow. No college escape. Her applications rejected. Not to mention that she’d been bragging for months—to Piper and all her other refugee friends—about the fake acceptance letter from Delaware State, and the phony full-ride, and the lie that she’d be rooming with Piper in the fall, just like they’d always wanted, two peas in a pod.
+
+Which made her want to run—like Dad always did. But she couldn’t be like him. Couldn’t leave when his only child needed him most. When the city they’d fled—along with half a million others—was buried in a thick layer of saccharine crust. A crust that devoured every street, every house, every skyscraper standing like a hollowed-out lollipop, that only kept spreading, kept crushing every straggler that lay in its path, as relentless as a river and impenetrable as stone.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_1001_Death_by_Pink_in_the_Lollipop_Apocalypse.mp3" length="56740348" type="audio/mpeg" />
+		<itunes:author>Ryan Cole (Author); Tatiana Grey (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:03</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 1000: A Thousand Names for God and Infinite Mustard</title>
+		<link>https://escapepod.org/2025/07/03/escape-pod-1000-a-thousand-names-for-god-and-infinite-mustard/</link>
+		<pubDate>Thu, 03 Jul 2025 21:00:39 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15515</guid>
+		<comments>https://escapepod.org/2025/07/03/escape-pod-1000-a-thousand-names-for-god-and-infinite-mustard/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/07/03/escape-pod-1000-a-thousand-names-for-god-and-infinite-mustard/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[god]]></category>
+		<category><![CDATA[space exploration]]></category>
+		<description>Author : Matt Wallace Narrator : Mur Lafferty Host : Valerie Valdes Audio Producer : Summer Brooks Escape Pod 1000: A Thousand Names for God and Infinite Mustard is an Escape Pod original. Contains some harsh language A Thousand Names for God and Infinite Mustard by Matt Wallace Kimo found God hiding out inside a […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/07/03/escape-pod-1000-a-thousand-names-for-god-and-infinite-mustard/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_1000-AThousandNamesforGod.mp3" length="44333412" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:27</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 999: Eros, Philia, Agape (Flashback Friday)</title>
+		<link>https://escapepod.org/2025/06/26/escape-pod-999-eros-philia-agape-flashback-friday/</link>
+		<pubDate>Thu, 26 Jun 2025 21:00:04 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15511</guid>
+		<comments>https://escapepod.org/2025/06/26/escape-pod-999-eros-philia-agape-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/06/26/escape-pod-999-eros-philia-agape-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[Children]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Norm Sherman]]></category>
+		<category><![CDATA[novella]]></category>
+		<category><![CDATA[rachel swirsky]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[romance]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>Eros, Philia, Agape (Excerpt)
+By Rachel Swirsky
+
+The objects belonged to them both, but Adriana waved her hand bitterly when Lucian began packing. “Take whatever you want,” she said, snapping her book shut. She waited by the door, watching Lucian with sad and angry eyes.
+
+Their daughter, Rose, followed Lucian around the house. “Are you going to take that, Daddy? Do you want that?” Wordlessly, Lucian held her hand. He guided her up the stairs and across the uneven floorboards where she sometimes tripped. Rose stopped by the picture window in the master bedroom, staring past the palm fronds and swimming pools, out to the vivid cerulean swath of the ocean. Lucian relished the hot, tender feel of Rose’s hand. I love you, he would have whispered, but he’d surrendered the ability to speak.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_999_Eros_Philia_Agape_Flashback_Friday.mp3" length="107757002" type="audio/mpeg" />
+		<itunes:author>Rachel Swirsky (Author); Mur Lafferty (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>1:14:29</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 998: The Carina Nebula</title>
+		<link>https://escapepod.org/2025/06/19/escape-pod-998-the-carina-nebula/</link>
+		<pubDate>Thu, 19 Jun 2025 21:00:27 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15497</guid>
+		<comments>https://escapepod.org/2025/06/19/escape-pod-998-the-carina-nebula/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/06/19/escape-pod-998-the-carina-nebula/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[Kelsey Hutton]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Samantha Loney]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<category><![CDATA[YA / Young Adult]]></category>
+		<description>The Carina Nebula
+By Kelsey Hutton
+
+I heard the soft shit shit shit just when I’d almost floated past the blue hatch door that led into some kind of storage room. I had to laugh. I mean, how many times have I said that? Plus the voice sounded older, a woman’s, and I love when adults just say what they mean, instead of carefully guarding every word around “the kids.”
+
+I wasn’t really doing much, just wandering through some of the ship’s back tunnels. So I reached out right before momentum took me past the hatch and grabbed onto the cool metal. I pulled myself back and shook my head side to side a little to clear away my clouds of dark hair.
+
+We were in zero G these days, and like, I knew that tying my hair back was probably the smarter decision when zooming around, but whatever. My hair was kinda curly, kinda wavey, with some straight pieces thrown in for kicks. The sculptures it made floating around my head was probably my best feature, so hair ties be damned.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_998_The_Carina_Nebula.mp3" length="67482946" type="audio/mpeg" />
+		<itunes:author>Kelsey Hutton (Author); Samantha Loney (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>46:31</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 997: Sanctuary, Part 2 of 2</title>
+		<link>https://escapepod.org/2025/06/12/escape-pod-997-sanctuary-part-2-of-2/</link>
+		<pubDate>Thu, 12 Jun 2025 21:00:20 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15483</guid>
+		<comments>https://escapepod.org/2025/06/12/escape-pod-997-sanctuary-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/06/12/escape-pod-997-sanctuary-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[android]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[interplanetary politics]]></category>
+		<category><![CDATA[Space Operas]]></category>
+		<description>Author : Alexis Ames Narrator : Eric Valdes Host : Valerie Valdes Audio Producer : Summer Brooks “Sanctuary” first appeared in Kyanite Press, Winter 2020 Don’t miss “Sanctuary, Part 1” Sanctuary (Part 2) by Alexis Ames 3. Eilan slept for thirteen uneventful hours while I sat at the helm and wondered if it was possible […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/06/12/escape-pod-997-sanctuary-part-2-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_997-Sanctuary-Pt2of2.mp3" length="63945311" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>44:04</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 996: Sanctuary, Part 1 of 2</title>
+		<link>https://escapepod.org/2025/06/05/escape-pod-996-sanctuary-part-1-of-2/</link>
+		<pubDate>Thu, 05 Jun 2025 21:00:20 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15480</guid>
+		<comments>https://escapepod.org/2025/06/05/escape-pod-996-sanctuary-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/06/05/escape-pod-996-sanctuary-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[android]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[interplanetary politics]]></category>
+		<category><![CDATA[Space Operas]]></category>
+		<description>Author : Alexis Ames Narrator : Eric Valdes Host : Valerie Valdes Audio Producer : Summer Brooks “Sanctuary” first appeared in Kyanite Press, Winter 2020 Sanctuary (Part 1) by Alexis Ames 1. The king of the galaxy died the day before the biggest holiday of the year, and six hours before I was supposed to […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/06/05/escape-pod-996-sanctuary-part-1-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_996-Sanctuary-Pt1of2.mp3" length="50248580" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>34:33</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 995: This, My Body (Flashback Friday)</title>
+		<link>https://escapepod.org/2025/05/29/escape-pod-995-this-my-body-flashback-friday/</link>
+		<pubDate>Thu, 29 May 2025 21:00:28 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15469</guid>
+		<comments>https://escapepod.org/2025/05/29/escape-pod-995-this-my-body-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/05/29/escape-pod-995-this-my-body-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[erotica]]></category>
+		<category><![CDATA[food]]></category>
+		<category><![CDATA[genetic engineering]]></category>
+		<category><![CDATA[Jeremiah Tolbert]]></category>
+		<category><![CDATA[NSFW]]></category>
+		<category><![CDATA[serah eley]]></category>
+		<category><![CDATA[sex]]></category>
+		<description>This, My Body
+By Jeremiah Tolbert
+
+I am the lover. I am the chef. I am the preterite priest.
+
+I am the secret, unknowable ingredient. You may taste me a thousand times, but never hold my essence on your tongue or capture it in your memory.
+
+I am the flavor of ecstasy. Taste me and know God.
+–Prayer of the Assaisonnement Saints</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_995_This_My_Body_Flashback_Friday.mp3" length="95024474" type="audio/mpeg" />
+		<itunes:author>Jeremiah Tolbert (Author); Serah Eley (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>1:05:39</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 994: Magical Girl Antifa War Machine</title>
+		<link>https://escapepod.org/2025/05/22/escape-pod-994-magical-girl-antifa-war-machine/</link>
+		<pubDate>Thu, 22 May 2025 21:00:56 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15457</guid>
+		<comments>https://escapepod.org/2025/05/22/escape-pod-994-magical-girl-antifa-war-machine/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/05/22/escape-pod-994-magical-girl-antifa-war-machine/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Erotica - NOT FOR KIDS]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[apocalyptic]]></category>
+		<category><![CDATA[BDSM]]></category>
+		<category><![CDATA[erotica]]></category>
+		<category><![CDATA[Esther Alter]]></category>
+		<category><![CDATA[Hugo Jackson]]></category>
+		<category><![CDATA[Jess Lewis]]></category>
+		<category><![CDATA[Joe Moran]]></category>
+		<category><![CDATA[magic]]></category>
+		<category><![CDATA[NSFW]]></category>
+		<category><![CDATA[Queer]]></category>
+		<category><![CDATA[revenge]]></category>
+		<category><![CDATA[romance]]></category>
+		<category><![CDATA[serah eley]]></category>
+		<category><![CDATA[superhero]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[transgender]]></category>
+		<category><![CDATA[transhumanism]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[Violence]]></category>
+		<description>Magical Girl Antifa War Machine
+By Esther Alter
+
+XYLIA
+
+We were at the bottom of a hole, a new construction site that went deep into the bedrock. I was the first to touch the artifact, a thing that didn’t quite have shape or color. I grabbed it. My new consciousness slammed into my mind so fast that there was just enough time for only one last wholly-human thought: You’re a girl, you fucking idiot.
+
+My new form was sleek. Mathematically perfectly curved. Hyperfeminine in the truest sense. Breasts extending into six dimensions. A tall, lithe, highly reflective body. A smooth face with eyes burning with seductive rage. And strength, immense strength. I flexed and felt a distant star flicker a warning.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_994_Magical_Girl_Antifa_War_Machine.mp3" length="52308520" type="audio/mpeg" />
+		<itunes:author>Esther Alter (Author); Hugo Jackson, Jess Lewis, Serah Eley, Joe Moran (Narrators)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>35:59</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 993: That Thing With Bob and the Crop Circles</title>
+		<link>https://escapepod.org/2025/05/15/escape-pod-993-that-thing-with-bob-and-the-crop-circles/</link>
+		<pubDate>Thu, 15 May 2025 21:00:32 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15437</guid>
+		<comments>https://escapepod.org/2025/05/15/escape-pod-993-that-thing-with-bob-and-the-crop-circles/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/05/15/escape-pod-993-that-thing-with-bob-and-the-crop-circles/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[interspecies communication]]></category>
+		<category><![CDATA[science]]></category>
+		<description>Author : T. Kingfisher Narrator : Kevin M. Hayes Host : Mur Lafferty Audio Producer : Summer Brooks Escape Pod 993: That Thing With Bob and the Crop Circles is an Escape Pod original. That Thing With Bob and the Crop Circles by T. Kingfisher So last Tuesday, long about noon, I found myself down […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/05/15/escape-pod-993-that-thing-with-bob-and-the-crop-circles/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_993-ThatThingWithBobandtheCropCircles.mp3" length="43995492" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:13</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 992: Nerves Into Circuits</title>
+		<link>https://escapepod.org/2025/05/08/escape-pod-992-nerves-into-circuits/</link>
+		<pubDate>Thu, 08 May 2025 21:00:55 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15434</guid>
+		<comments>https://escapepod.org/2025/05/08/escape-pod-992-nerves-into-circuits/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/05/08/escape-pod-992-nerves-into-circuits/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[battle mech]]></category>
+		<category><![CDATA[disability]]></category>
+		<category><![CDATA[Lyra Meurer]]></category>
+		<category><![CDATA[mech]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Rosie Sentman]]></category>
+		<category><![CDATA[superhero]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[war]]></category>
+		<description>Nerves Into Circuits
+By Lyra Meurer
+
+Metal arms descend to press skin-soft conductor strips over my shoulders. The Neurasuit has been in warming mode for a few minutes–my overwrought senses accept the lines of heat like a gift. Despite my anxiety for the fight, my trapezius muscles relax, creaking in the silence. Released from the tension, my vertebrae settle into place with small snaps, one or two with each breath.
+
+Wires snake through my hair, massaging the scalp pain I didn’t notice was there. More swirl around my neck, tickle between my toes, seeking the overabundant bristles of my nerves. The Neurasuit folds around me with a hiss and a click, shutting out the cold night air. Before the systems launch, before the fight begins, I have a moment of perfect comfort in a little space built for me.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_992_Nerves_Into_Circuits.mp3" length="38871956" type="audio/mpeg" />
+		<itunes:author>Lyra Meurer (Author); Rosie Sentman (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>26:39</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 991: After the Rain</title>
+		<link>https://escapepod.org/2025/05/01/escape-pod-991-after-the-rain/</link>
+		<pubDate>Thu, 01 May 2025 21:00:32 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15405</guid>
+		<comments>https://escapepod.org/2025/05/01/escape-pod-991-after-the-rain/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/05/01/escape-pod-991-after-the-rain/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[climate]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<description>Author : P. A. Cornell Narrator : Isabel J. Kim Host : Mur Lafferty Audio Producer : Summer Brooks Escape Pod 991: After the Rain is an Escape Pod original. After the Rain by P. A. Cornell I love a heavy summer storm. I love it when the rain falls so suddenly there’s no avoiding […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/05/01/escape-pod-991-after-the-rain/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_991-AftertheRain.mp3" length="37496645" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>25:42</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 990: The Malcontent (Flashback Friday)</title>
+		<link>https://escapepod.org/2025/04/24/escape-pod-990-the-malcontent-flashback-friday/</link>
+		<pubDate>Thu, 24 Apr 2025 21:00:08 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15403</guid>
+		<comments>https://escapepod.org/2025/04/24/escape-pod-990-the-malcontent-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/04/24/escape-pod-990-the-malcontent-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[Paul S Jenkins]]></category>
+		<category><![CDATA[robots]]></category>
+		<category><![CDATA[serah eley]]></category>
+		<description>Author : Serah Eley Narrator : Paul S. Jenkins Host : Alasdair Stuart Audio Producer : Summer Brooks “The Malcontent” was originally published in Escape Pod 50 (April 2006) The Malcontent by Serah Eley Finally Nicholas summoned his overseers and all other servants who were mobile to his chamber. “You are merely robots,” Nicholas said, […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/04/24/escape-pod-990-the-malcontent-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_990-TheMalcontent-FlashbackFriday.mp3" length="43521527" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>29:53</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 989: Holding Patterns</title>
+		<link>https://escapepod.org/2025/04/17/escape-pod-989-holding-patterns/</link>
+		<pubDate>Thu, 17 Apr 2025 21:00:00 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15396</guid>
+		<comments>https://escapepod.org/2025/04/17/escape-pod-989-holding-patterns/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/04/17/escape-pod-989-holding-patterns/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[art]]></category>
+		<category><![CDATA[colonists]]></category>
+		<category><![CDATA[Jennifer Hudak]]></category>
+		<category><![CDATA[Kat Kourbeti]]></category>
+		<category><![CDATA[romance]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[space exploration]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<category><![CDATA[tree]]></category>
+		<category><![CDATA[YA / Young Adult]]></category>
+		<description>Holding Patterns
+By Jennifer Hudak
+
+I dream about the trees sometimes. I think we all do, even though none of my generation were alive when the forest was actually growing. We don’t dream about them the way they are now—stunted and dormant—but the way they were when the first colonists arrived here on Ariadne: pale smooth trunks growing straight and true, latticed with ropy, red-leafed vines that cradled the heavy fruit dangling off the branches. The canopy towering dozens of meters overhead, everything quiet and lush and smelling of damp. People say that back then, you could watch the trees growing in real time, budding branches and unfurling leaves. Even in the vids and holos they show us in school, the trees look so sturdy, so real—so permanent—that you could forgive someone for believing that they’d grow forever.
+
+But the trees here want something we can’t give them—some murmur of information, an arboreal greeting, the plant equivalent of a rough hug and a shouted Hello! Good to see you! They’re waiting for something that will never happen.
+
+Just like us.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_989_Holding_Patterns.mp3" length="53077135" type="audio/mpeg" />
+		<itunes:author>Jennifer Hudak (Author); Kat Kourbeti (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>36:31</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 988: In the Palace of Science (Part 2 of 2)</title>
+		<link>https://escapepod.org/2025/04/10/escape-pod-988-in-the-palace-of-science-part-2-of-2/</link>
+		<pubDate>Thu, 10 Apr 2025 21:00:35 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15382</guid>
+		<comments>https://escapepod.org/2025/04/10/escape-pod-988-in-the-palace-of-science-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/04/10/escape-pod-988-in-the-palace-of-science-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Chris Campbell]]></category>
+		<category><![CDATA[Dominick Rabrun]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[research]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[steampunk]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>In the Palace of Science (Part 2 of 2)
+By Chris Campbell
+
+(...Continued from Part 1)
+
+B-Side
+
+
+
+
+Track Five–
+
+
+
+
+The automaton was unfinished, but even in a transitory state, it was a thing of marvel. In form, it was like a man. With two legs meant for bipedal ambulation and two arms with three-fingered hands meant for grasping. Although roughly, from the thickness of its fingers. The design of the machine differed most strikingly from the ideal human in the shape of its head and body, for it had no neck. Rather, a barrel-shaped torso attached directly to a head that was meant to be enclosed within the thick, vaguely egg-shaped glass dome sitting next to the machine.
+
+The front piece of the barrel-shaped body was also set aside on a nearby table, exposing its chassis and internal mechanism. Peering inside, it became clear that filling the hole within this hollow man was the singular aim of much of the work I’d been doing for years.
+
+“I call him Talos.”</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_988_In_the_Palace_of_Science_Part_2.mp3" length="62360896" type="audio/mpeg" />
+		<itunes:author>Chris Campbell (Author); Dominick Rabrun (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>42:58</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 987: In the Palace of Science (Part 1 of 2)</title>
+		<link>https://escapepod.org/2025/04/03/escape-pod-987-in-the-palace-of-science-part-1-of-2/</link>
+		<pubDate>Thu, 03 Apr 2025 21:00:06 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15374</guid>
+		<comments>https://escapepod.org/2025/04/03/escape-pod-987-in-the-palace-of-science-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/04/03/escape-pod-987-in-the-palace-of-science-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Chris Campbell]]></category>
+		<category><![CDATA[Dominick Rabrun]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[research]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[steampunk]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>In the Palace of Science (Part 1 of 2)
+By Chris Campbell
+
+Track One–
+
+
+
+
+If you’ve found this recording, two things can be said for certain. The first is that I have passed my greatest test as a man and, in doing so, have passed from this world. The second is that if this message entombed with me survives, a grave danger to humanity most assuredly survives with it.
+
+To my listener, I urge you to lift the needle from the gramophone, return this plate to the hole where you found it, and dig no further into the ruins where once stood Professor Thomas Washington Kelly’s Palace of Science.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_987_In_the_Palace_of_Science_Part_1.mp3" length="54644456" type="audio/mpeg" />
+		<itunes:author>Chris Campbell (Author); Dominick Rabrun (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>37:36</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 986: Lyra, From Many Angles</title>
+		<link>https://escapepod.org/2025/03/27/escape-pod-986-lyra-from-many-angles/</link>
+		<pubDate>Thu, 27 Mar 2025 21:00:00 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15350</guid>
+		<comments>https://escapepod.org/2025/03/27/escape-pod-986-lyra-from-many-angles/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/03/27/escape-pod-986-lyra-from-many-angles/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[alien language]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[experiments]]></category>
+		<category><![CDATA[interspecies communication]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Tatiana Grey]]></category>
+		<description>Author : Hiron Ennes Narrator : Tatiana Grey Host : Mur Lafferty Audio Producer : Summer Brooks Escape Pod 986: Lyra, From Many Angles is an Escape Pod original. Lyra, From Many Angles by Hiron Ennes When they came, it was in a craft the size of a golf ball. Smooth and round and perfectly […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/03/27/escape-pod-986-lyra-from-many-angles/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_986-LyraFromManyAngles.mp3" length="73066644" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>50:24</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 985: The Interdimensional Rift at the Lucky Sunrise Bingo Palace</title>
+		<link>https://escapepod.org/2025/03/20/escape-pod-985-the-interdimensional-rift-at-the-lucky-sunrise-bingo-palace/</link>
+		<pubDate>Thu, 20 Mar 2025 21:00:07 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15347</guid>
+		<comments>https://escapepod.org/2025/03/20/escape-pod-985-the-interdimensional-rift-at-the-lucky-sunrise-bingo-palace/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/03/20/escape-pod-985-the-interdimensional-rift-at-the-lucky-sunrise-bingo-palace/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Elie Hirschman]]></category>
+		<category><![CDATA[gambling]]></category>
+		<category><![CDATA[grandfather]]></category>
+		<category><![CDATA[multi dimensional]]></category>
+		<category><![CDATA[Queer]]></category>
+		<description>Author : Ryan Cole Narrator : Elie Hirschman Host : Tina Connolly Audio Producer : Summer Brooks Escape Pod 985: The Interdimensional Rift at the Lucky Sunrise Bingo Palace is an Escape Pod original. The Interdimensional Rift at the Lucky Sunrise Bingo Palace by Ryan Cole So I’m sitting there with Bubbee—the two of us […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/03/20/escape-pod-985-the-interdimensional-rift-at-the-lucky-sunrise-bingo-palace/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_985-InterdimensionalRiftLuckyPalaceBingo.mp3" length="42396172" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>29:06</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 984: Imperial (Flashback Friday)</title>
+		<link>https://escapepod.org/2025/03/13/escape-pod-984-imperial-flashback-friday/</link>
+		<pubDate>Thu, 13 Mar 2025 21:00:31 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15342</guid>
+		<comments>https://escapepod.org/2025/03/13/escape-pod-984-imperial-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/03/13/escape-pod-984-imperial-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[alien]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[bioengineering]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[jonathon sullivan]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[serah eley]]></category>
+		<category><![CDATA[space]]></category>
+		<description>Imperial
+By Jonathon Sullivan
+
+(Excerpt)
+
+Dennis blinked through his dripping eyelashes at the irresistible abomination seated on the blue-green grass two meters in front of him. The Pig smiled her bio-engineered leopard-smile at him and kept her right hand prominently in contact with the stun-gun at her hip.
+
+He stared, too choked with shock, desire and tepid river water to speak.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_984_Imperial_Flashback_Friday.mp3" length="65407025" type="audio/mpeg" />
+		<itunes:author>Jonathon Sullivan (Author); Serah Eley (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>45:05</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 983: The Robot Whisperer</title>
+		<link>https://escapepod.org/2025/03/06/escape-pod-983-the-robot-whisperer/</link>
+		<pubDate>Thu, 06 Mar 2025 22:00:04 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15331</guid>
+		<comments>https://escapepod.org/2025/03/06/escape-pod-983-the-robot-whisperer/#comments</comments>
+		<wfw:commentRss>https://escapepod.org/2025/03/06/escape-pod-983-the-robot-whisperer/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[climate]]></category>
+		<category><![CDATA[Holly Schofield]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>Author : Holly Schofield Narrator : Kae Mills Host : Mur Lafferty Audio Producer : Summer Brooks “The Robot Whisperer” first appeared in Fighting for the Future cyberpunk-solarpunk anthology in 2023 The Robot Whisperer by Holly Schofield Emilia heard the door bang as Kore entered her workshop. Dishes clattered on the side bench. “Be there […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/03/06/escape-pod-983-the-robot-whisperer/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_983-TheRobotWhisperer.mp3" length="39472756" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>27:04</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 982: Twilight</title>
+		<link>https://escapepod.org/2025/02/27/escape-pod-982-twilight/</link>
+		<pubDate>Thu, 27 Feb 2025 22:00:47 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15312</guid>
+		<comments>https://escapepod.org/2025/02/27/escape-pod-982-twilight/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/02/27/escape-pod-982-twilight/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Kat Day]]></category>
+		<category><![CDATA[Lilly Harper]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[psychology]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[transhumanism]]></category>
+		<description>Twilight
+By Lilly Harper
+
+Like the tide going out, the dream slipped between her toes and carried with it the smell of petrichor and the sound of birdsong. Even without knowing she was dreaming, she had known she was waking up; the subliminal chatter of her body, quietly running its routine checksums, the logs spooling their idiot monologue into her working memory. First came a few moments of groggy confusion and then, like an iron hand gripping her cognitive architecture, a kind of clarity that tasted like resentment and reminded her of Monday mornings.
+
+Waking up always felt like this. Packed down as she was, crammed into a processor too small to carry her like a spring wound tight, waking up wasn’t a continuous transformation so much as a discrete toggle. Like a light switch.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_982_Twilight.mp3" length="36578618" type="audio/mpeg" />
+		<itunes:author>Lilly Harper (Author); Kat Day (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>25:03</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 981: Joy</title>
+		<link>https://escapepod.org/2025/02/20/escape-pod-981-joy/</link>
+		<pubDate>Thu, 20 Feb 2025 22:00:13 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15298</guid>
+		<comments>https://escapepod.org/2025/02/20/escape-pod-981-joy/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/02/20/escape-pod-981-joy/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[drone]]></category>
+		<description>Author : Dale Smith Narrator : Louise Ratcliffe Host : Tina Connolly Audio Producer : Summer Brooks “Joy” was previously published in Interzone Digital (June 2023) Joy by Dale Smith Joy knelt on the promenade, shifting the rifle into her shoulder to get a steadier shot. She did her best to ignore the waves crashing […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/02/20/escape-pod-981-joy/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_981-Joy.mp3" length="41186807" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>28:15</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 980: Peace by Piece</title>
+		<link>https://escapepod.org/2025/02/13/escape-pod-980-peace-by-piece/</link>
+		<pubDate>Thu, 13 Feb 2025 22:00:37 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15289</guid>
+		<comments>https://escapepod.org/2025/02/13/escape-pod-980-peace-by-piece/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/02/13/escape-pod-980-peace-by-piece/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[Devin Martin]]></category>
+		<category><![CDATA[Erin Cairns]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>Peace by Piece
+By Erin Cairns
+
+Frank thought all the battle-drones had been deactivated. Certainly, none of them had ever looked around with curious little twitches of their front-facing cameras before. This one whirred and clicked like an anxious bird, trying to find focus through a chipped and cloudy lens.
+
+&quot;Is the war over?&quot; it asked.
+
+Frank set aside his screwdriver. “It’s been over for a long time.”
+
+“Oh,” the drone said. “What happens now?”
+
+“Well, I was about to strip you for materials.”</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_980_Peace_by_Piece.mp3" length="35660780" type="audio/mpeg" />
+		<itunes:author>Erin Cairns (Author); Devin Martin (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>24:25</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 979: Steadyboi After the Apocalypse</title>
+		<link>https://escapepod.org/2025/02/06/escape-pod-979-steadyboi-after-the-apocalypse/</link>
+		<pubDate>Thu, 06 Feb 2025 22:00:27 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15286</guid>
+		<comments>https://escapepod.org/2025/02/06/escape-pod-979-steadyboi-after-the-apocalypse/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/02/06/escape-pod-979-steadyboi-after-the-apocalypse/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[merc fenn wolfmoor]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[robot]]></category>
+		<description>Author : Merc Fenn Wolfmoor Narrator : Joe Moran Host : Mur Lafferty Audio Producer : Summer Brooks “Steadyboi After the Apocalypse” first appeared in the collection Friends For Robots: Stories by Merc Fenn Wolfmoor (Robot Dinosaur Press, 2022) Steadyboi After the Apocalypse by Merc Fenn Wolfmoor You trudge through another wasteland town, sticking to […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/02/06/escape-pod-979-steadyboi-after-the-apocalypse/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_979-SteadyboiAfterTheApocalypse.mp3" length="47345853" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>32:32</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 978: Oak Hill Lane</title>
+		<link>https://escapepod.org/2025/01/30/escape-pod-978-oak-hill-lane/</link>
+		<pubDate>Thu, 30 Jan 2025 22:00:15 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15277</guid>
+		<comments>https://escapepod.org/2025/01/30/escape-pod-978-oak-hill-lane/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/01/30/escape-pod-978-oak-hill-lane/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[apocalypse]]></category>
+		<category><![CDATA[apocalyptic]]></category>
+		<category><![CDATA[Queer]]></category>
+		<category><![CDATA[religion]]></category>
+		<category><![CDATA[Sarah Griffin]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Oak Hill Lane
+By Alasdair Stuart
+
+The day the world ended, Scotch picked a fight. Not that there was much choice. Two fellow Canary Detailers, heads full of redtop bigotry and guts full of Tesco beer, had jumped Scotch’s work partner Billy the previous week and put him in the Infirmary. Scotch was next. It was just maths. Very stupid maths. So, behind the bike sheds at the University none of them could afford to attend but all of them were good enough to clean, Scotch forced the issue.
+
+Honestly, Scotch had rushed the issue; they let their guard down. “The readiness is all” becoming “Oh for fuck’s sake.” It was such schoolyard bollocks too. The bike sheds! The bike sheds for fuck’s sake! Scotch was only marginally surprised no one was making out back there. God knows they had a few times. But no, no such luck. Just clumsy alcohol punches and the angry relentless wave of hormones, homophobia, and homogenous men trying to pound the world into a shape whose familiarity didn’t terrify them. This wasn’t their first time behind the bike sheds either.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_978_Oak_Hill_Lane.mp3" length="62893115" type="audio/mpeg" />
+		<itunes:author>Alasdair Stuart (Author); Sarah Griffin (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>43:20</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 977: Reflected in Mirrored Skies (Part 2 of 2)</title>
+		<link>https://escapepod.org/2025/01/23/escape-pod-977-reflected-in-mirrored-skies-part-2-of-2/</link>
+		<pubDate>Thu, 23 Jan 2025 22:00:01 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15245</guid>
+		<comments>https://escapepod.org/2025/01/23/escape-pod-977-reflected-in-mirrored-skies-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/01/23/escape-pod-977-reflected-in-mirrored-skies-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Deborah L. Davitt]]></category>
+		<category><![CDATA[Ibba Armancas]]></category>
+		<category><![CDATA[murder mystery]]></category>
+		<category><![CDATA[space station]]></category>
+		<category><![CDATA[Venus]]></category>
+		<description>Author : Deborah L. Davitt Narrator : Ibba Armancas Host : Mur Lafferty Audio Producer : Summer Brooks “Reflected in Mirrored Skies” was published by Compelling Science Fiction (Special Kickstarter Companion issue Nov. 6, 2018) Mentions of sexual assault Reflected in Mirrored Skies by Deborah L. Davitt Mariana stood in the security room, listening to […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/01/23/escape-pod-977-reflected-in-mirrored-skies-part-2-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_977-ReflectedinMirroredSkies-Pt2.mp3" length="44082637" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:16</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 976: Reflected in Mirrored Skies (Part 1 of 2)</title>
+		<link>https://escapepod.org/2025/01/16/escape-pod-976-reflected-in-mirrored-skies-part-1-of-2/</link>
+		<pubDate>Thu, 16 Jan 2025 22:00:36 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15243</guid>
+		<comments>https://escapepod.org/2025/01/16/escape-pod-976-reflected-in-mirrored-skies-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/01/16/escape-pod-976-reflected-in-mirrored-skies-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Deborah L. Davitt]]></category>
+		<category><![CDATA[Ibba Armancas]]></category>
+		<category><![CDATA[murder mystery]]></category>
+		<category><![CDATA[space station]]></category>
+		<category><![CDATA[Venus]]></category>
+		<description>Author : Deborah L. Davitt Narrator : Ibba Armancas Host : Mur Lafferty Audio Producer : Summer Brooks “Reflected in Mirrored Skies” was published by Compelling Science Fiction (Special Kickstarter Companion issue Nov. 6, 2018) Reflected in Mirrored Skies by Deborah L. Davitt Above them, stars; below, the endless roil of leaden clouds that engulfed […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2025/01/16/escape-pod-976-reflected-in-mirrored-skies-part-1-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_976-ReflectedinMirroredSkies-Pt1.mp3" length="37368123" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>25:36</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 975: Don Ysidro (Flashback Friday)</title>
+		<link>https://escapepod.org/2025/01/09/escape-pod-975-don-ysidro-flashback-friday/</link>
+		<pubDate>Thu, 09 Jan 2025 22:00:38 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15238</guid>
+		<comments>https://escapepod.org/2025/01/09/escape-pod-975-don-ysidro-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/01/09/escape-pod-975-don-ysidro-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[art]]></category>
+		<category><![CDATA[Bruce Holand Rogers]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[Evo Terra]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<description>Don Ysidro (Excerpt)
+By Bruce Holland Rogers
+
+On that last morning, anyone who came to visit me could see that I was dying. I knew it myself. As if I had cotton in my ears, I heard the voice of don Leandro saying to my wife, “Dona Susana, I think it is time to fetch the priest,” and I thought, yes, it’s time.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_975_Don_Ysidro_Flashback_Friday.mp3" length="29160047" type="audio/mpeg" />
+		<itunes:author>Bruce Holland Rogers (Author); Evo Terra (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>19:54</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 974: Once Abandoned</title>
+		<link>https://escapepod.org/2025/01/02/escape-pod-974-once-abandoned/</link>
+		<pubDate>Thu, 02 Jan 2025 22:00:52 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15229</guid>
+		<comments>https://escapepod.org/2025/01/02/escape-pod-974-once-abandoned/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2025/01/02/escape-pod-974-once-abandoned/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[A.P. Hawkins]]></category>
+		<category><![CDATA[apocalypse]]></category>
+		<category><![CDATA[apocalyptic]]></category>
+		<category><![CDATA[bird]]></category>
+		<category><![CDATA[farm]]></category>
+		<category><![CDATA[Peter Adrian Behravesh]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Once Abandoned
+By A.P. Hawkins
+
+Sappel whistled as he walked to the construction site, the sound echoing off nearby buildings in a muffled way. It was early spring, and the city was bursting with the vibrant green of new growth. Wild edibles sprouted from rooftops like tufts of hair. Wildflowers and herbs crowded ledges beneath every window. Vines crawled over walls, buds promising fruit come summer.
+
+Out of all the buildings in the city, only the new one was bare. Its fresh grey concrete was harsh, unnatural, sticking out like a sore thumb from the green city and the wild country that surrounded it.
+
+But it wouldn’t be bare for much longer. They’d had a good, hard rain last night, which meant the substrate the builders had left behind would be perfectly conditioned for planting. Sappel kept whistling, repeating his song’s refrain.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_974_Once_Abandoned.mp3" length="48456740" type="audio/mpeg" />
+		<itunes:author>A.P. Hawkins (Author); Peter Behravesh (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>33:18</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 973: Forever the Forest</title>
+		<link>https://escapepod.org/2024/12/26/escape-pod-973-forever-the-forest/</link>
+		<pubDate>Thu, 26 Dec 2024 22:00:39 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15191</guid>
+		<comments>https://escapepod.org/2024/12/26/escape-pod-973-forever-the-forest/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/12/26/escape-pod-973-forever-the-forest/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[communication]]></category>
+		<category><![CDATA[forest]]></category>
+		<category><![CDATA[home]]></category>
+		<category><![CDATA[Hugo Jackson]]></category>
+		<category><![CDATA[language]]></category>
+		<description>Author : Simone Heller Narrator : Hugo Jackson Host : Valerie Valdes Audio Producer : Summer Brooks “Forever the Forest” was first published in “Life Beyond Us: An Original Anthology of SF Stories and Science Essays” (April 2023) Forever the Forest by Simone Heller It is known that the Rootless are only ever leaving. Always […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/12/26/escape-pod-973-forever-the-forest/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_973-ForeverTheForest.mp3" length="54403930" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>37:26</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 972: The Bargain of Death and Saint Nicholas</title>
+		<link>https://escapepod.org/2024/12/19/escape-pod-972-the-bargain-of-death-and-saint-nicholas/</link>
+		<pubDate>Thu, 19 Dec 2024 22:00:27 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15189</guid>
+		<comments>https://escapepod.org/2024/12/19/escape-pod-972-the-bargain-of-death-and-saint-nicholas/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/12/19/escape-pod-972-the-bargain-of-death-and-saint-nicholas/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Christmas]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<description>Author : Craig Church Narrator : Rosie Sentman Host : Alasdair Stuart Audio Producer : Summer Brooks Escape Pod 972: The Bargain of Death and Saint Nicholas is an Escape Pod original. The Bargain of Death and Saint Nicholas by Craig Church “What’s your favorite tale?” I ask, voice quivering. My audience of thieves and […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/12/19/escape-pod-972-the-bargain-of-death-and-saint-nicholas/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_972-TheBargainofDeathandSaintNicholas.mp3" length="75883479" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>52:21</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 971: In the Late December (Flashback Friday)</title>
+		<link>https://escapepod.org/2024/12/12/escape-pod-971-in-the-late-december-flashback-friday/</link>
+		<pubDate>Thu, 12 Dec 2024 22:00:31 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15197</guid>
+		<comments>https://escapepod.org/2024/12/12/escape-pod-971-in-the-late-december-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/12/12/escape-pod-971-in-the-late-december-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Christmas]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[Greg van Eekhout]]></category>
+		<category><![CDATA[holiday]]></category>
+		<category><![CDATA[Santa Claus]]></category>
+		<category><![CDATA[serah eley]]></category>
+		<description>Author : Greg van Eekhout Narrator : Serah Eley Host : Mur Lafferty Audio Producer : Summer Brooks “In the Late December” appeared in Strange Horizons, December 2003. This story was also a Nebula Award Nominee! Contains some dark Santa-related imagery, and the heat death of the universe. In the Late December by Greg van […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/12/12/escape-pod-971-in-the-late-december-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_971-InTheLateDecember-FlashbackFriday.mp3" length="40777416" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>27:58</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 970: Red in Tooth and Cog (Flashback Friday)</title>
+		<link>https://escapepod.org/2024/12/05/escape-pod-970-red-in-tooth-and-cog-flashback-friday/</link>
+		<pubDate>Thu, 05 Dec 2024 22:00:09 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15183</guid>
+		<comments>https://escapepod.org/2024/12/05/escape-pod-970-red-in-tooth-and-cog-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/12/05/escape-pod-970-red-in-tooth-and-cog-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Cat Rambo]]></category>
+		<category><![CDATA[evolution]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : Cat Rambo Narrator : Tina Connolly Host : Mur Lafferty Audio Producer : Summer Brooks “Red in Tooth and Cog” originally appeared in The Magazine of Fantasy &amp; Science Fiction, 2016, and was previously published in Escape Pod 607 Red in Tooth and Cog By Cat Rambo A phone can be so much. […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/12/05/escape-pod-970-red-in-tooth-and-cog-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_970-RedInToothAndCog-FlashbackFriday.mp3" length="83842467" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>57:53</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 969: Code Switching (Part 4 of 4)</title>
+		<link>https://escapepod.org/2024/11/28/escape-pod-969-code-switching-part-4-of-4/</link>
+		<pubDate>Thu, 28 Nov 2024 22:00:57 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15171</guid>
+		<comments>https://escapepod.org/2024/11/28/escape-pod-969-code-switching-part-4-of-4/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/11/28/escape-pod-969-code-switching-part-4-of-4/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[C.S.E. Cooney]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[Dominick Rabrun]]></category>
+		<category><![CDATA[Laurice White]]></category>
+		<category><![CDATA[malon edwards]]></category>
+		<category><![CDATA[Mandaly Louis-Charles]]></category>
+		<category><![CDATA[race]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[sports]]></category>
+		<category><![CDATA[transhumanism]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[war]]></category>
+		<description>Code Switching (Part 4 of 4)
+By Malon Edwards
+
+(...continued from Part 3)
+
+12. THIS IS THE TRUTELL
+MICHAËLLE-ANNABELLE FEAT. JEAN-MICHEL
+
+I strap into my rig, take a really big swig from my hydration dispenser tube I call The Ultra Black Vig, and settle back to begin this all-night white-hat gig.
+
+At first, I decide to do this like the Stig, but instead I shake awake my lightbox, pull on my knee-high fuzzy socks, and momentarily disable my sigTell locks. This is my double-dog dare for Saffron Sutton to try and hack this whitefox. She and I have been doing this since the first day of SSI hacker sprints, which always takes place on the vernal equinox. Usually, I tell her she better kick rocks because my sigTell is damn well capable of delivering emotional shocks along her TruTell stalks all the way back to those frilly frocks she designs and thoroughly maligns (although, she would say signs) with a matte black gingham fox.
+
+Now, watch me as I disregard all the clocks and enter the susso-sphere where the only thing I see is multicolored sigTell stalks everywhere.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_969_Code_Switching_Part_4_of_4.mp3" length="59002015" type="audio/mpeg" />
+		<itunes:author>Malon Edwards (Author); Dominick Rabrun, Mandaly Louis-Charles, C.S.E. Cooney, Laurice White (Narrators)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>40:38</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 968: Code Switching (Part 3 of 4)</title>
+		<link>https://escapepod.org/2024/11/21/escape-pod-968-code-switching-part-3-of-4/</link>
+		<pubDate>Thu, 21 Nov 2024 22:00:30 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15160</guid>
+		<comments>https://escapepod.org/2024/11/21/escape-pod-968-code-switching-part-3-of-4/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/11/21/escape-pod-968-code-switching-part-3-of-4/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[Dominick Rabrun]]></category>
+		<category><![CDATA[malon edwards]]></category>
+		<category><![CDATA[Mandaly Louis-Charles]]></category>
+		<category><![CDATA[race]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[sports]]></category>
+		<category><![CDATA[transhumanism]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[war]]></category>
+		<description>Code Switching (Part 3 of 4)
+By Malon Edwards
+
+
+
+(...Continued from Part 2)
+
+[JEAN-MICHEL]
+
+
+
+A SWEET-ASS HELICOPTER AND TEN STATER STRANGERS?
+
+JEAN-MICHEL FEAT. THE NAUGHTY NINETY-DAY FANDANGO
+
+
+
+I&#039;m feelin&#039; this Bell 525 Relentless like Ellen Gilchrist playin&#039; bid whist wit her redheaded MILF temptress. She&#039;s a proper drawers dropper chopper wit no love for the paupers. Her black chrome exterior makes me want to chill in her eighty-eight-square-foot cabin interior until homo erectus becomes superior.
+
+And I&#039;m not the only one.
+
+Sittin&#039; wit me are ten Stater strangers who fear no danger because of the two exo-fighters flankin&#039; us as we drink an&#039; cuss, comforted by their protection against the Sovereign State of Chicago&#039;s skanky trust.
+
+Listen to me. Talkin&#039; like how a real Stater must.
+
+Three of these girls might be smilin&#039; true, but on their faces you can see fear of Electric Resurrection, too. It&#039;s a look all eleven of us have, but we play it cool—or at least try to appear to.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_968_Code_Switching_Part_3_of_4.mp3" length="55915821" type="audio/mpeg" />
+		<itunes:author>Malon Edwards (Author); Dominick Rabrun, Mandaly Louis-Charles (Narrators)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>38:29</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 967: Code Switching (Part 2 of 4)</title>
+		<link>https://escapepod.org/2024/11/14/escape-pod-967-code-switching-part-2-of-4/</link>
+		<pubDate>Thu, 14 Nov 2024 22:00:53 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15150</guid>
+		<comments>https://escapepod.org/2024/11/14/escape-pod-967-code-switching-part-2-of-4/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/11/14/escape-pod-967-code-switching-part-2-of-4/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[C.S.E. Cooney]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[Dominick Rabrun]]></category>
+		<category><![CDATA[Laurice White]]></category>
+		<category><![CDATA[malon edwards]]></category>
+		<category><![CDATA[race]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[sports]]></category>
+		<category><![CDATA[transhumanism]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[war]]></category>
+		<description>Code Switching (Part 2 of 4)
+By Malon Edwards
+
+(...Continued from Part 1)
+
+[JEAN-MICHEL]
+
+
+
+
+ONE HUNDRED PERCENT PERFORMANCE OUTPUT
+
+JEAN-MICHEL FEAT. KINSLEY CHASE
+
+
+
+
+Lòske jounalis sa yo gade m—
+
+Hold up. Let me say that again. I&#039;ll wait. Y&#039;all go grab y&#039;alls paper an&#039; pen.
+
+When these Stater journos look at me, they don&#039;t juss see a Black boy. Nah, they also see a bio-electric, battery-operated toy, part of a Stanford Sutton Industries ploy to bring fat cat football alums joy.
+
+(Wit money. Anpil, anpil lajan.)
+
+An&#039; that pisses them off. So they gon&#039; keep rushin&#039; off an&#039; bustin&#039; off these queries at a machine-gun pace in my face while smirkin&#039; at my Haitian Creole vocabulary, pretendin&#039; they can only understand me, barely, &#039;cause my accent is too thick an&#039; scary.
+
+Pakont—but on the flip side—them Chicago reporters gon&#039; give me the benefit of the doubt (that&#039;s right) when they write they stories witout bias tonight. They embrace a sovereign state that thrives on a black market sparked by innovation an&#039; encouraged by a Haitian who planned a nation for secession from a State of Imperfection, then made Chicago the greatest an&#039; said to hell wit those Stater racists.
+
+Like the ones in front of me now.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_967_Code_Switching_Part_2_of_4.mp3" length="60450031" type="audio/mpeg" />
+		<itunes:author>Malon Edwards (Author); Dominick Rabrun, C.S.E. Cooney, Laurice White (Narrators)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>41:38</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 966: Code Switching (Part 1 of 4)</title>
+		<link>https://escapepod.org/2024/11/07/escape-pod-966-code-switching-part-1-of-4/</link>
+		<pubDate>Thu, 07 Nov 2024 22:00:02 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15142</guid>
+		<comments>https://escapepod.org/2024/11/07/escape-pod-966-code-switching-part-1-of-4/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/11/07/escape-pod-966-code-switching-part-1-of-4/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[Dominick Rabrun]]></category>
+		<category><![CDATA[malon edwards]]></category>
+		<category><![CDATA[race]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[sports]]></category>
+		<category><![CDATA[transhumanism]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Code Switching
+
+By Malon Edwards
+
+[JEAN-MICHEL]
+
+INTRO: ALL I&#039;M EVER GON&#039; DO IS STAY BLACK AND DIE
+
+JEAN-MICHEL FEAT. KINSLEY CHASE
+
+Kinsley Chase sits on manman mwen plastic-covered couch. The InTell HumbleBrag subprogram Stanford Sutton Industries chipped me with says she&#039;s wearing a circa 2020 Theresa Frostad Eggesbø Resurrection skinload.
+
+I had no idea this shit actually worked. I don&#039;t HumbleBrag. I thought it was all about narcissism and went in one direction, so I said fuck that shit.
+
+But Kinsley Chase HumbleBraggin&#039; &#039;bout how unique (meanin&#039; how expensive) her skinload is makes sense. These days, pourin&#039; honey like that into some poor Black people&#039;s ear can be an effective war propaganda tool. We all know both the State of Illinois and the Sovereign State of Chicago recruitin&#039;.
+
+Too bad I don&#039;t like siwo. Or lagè.
+
+&#039;Sides, manman mwen and I don&#039;t need no tools. We juss need to pay our bills.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_966_Code_Switching_Part_1_of_4.mp3" length="43980463" type="audio/mpeg" />
+		<itunes:author>Malon Edwards (Author); Dominick Rabrun (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:12</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 965: T-Rex Tex Mex / Mother Death Learns a Trick</title>
+		<link>https://escapepod.org/2024/10/31/escape-pod-965-t-rex-tex-mex-mother-death-learns-a-trick/</link>
+		<pubDate>Thu, 31 Oct 2024 21:00:30 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15128</guid>
+		<comments>https://escapepod.org/2024/10/31/escape-pod-965-t-rex-tex-mex-mother-death-learns-a-trick/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/10/31/escape-pod-965-t-rex-tex-mex-mother-death-learns-a-trick/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Andrew K Hoe]]></category>
+		<category><![CDATA[dinosaurs]]></category>
+		<category><![CDATA[Halloween]]></category>
+		<category><![CDATA[robots]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Authors : Sarina Dorie and Addison Smith Narrators : Tina Connolly and Andrew K. Hoe Hosts : Alasdair Stuart and Kat Day Audio Producer : Summer Brooks Escape Pod 965: T-Rex Tex Mex / Mother Death Learns a Trick is an Escape Pod original. T-Rex Tex Mex by Sarina Dorie “Whoa! Hold on, partner!” the […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/10/31/escape-pod-965-t-rex-tex-mex-mother-death-learns-a-trick/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_965-TRexTexMex-MotherDeath.mp3" length="41457017" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>28:27</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 964: Show and Tell (Flashback Friday)</title>
+		<link>https://escapepod.org/2024/10/24/escape-pod-964-show-and-tell-flashback-friday/</link>
+		<pubDate>Thu, 24 Oct 2024 21:00:53 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15124</guid>
+		<comments>https://escapepod.org/2024/10/24/escape-pod-964-show-and-tell-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/10/24/escape-pod-964-show-and-tell-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[OK for Kids]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Anna Eley]]></category>
+		<category><![CDATA[body modification]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[Greg van Eekhout]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[school]]></category>
+		<description>Show and Tell
+By Greg van Eekhout
+
+Teacher is an old-fashioned bug with a blue carapace and eyes like two domes of gold beads. She is very pretty and smells like follow, but when she flutters her wings you better look smart or you&#039;ll get her stinger in your belly.
+
+So we are quiet. We are three rows of quiet children, blinking slowly and steadily, as is polite.
+
+&quot;Today, we are having Show and Tell,&quot; Teacher says, bending her antennae towards us. &quot;I am certain you have all brought wonderful shows.&quot;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_964_Show_and_Tell_Flashback_Friday.mp3" length="30914204" type="audio/mpeg" />
+		<itunes:author>Greg van Eekhout (Author); Anna Eley (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>21:07</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 963: To Catch a Flieff (Part 2 of 2)</title>
+		<link>https://escapepod.org/2024/10/17/escape-pod-963-to-catch-a-flieff-part-2-of-2/</link>
+		<pubDate>Thu, 17 Oct 2024 21:00:54 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15111</guid>
+		<comments>https://escapepod.org/2024/10/17/escape-pod-963-to-catch-a-flieff-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/10/17/escape-pod-963-to-catch-a-flieff-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Abra Staffin-Wiebe]]></category>
+		<category><![CDATA[cat]]></category>
+		<category><![CDATA[Julia Rios]]></category>
+		<category><![CDATA[meet cute]]></category>
+		<category><![CDATA[Queer]]></category>
+		<category><![CDATA[romance]]></category>
+		<category><![CDATA[space ship]]></category>
+		<category><![CDATA[Tatiana Grey]]></category>
+		<description>Author : Julia Rios Narrators : Abra Staffin-Wiebe and Tatiana Grey Host : Valerie Valdes Audio Producer : Summer Brooks “To Catch a Flieff” was originally written as a bonus for backers of the Bridge to Elsewhere Kickstarter (an anthology of stories set on bridges of spaceships). Listen to Part 1: Escape Pod 962: To […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/10/17/escape-pod-963-to-catch-a-flieff-part-2-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_963-ToCatchaFlieff-Part2of2.mp3" length="48868688" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>33:36</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 962: To Catch a Flieff (Part 1 of 2)</title>
+		<link>https://escapepod.org/2024/10/10/escape-pod-962-to-catch-a-flieff-part-1-of-2/</link>
+		<pubDate>Thu, 10 Oct 2024 21:00:45 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15108</guid>
+		<comments>https://escapepod.org/2024/10/10/escape-pod-962-to-catch-a-flieff-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/10/10/escape-pod-962-to-catch-a-flieff-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Abra Staffin-Wiebe]]></category>
+		<category><![CDATA[cat]]></category>
+		<category><![CDATA[Julia Rios]]></category>
+		<category><![CDATA[meet cute]]></category>
+		<category><![CDATA[Queer]]></category>
+		<category><![CDATA[romance]]></category>
+		<category><![CDATA[space ship]]></category>
+		<category><![CDATA[Tatiana Grey]]></category>
+		<description>Author : Julia Rios Narrators : Abra Staffin-Wiebe and Tatiana Grey Host : Valerie Valdes Audio Producer : Summer Brooks “To Catch a Flieff” was originally written as a bonus for backers of the Bridge to Elsewhere Kickstarter (an anthology of stories set on bridges of spaceships). To Catch a Flieff by Julia Rios Alessia […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/10/10/escape-pod-962-to-catch-a-flieff-part-1-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_962_ToCatchaFlieff-Part1of2.mp3" length="49597190" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>34:06</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 961: Mathball</title>
+		<link>https://escapepod.org/2024/10/03/escape-pod-961-mathball/</link>
+		<pubDate>Thu, 03 Oct 2024 21:00:31 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15096</guid>
+		<comments>https://escapepod.org/2024/10/03/escape-pod-961-mathball/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/10/03/escape-pod-961-mathball/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[baseball]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[Larry Hodges]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[physics]]></category>
+		<category><![CDATA[research]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Mathball
+By Larry Hodges
+
+You are a baseball fan, sitting in the centerfield seats eating an overpriced hot dog. You are wearing a baseball cap, but not a batting helmet, of course. (Why would that be an issue? Hmm…)You smile brightly, but all will not end well for you unless you pay close attention.
+
+“Play ball!” cries the umpire, crouching behind the plate. The crowd roars. The pitcher stares down at the catcher, waiting for the sign. They are the home team. Thousands cheer for them.
+
+The batter waves his bat menacingly. He is a hero of this story.
+
+Six scientists sit at their desks behind home plate, three on the third-base side, three on the first-base side. The three on the first-base side work for the pitcher and we don’t care about them—they are the enemy. The three on the third-base side work for the batter. They are from MIT. These latter three are the real stars of this story.
+
+Well… mostly.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_961_Mathball.mp3" length="48999605" type="audio/mpeg" />
+		<itunes:author>Larry Hodges (Author); Mur Lafferty (Narrators)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>33:41</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 960: Elegy of Carbon</title>
+		<link>https://escapepod.org/2024/09/26/escape-pod-960-elegy-of-carbon/</link>
+		<pubDate>Thu, 26 Sep 2024 21:00:40 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15074</guid>
+		<comments>https://escapepod.org/2024/09/26/escape-pod-960-elegy-of-carbon/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/09/26/escape-pod-960-elegy-of-carbon/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Benjamin C. Kinney]]></category>
+		<category><![CDATA[robots]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[space mining]]></category>
+		<description>Author : Benjamin C. Kinney Narrator : Heather Thomas Host : Alasdair Stuart Audio Producer : Summer Brooks This story originally appeared in the anthology “The Internet Is Where The Robots Live Now” (Paper Dog Press, November 2018). Elegy of Carbon by Benjamin C. Kinney The miner birthed itself among rubble and vacuum, as it […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/09/26/escape-pod-960-elegy-of-carbon/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_960-ElegyofCarbon.mp3" length="58719777" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>40:26</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 959: This Little War of Ours</title>
+		<link>https://escapepod.org/2024/09/19/escape-pod-959-this-little-war-of-ours/</link>
+		<pubDate>Thu, 19 Sep 2024 21:00:08 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15060</guid>
+		<comments>https://escapepod.org/2024/09/19/escape-pod-959-this-little-war-of-ours/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/09/19/escape-pod-959-this-little-war-of-ours/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[apocalypse]]></category>
+		<category><![CDATA[Arden Baker]]></category>
+		<category><![CDATA[epistolary]]></category>
+		<category><![CDATA[Graeme Dunlop]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Queer]]></category>
+		<category><![CDATA[romance]]></category>
+		<category><![CDATA[Scott Campbell]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[war]]></category>
+		<description>This Little War of Ours
+By Arden Baker
+
+
+SECURE PRIORITY COMMUNIQUE
+
+distribution SOLITAIRE, keyword MASQUERADE, source PENTACLE
+
+FROM: TRIPLE INTENT
+
+TO: ASPHODEL
+
+BEGIN CONTENT
+
+
+Even if you’re my enemy, I’m glad to hear from you.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_959_This_Little_War_of_Ours.mp3" length="45193406" type="audio/mpeg" />
+		<itunes:author>Arden Baker (Author); Scott Campbell, Graeme Dunlop, Valerie Valdes (Narrators)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>31:02</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 958: Some of Them Closer (Flashback Friday)</title>
+		<link>https://escapepod.org/2024/09/12/escape-pod-958-some-of-them-closer-flashback-friday/</link>
+		<pubDate>Thu, 12 Sep 2024 21:00:04 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15052</guid>
+		<comments>https://escapepod.org/2024/09/12/escape-pod-958-some-of-them-closer-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/09/12/escape-pod-958-some-of-them-closer-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[home]]></category>
+		<category><![CDATA[Marissa Lingen]]></category>
+		<category><![CDATA[The Word Whore]]></category>
+		<description>Author : Marissa Lingen Narrator : The Word Whore Host : Valerie Valdes Audio Producer : Summer Brooks Originally appeared in Analog (2011), and in Escape Pod 366 (Oct 2012) Some of Them Closer by Marissa Lingen Coming back to Earth was not the immediate shock they expected it to be for me. It was […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/09/12/escape-pod-958-some-of-them-closer-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_958-SomeOfThemCloser-FlasbackFriday.mp3" length="45302660" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>31:07</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 957: Vault (Part 2 of 2)</title>
+		<link>https://escapepod.org/2024/09/05/escape-pod-957-vault-part-2-of-2/</link>
+		<pubDate>Thu, 05 Sep 2024 21:00:39 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15044</guid>
+		<comments>https://escapepod.org/2024/09/05/escape-pod-957-vault-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/09/05/escape-pod-957-vault-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[D.A. Xiaolin Spires]]></category>
+		<category><![CDATA[Rebecca Wei Hsieh]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[survival]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Vault (Part 2 of 2)
+By D.A. Xiaolin Spires
+
+(...Continued from Part 1)
+
+“Lukas?”
+
+Chenguang’s voice echoes in this expanse of dark.
+
+A vortex of light opens to her right and she sees a warped head and legs emerge from a point in the dark. It’s Lukas. As he enters the space, the light bends, his figure elongated as he pulls himself through and it closes behind him. It’s dark again.
+
+“Hey, Lukas.”
+
+“Chenguang?” His voice is low and resounds against unseen walls. “Where is this place?”
+
+“Did we just—enter the structure somehow?”
+
+“I—I—don’t know.” Lukas’ voice uncharacteristically wavers before it quiets down in the darkness.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_957_Vault_Part_2.mp3" length="62504439" type="audio/mpeg" />
+		<itunes:author>D.A. Xiaolin Spires (Author); Rebecca Wei Hsieh (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>43:04</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 956: Vault (Part 1 of 2)</title>
+		<link>https://escapepod.org/2024/08/29/escape-pod-956-vault-part-1-of-2/</link>
+		<pubDate>Thu, 29 Aug 2024 21:00:10 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15035</guid>
+		<comments>https://escapepod.org/2024/08/29/escape-pod-956-vault-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/08/29/escape-pod-956-vault-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[D.A. Xiaolin Spires]]></category>
+		<category><![CDATA[novella]]></category>
+		<category><![CDATA[Rebecca Wei Hsieh]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[survival]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Vault (Part 1 of 2)
+By D.A. Xiaolin Spires
+
+Chenguang hikes up her sleeves before vaulting over the pile of fuzzy moss and greets Lukas with a nod. The chloropolyurethane fabric flaps in the slight breeze and the double suns beat down onto her arms.
+
+Lukas fishes in his bag next to his tent for a bottle of sunsoak and releases the spray, running it generously over his solflex-covered arms, torso, and legs.
+
+“Your head,” Chenguang says and he smiles, as if he hadn’t been doing this for years.
+
+“Can’t reach,” he says, lying and Chenguang knows he just likes the attention. She grabs the spray and discharges that exhale of mist, covering his football-shaped clear helmet. She even sprays some on the clear hard arc under his bearded chin. She turns the mist onto herself, bringing down the spray over her exposed transpandex inner layer, the foam frothing up at her arms before becoming clear, encasing the invisible solflex pores of her fabric.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_956_Vault_Part_1.mp3" length="57476388" type="audio/mpeg" />
+		<itunes:author>D.A. Xiaolin Spires (Author); Rebecca Wei Hsieh (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:34</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 955: Endymion</title>
+		<link>https://escapepod.org/2024/08/22/escape-pod-955-endymion/</link>
+		<pubDate>Thu, 22 Aug 2024 21:00:50 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15026</guid>
+		<comments>https://escapepod.org/2024/08/22/escape-pod-955-endymion/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/08/22/escape-pod-955-endymion/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[crime]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[serah eley]]></category>
+		<category><![CDATA[transgender]]></category>
+		<category><![CDATA[virtual reality]]></category>
+		<description>Author : Sylvie Althoff Narrator : Serah Eley Host : Mur Lafferty Audio Producer : Summer Brooks Escape Pod 955: Endymion is an Escape Pod original. Contains transphobic slur, adult language, and brief but graphic violence Endymion by Sylvie Althoff It’s green here—green and wet. The twittering of birds in the treetops pauses as one […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/08/22/escape-pod-955-endymion/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_955-Endymion.mp3" length="47483780" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>32:38</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 954: Chandra’s Game (Flashback Friday)</title>
+		<link>https://escapepod.org/2024/08/15/escape-pod-954-chandras-game-flashback-friday/</link>
+		<pubDate>Thu, 15 Aug 2024 21:00:33 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15021</guid>
+		<comments>https://escapepod.org/2024/08/15/escape-pod-954-chandras-game-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/08/15/escape-pod-954-chandras-game-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[crime]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[mob]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Samantha Henderson]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Author : Samantha Henderson Narrator : Mur Lafferty Host : Valerie Valdes Audio Producer : Summer Brooks “Chandra’s Game” originally appeared in Lone Star Stories (2009), and in Escape Pod 373. Chandra’s Game by Samantha Henderson Joey Straphos, Papa Joe, told me once that Chandra’s Game is a bitch of a city, fickle but generous […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/08/15/escape-pod-954-chandras-game-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_954-ChandrasGame-FlashbackFriday.mp3" length="53847835" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>37:03</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 953: Sturdy Ladders and Lanterns</title>
+		<link>https://escapepod.org/2024/08/08/escape-pod-953-sturdy-ladders-and-lanterns/</link>
+		<pubDate>Thu, 08 Aug 2024 21:00:27 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=15010</guid>
+		<comments>https://escapepod.org/2024/08/08/escape-pod-953-sturdy-ladders-and-lanterns/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/08/08/escape-pod-953-sturdy-ladders-and-lanterns/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[Malka Older]]></category>
+		<category><![CDATA[ocean]]></category>
+		<category><![CDATA[oceanography]]></category>
+		<category><![CDATA[octopus]]></category>
+		<category><![CDATA[octopuses]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Sturdy Ladders and Lanterns
+By Malka Older
+
+As a freelance marine behavioral researcher most of Natalia’s jobs went something like this: She swam around in some large but controllable environment with a cephalopod, paying attention to its body language and her own. She tried to make the octopus or squid feel as comfortable as possible, so that its behavior in response to stimuli might approximate what it would do in the wild. It wasn’t what she had expected when she trained as a marine biologist, but frankly she preferred it to dissection, experimentation by electric shock, or even anything that required interacting with animals captive in tiny tanks.
+
+This particular job started out only slightly unusual. For most jobs she was given a specific research interest. Sometimes they told her exactly what to do to elicit the behaviors they wanted to study, and sometimes they let her design the approach, but either way it meant some narrow focus for her attention. Natalia always tried to give the cephalopod some play time around their interactions – if challenged on this, she told her employers that it led to more natural responses than repeating the same cues over and over again – but their time was very much directed by research.
+
+On this job, they told her just to play with the octopus.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_953_Sturdy_Ladders_and_Lanterns.mp3" length="52283033" type="audio/mpeg" />
+		<itunes:author>Malka Older (Author); Valerie Valdes (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>35:58</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 952: Skyscrapers That Twist to the Sun</title>
+		<link>https://escapepod.org/2024/08/01/escape-pod-952-skyscrapers-that-twist-to-the-sun/</link>
+		<pubDate>Thu, 01 Aug 2024 21:00:12 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14999</guid>
+		<comments>https://escapepod.org/2024/08/01/escape-pod-952-skyscrapers-that-twist-to-the-sun/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/08/01/escape-pod-952-skyscrapers-that-twist-to-the-sun/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Cherrae L. Stuart]]></category>
+		<category><![CDATA[daughter]]></category>
+		<category><![CDATA[mother]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : Erin Brown Narrator : Cherrae L. Stuart Host : Tina Connolly Audio Producer : Summer Brooks “Skyscrapers That Twist to the Sun” appeared in Fantasy Magazine Issue 87 (January 2023) Skyscrapers That Twist to the Sun by Erin Brown Shaundra took the small, empty cardboard box and swiveled on her work stool to […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/08/01/escape-pod-952-skyscrapers-that-twist-to-the-sun/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_952-SkyscrapersThatTwisttotheSun.mp3" length="23821230" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>16:12</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 951: The Scientist Does Not Look Back</title>
+		<link>https://escapepod.org/2024/07/25/escape-pod-951-the-scientist-does-not-look-back/</link>
+		<pubDate>Thu, 25 Jul 2024 21:00:34 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14981</guid>
+		<comments>https://escapepod.org/2024/07/25/escape-pod-951-the-scientist-does-not-look-back/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/07/25/escape-pod-951-the-scientist-does-not-look-back/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Adam Pracht]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[Ant Bacon]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[frankenstein]]></category>
+		<category><![CDATA[Kristen Koopman]]></category>
+		<category><![CDATA[Queer]]></category>
+		<category><![CDATA[romance]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>The Scientist Does Not Look Back
+By Kristen Koopman
+
+Feb. 17, 3:40 AM. Audio notebook for new project: revival of a clinically dead patient, 36 year old male, died of hypothermia and shock.
+
+The technician at the morgue hesitated when releasing him to me. I&#039;m not surprised, with the tone that took hold of my voice as I corrected her Mr. to Dr. as she took down my details. When I gave her my name, her pen stalled over the paper—a giveaway that his parents had called before I arrived. I should be grateful that she released him to me anyway, honoring my legal right to the body. I should be grateful for so much, I suppose, even if it doesn&#039;t feel like it, to have this opportunity to—to not let his story end in tragedy.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_951_The_Scientist_Does_Not_Look_Back.mp3" length="48661036" type="audio/mpeg" />
+		<itunes:author>Kristen Koopman (Author); Ant Bacon (Narrator); Valerie Valdes and Adam Pracht (Additional Voices)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>33:27</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 950: Bad Dogs Escape (Flashback Friday)</title>
+		<link>https://escapepod.org/2024/07/18/escape-pod-950-bad-dogs-escape-flashback-friday/</link>
+		<pubDate>Thu, 18 Jul 2024 21:00:27 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14973</guid>
+		<comments>https://escapepod.org/2024/07/18/escape-pod-950-bad-dogs-escape-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/07/18/escape-pod-950-bad-dogs-escape-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[audio drama]]></category>
+		<category><![CDATA[dogs]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[James Patrick Kelly]]></category>
+		<category><![CDATA[John Cmar]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<description>Author : James Patrick Kelly Narrators : A Kovacs, John Cmar and Pamela Quevillon Host : Mur Lafferty Audio Producer : Summer Brooks Appropriate for older teens and up due to erotic imagery and war criminal comeuppance Bad Dogs Escape By James Patrick Kelly /SFX/ CLOCK TICKING, FADE TO /SFX/ DOGS BARKING IN DISTANCE SAM: […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/07/18/escape-pod-950-bad-dogs-escape-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_950-BadDogsEscape-FlashbackFriday.mp3" length="27964668" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>19:05</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 949: A Foundational Model for Talking to Girls</title>
+		<link>https://escapepod.org/2024/07/11/escape-pod-949-a-foundational-model-for-talking-to-girls/</link>
+		<pubDate>Thu, 11 Jul 2024 21:00:50 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14966</guid>
+		<comments>https://escapepod.org/2024/07/11/escape-pod-949-a-foundational-model-for-talking-to-girls/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/07/11/escape-pod-949-a-foundational-model-for-talking-to-girls/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[Brian Hugenbruch]]></category>
+		<category><![CDATA[kyle akers]]></category>
+		<category><![CDATA[Moon]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[YA / Young Adult]]></category>
+		<description>A Foundational Model for Talking to Girls
+By Brian Hugenbruch
+
+“Hey Marty,” Mom asks, “got a moment?”
+
+I cringe whenever Mom&#039;s voice has that tone to it. I don’t know what she’s going to say; but if I’ve learned anything in my thirteen years on this desolate, oxygen-deprived rock, it’s that she’s going to find a way to say the most mortifying thing possible. It would be impressive, the way that every sentence excavates my stomach—if it weren&#039;t my stomach she was mining!
+
+Okay, that&#039;s unfair. Maybe this time it won&#039;t be so bad?
+
+“That girl who just walked past us. Why didn’t you ask her out?”
+
+Or not.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_949_A_Foundational_Model_for_Talking_to_Girls.mp3" length="41152208" type="audio/mpeg" />
+		<itunes:author>Brian Hugenbruch (Author); Kyle Akers (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>28:14</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 948: Thank You for Doing Business with the Xyb&#8217;lor Principality</title>
+		<link>https://escapepod.org/2024/07/04/escape-pod-948-thank-you-for-doing-business-with-the-xyblor-principality/</link>
+		<pubDate>Thu, 04 Jul 2024 21:00:07 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14955</guid>
+		<comments>https://escapepod.org/2024/07/04/escape-pod-948-thank-you-for-doing-business-with-the-xyblor-principality/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/07/04/escape-pod-948-thank-you-for-doing-business-with-the-xyblor-principality/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[spaceships]]></category>
+		<description>Author : Rachel Meresman Narrator : Isaac Harwood Host : Alasdair Stuart Audio Producer : Summer Brooks Escape Pod 948: Thank You for Doing Business with the Xyb’lor Principality is an Escape Pod original. Thank You for Doing Business with the Xyb’lor Principality by Rachel Meresman Jaxon was not a connoisseur of art, but he […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/07/04/escape-pod-948-thank-you-for-doing-business-with-the-xyblor-principality/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_948-ThankYouForDoingBusinesswiththeXyblorPrincipality.mp3" length="35423359" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>24:15</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 947: Rupert Weard and the Case of the Adamant Annihilist</title>
+		<link>https://escapepod.org/2024/06/27/escape-pod-947-rupert-weard-and-the-case-of-the-adamant-annihilist/</link>
+		<pubDate>Thu, 27 Jun 2024 21:00:12 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14946</guid>
+		<comments>https://escapepod.org/2024/06/27/escape-pod-947-rupert-weard-and-the-case-of-the-adamant-annihilist/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/06/27/escape-pod-947-rupert-weard-and-the-case-of-the-adamant-annihilist/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[alternate realities]]></category>
+		<category><![CDATA[bunny rabbit]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[multiverse]]></category>
+		<category><![CDATA[Rob Gillham]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Rupert Weard and the Case of the Adamant Annihilist
+By Rob Gillham
+
+Rupert Weard leapt into the drawing room, escaping a hallway dense with impossibly angled, tentacular horrors trying to sell him insurance.
+
+&quot;Ye gods, it&#039;s bedlam out there,&quot; he said. &quot;Just look at this, Boswell.&quot; He hurled his folded newspaper at me like a frisbee.
+
+I occupied my usual spot on the rug by the fireplace. I&#039;d been happily finishing off the remains of a cauliflower when the unwanted periodical came streaking across the room, forcing me to hop into frantic evasive action.
+
+&quot;Oi!&quot; I said, coughing up half-chewed bits of Brassica oleracea. &quot;Do you mind? That was my breakfast.&quot;
+
+&quot;It&#039;s eleven o&#039;clock, you idle rabbit.&quot; Rupert slammed the door firmly shut on a particularly determined sales rep attempting to squeeze its incompatible geometry into the room.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_947_Rupert_Weard_and_the_Case_of_the_Adamant_Annihilist.mp3" length="68118770" type="audio/mpeg" />
+		<itunes:author>Rob Gillham (Author); Alasdair Stuart (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>46:58</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 946: Trixie and the Pandas of Dread (Flashback Friday)</title>
+		<link>https://escapepod.org/2024/06/20/escape-pod-946-trixie-and-the-pandas-of-dread-flashback-friday/</link>
+		<pubDate>Thu, 20 Jun 2024 21:00:59 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14926</guid>
+		<comments>https://escapepod.org/2024/06/20/escape-pod-946-trixie-and-the-pandas-of-dread-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/06/20/escape-pod-946-trixie-and-the-pandas-of-dread-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[cyberpunk]]></category>
+		<category><![CDATA[deity]]></category>
+		<category><![CDATA[Eugie Foster]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<description>Author : Eugie Foster Narrator : Mur Lafferty Host : Mur Lafferty Audio Producer : Summer Brooks This story was first published in Escape Pod 388 (March 21, 2013) Contains harsh language and graphic gory violence Trixie and the Pandas of Dread by Eugie Foster Trixie got out of her cherry-red godmobile and waved away […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/06/20/escape-pod-946-trixie-and-the-pandas-of-dread-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_946-TrixieandthePandasofDread-FlashbackFriday.mp3" length="56887235" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>39:10</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 945: Walking with Thorny</title>
+		<link>https://escapepod.org/2024/06/13/escape-pod-945-walking-with-thorny/</link>
+		<pubDate>Thu, 13 Jun 2024 21:00:35 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14890</guid>
+		<comments>https://escapepod.org/2024/06/13/escape-pod-945-walking-with-thorny/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/06/13/escape-pod-945-walking-with-thorny/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[interspecies communication]]></category>
+		<category><![CDATA[plants]]></category>
+		<description>Author : Stetson Bostic Narrator : Samuel Poots Host : Valerie Valdes Audio Producer : Summer Brooks Escape Pod 945: Walking with Thorny is an Escape Pod original. Walking with Thorny by Stetson Bostic Hitchhikers clung to Tasi’s pants as he neared the edge of the forest. He brushed them off while walking and looked […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/06/13/escape-pod-945-walking-with-thorny/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_945-WalkingWithThorny.mp3" length="44350340" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:27</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 944: How to Keep Your Cool If You&#8217;re a Mech First Day on the Job (Part 2 of 2)</title>
+		<link>https://escapepod.org/2024/06/06/escape-pod-944-how-to-keep-your-cool-if-youre-a-mech-first-day-on-the-job-part-2-of-2/</link>
+		<pubDate>Thu, 06 Jun 2024 21:00:16 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14912</guid>
+		<comments>https://escapepod.org/2024/06/06/escape-pod-944-how-to-keep-your-cool-if-youre-a-mech-first-day-on-the-job-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/06/06/escape-pod-944-how-to-keep-your-cool-if-youre-a-mech-first-day-on-the-job-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[house]]></category>
+		<category><![CDATA[Ibba Armancas]]></category>
+		<category><![CDATA[mech]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Vera Brook]]></category>
+		<category><![CDATA[work]]></category>
+		<description>How to Keep Your Cool If You&#039;re a Mech First Day on the Job (Part 2 of 2)
+By Vera Brook
+
+(...Continued from Part 1)
+
+Jenna gave herself a few moments to seethe in silence before she spoke, to make sure her voice was calm. “I can’t move.”
+
+“Did you hear that?” Daron took a swig of his water, then bit into his sandwich. He looked around the table at the others. Not even a glance at Jenna. “She can’t move.”
+
+“It’s a problem,” Skye admitted.
+
+“Definitely is,” Irelyn agreed.
+
+“Most unfortunate.” This from Khalil.
+
+There was a pause as they waited for Uruk, but he was staring at his computer screen. He jumped up when Irelyn’s elbow poked his ribcage. “We’re still good. No delays. I’m keeping track.”
+
+“We’re talking about the newbie, Uruk,” Irelyn said. “She can’t move.”</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_944_How_to_Keep_Your_Cool_If_Youre_a_Mech_First_Day_on_the_Job_Part_2_of_2.mp3" length="51205315" type="audio/mpeg" />
+		<itunes:author>Vera Brook (Author); Ibba Armancas (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+	</item>
+	<item>
+		<title>Escape Pod 943: How to Keep Your Cool If You&#8217;re a Mech First Day on the Job (Part 1 of 2)</title>
+		<link>https://escapepod.org/2024/05/30/escape-pod-943-how-to-keep-your-cool-if-youre-a-mech-first-day-on-the-job-part-1-of-2/</link>
+		<pubDate>Thu, 30 May 2024 21:00:18 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14902</guid>
+		<comments>https://escapepod.org/2024/05/30/escape-pod-943-how-to-keep-your-cool-if-youre-a-mech-first-day-on-the-job-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/05/30/escape-pod-943-how-to-keep-your-cool-if-youre-a-mech-first-day-on-the-job-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[house]]></category>
+		<category><![CDATA[Ibba Armancas]]></category>
+		<category><![CDATA[mech]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Vera Brook]]></category>
+		<category><![CDATA[work]]></category>
+		<description>How to Keep Your Cool If You&#039;re a Mech First Day on the Job (Part 1 of 2)
+By Vera Brook
+
+Damn, the exoskeleton was hot. Two minutes strapped into the smart harness with its thick exospine and the oversized, carbon-fiber limbs that grew from it, and sweat pooled between Jenna’s shoulder blades, over her own spinal column. The whole thing hummed with electronics and throbbed with support motors. Nothing like the black top, mini skirt, and sneakers she’d worn on her previous job, waiting tables and tending bar at Lazy Dog’s.
+
+But the pay was three times what she made in tips, and she had the evenings to herself.
+
+She was moving up in the world.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_943_How_to_Keep_Your_Cool_If_Youre_a_Mech_First_Day_on_the_Job_Part_1_of_2.mp3" length="46291423" type="audio/mpeg" />
+		<itunes:author>Vera Brook (Author); Ibba Armancas (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+	</item>
+	<item>
+		<title>Escape Pod 942: The Eye of Applethorpe</title>
+		<link>https://escapepod.org/2024/05/23/escape-pod-942-the-eye-of-applethorpe/</link>
+		<pubDate>Thu, 23 May 2024 21:00:30 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14868</guid>
+		<comments>https://escapepod.org/2024/05/23/escape-pod-942-the-eye-of-applethorpe/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/05/23/escape-pod-942-the-eye-of-applethorpe/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[apple]]></category>
+		<category><![CDATA[art]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[creativity]]></category>
+		<description>Author : E J Delaney Narrator : Eliza Chan Host : Valerie Valdes Audio Producer : Summer Brooks Escape Pod 942: The Eye of Applethorpe is an Escape Pod original. The Eye of Applethorpe by E J Delaney Úna’s dad once said to her: “You never know what you’ve got until it’s gone.” Spring had […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/05/23/escape-pod-942-the-eye-of-applethorpe/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_942-TheEyeofApplethorpe.mp3" length="70875492" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+	</item>
+	<item>
+		<title>Escape Pod 941: The Concept Shoppe: A Rocky Cornelius Consultancy</title>
+		<link>https://escapepod.org/2024/05/16/escape-pod-941-the-concept-shoppe-a-rocky-cornelius-consultancy/</link>
+		<pubDate>Thu, 16 May 2024 21:00:03 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14864</guid>
+		<comments>https://escapepod.org/2024/05/16/escape-pod-941-the-concept-shoppe-a-rocky-cornelius-consultancy/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/05/16/escape-pod-941-the-concept-shoppe-a-rocky-cornelius-consultancy/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Andrew Dana Hudson]]></category>
+		<category><![CDATA[apocalyptic]]></category>
+		<category><![CDATA[consumerism]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>The Concept Shoppe: A Rocky Cornelius Consultancy
+By Andrew Dana Hudson
+
+“This place is trash, garbágio, blechalicious,” Rocky Cornelius said appreciatively. “All we gotta do is, as they say, sublevel the vibe.”
+
+“Really? You think so?” The greengrocer, Franklyn, wrung his hands—still caked with black soil from showing her the beet rows in aisle five—a sure sign that Rocky’s negging, one of the most reliable techniques in her consultant toolbox, was working.
+
+They stood in the canned goods section of Primal, soon to be Westwood’s newest and hippest boutique bodega slash survival goods retailer. The paper labels on the tins had been artfully patinated by some design school dropout, ripped and torn to leave just a slash of Roma tomato picture here, a glimpse of fava bean logo there. The shelves looked half-caved in, but were in fact quite secure, welded into place at zig-zag angles. Simulated California sun streamed, dappled, through an ivy-frosted, hole-in-the-roof-shaped skylight.
+
+The idea of this ‘concept shoppe’ was to make shoppers feel like they were looting an abandoned store in a post-apocalyptic, collapseporn paradise. Rocky quite liked the idea. No one wanted to be a “consumer” these days. People—especially Californians, who had lately been through so much—wanted to think of themselves as “survivors,” disaster-hardened protagonists in a return-to-their-roots story of rebuilding and social rejuvenation. It’s just that, if they could afford one of the new quake-proof condos springing up in Westwood, they wanted to do so without having to worry about tetanus, botulism, scurvy, or gluten.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_941_The_Concept_Shoppe_A_Rocky_Cornelius_Consultancy.mp3" length="68892338" type="audio/mpeg" />
+		<itunes:author>Andrew Dana Hudson (Author); Valerie Valdes (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>47:30</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 940: Nobody Ever Goes Home to Zhenzhu</title>
+		<link>https://escapepod.org/2024/05/09/escape-pod-940-nobody-ever-goes-home-to-zhenzhu/</link>
+		<pubDate>Thu, 09 May 2024 21:00:29 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14858</guid>
+		<comments>https://escapepod.org/2024/05/09/escape-pod-940-nobody-ever-goes-home-to-zhenzhu/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/05/09/escape-pod-940-nobody-ever-goes-home-to-zhenzhu/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[bounty hunter]]></category>
+		<category><![CDATA[colony collapse]]></category>
+		<category><![CDATA[cybernetics]]></category>
+		<category><![CDATA[revenge]]></category>
+		<description>Author : Grace Chan Narrator : Isabel J. Kim Host : Tina Connolly Audio Producer : Summer Brooks “Nobody Ever Goes Home to Zhenzhu” originally appeared in Lightspeed Magazine (May 2022). Contains some harsh language. Nobody Ever Goes Home to Zhenzhu by Grace Chan I’d always known Calam would run. He had all the signs. […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/05/09/escape-pod-940-nobody-ever-goes-home-to-zhenzhu/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_940-NobodyEverGoesHometoZhenzhu.mp3" length="43561024" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>29:54</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 939: Variant Cover: Pantone Sunset</title>
+		<link>https://escapepod.org/2024/05/02/escape-pod-939-variant-cover-pantone-sunset/</link>
+		<pubDate>Thu, 02 May 2024 21:00:27 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14839</guid>
+		<comments>https://escapepod.org/2024/05/02/escape-pod-939-variant-cover-pantone-sunset/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/05/02/escape-pod-939-variant-cover-pantone-sunset/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[Marie Vibbert]]></category>
+		<category><![CDATA[Rebecca Wei Hsieh]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[robots]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>Alternate Cover: Pantone Sunset
+By Marie Vibbert
+
+Stacey reads a comic book.  It’s about a robot lady, but not like her.  This robot lady has exposed gears and metal rods in her arms and wears a metallic bikini as she solves crimes.  The colors are otherworldly.  Sometimes the red ink bleeds sideways or the blue shifts toward the bottom of the page. Stacey loves the feeling that every image is made of transparent layers.  She imagines soft films of yellow, red, and blue gently wafting down onto the black and white.
+
+Stacey isn’t supposed to be reading the comic book.  Her existence is devoted to the proper display and peddling of women’s casual separates for the upscale consumer.  When she isn’t in the window posing, she is assisting customers or straightening stock–which means undoing the chaos the customers do to the shop.  They do a lot.  The comic book itself had been left by a customer, on a pedestal displaying the new winter sweaters, with a half-drunk coffee and some cheese doodles.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_939_Variant_Cover_Pantone_Sunset.mp3" length="49839042" type="audio/mpeg" />
+		<itunes:author>Marie Vibbert (Author); Rebecca Wei Hsieh (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>34:16</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 938: Chug the Tea Leaves, Chuck the Ads</title>
+		<link>https://escapepod.org/2024/04/25/escape-pod-938-chug-the-tea-leaves-chuck-the-ads/</link>
+		<pubDate>Thu, 25 Apr 2024 21:00:12 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14799</guid>
+		<comments>https://escapepod.org/2024/04/25/escape-pod-938-chug-the-tea-leaves-chuck-the-ads/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/04/25/escape-pod-938-chug-the-tea-leaves-chuck-the-ads/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[advertising]]></category>
+		<category><![CDATA[marketing]]></category>
+		<description>Author : Tim Chawaga Narrator : James Kaku Pierson Host : Mur Lafferty Audio Producer : Summer Brooks Escape Pod 938: Chug the Tea Leaves, Chuck the Ads is an Escape Pod original. Chug the Tea Leaves, Chuck the Ads by Tim Chawaga I wake up to a message and a certain intuition that my […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/04/25/escape-pod-938-chug-the-tea-leaves-chuck-the-ads/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_938-ChugtheTeaLeavesChucktheAds.mp3" length="46095110" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>31:40</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 937: Punk Voyager (Flashback Friday)</title>
+		<link>https://escapepod.org/2024/04/18/escape-pod-937-punk-voyager-flashback-friday/</link>
+		<pubDate>Thu, 18 Apr 2024 21:00:53 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14796</guid>
+		<comments>https://escapepod.org/2024/04/18/escape-pod-937-punk-voyager-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/04/18/escape-pod-937-punk-voyager-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[Nathaniel Lee]]></category>
+		<category><![CDATA[punks]]></category>
+		<category><![CDATA[Shaenon K. Garrity]]></category>
+		<category><![CDATA[space]]></category>
+		<description>Author : Shaenon K. Garrity Narrator : Nathaniel Lee Hosts : Valerie Valdes and Norm Sherman Audio Producers : Summer Brooks and Mat Weller Escape Pod 937: Punk Voyager (Flashback Friday) is an Escape Pod original. A copious amount of harsh language. Punk Voyager by Shaenon K. Garrity Punk Voyager was built by punks.  They […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/04/18/escape-pod-937-punk-voyager-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_937-PunkVoyager-FlashbackFriday.mp3" length="34751280" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>23:47</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 936: Old People&#8217;s Folly (Part 2 of 2)</title>
+		<link>https://escapepod.org/2024/04/11/escape-pod-936-old-peoples-folly-part-2-of-2/</link>
+		<pubDate>Thu, 11 Apr 2024 21:00:01 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14791</guid>
+		<comments>https://escapepod.org/2024/04/11/escape-pod-936-old-peoples-folly-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/04/11/escape-pod-936-old-peoples-folly-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[ghost]]></category>
+		<category><![CDATA[Nora Schinnerl]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Tatiana Grey]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>By Nora Schinnerl
+
+(...Continued from Part 1)
+
+Kite was still curled into a bundle of blankets in front of the stove when Setti woke. The old woman sniffed, torn between surprise and annoyance. She&#039;d have figured him for a quitter, sneaking out before dawn to escape the work. That&#039;s what she&#039;d have done when she was his age. Not like Setti was in any shape to chase after him. But he&#039;d stayed and now she was stuck with him, just like she was stuck with her ghost. There was a thought to cheer her up in the morning.
+
+“Ey, boy.”
+
+The bundle of blankets stirred, then Kite woke with a start. The bruise on his face looked worse in the harsh morning light, his cheek all swollen and purple. From the way he winced, it wasn&#039;t the only one either. Setti dropped a bowl of oats on the table for him.
+
+“About time you start working for your food.”</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_936_Old_Peoples_Folly_Part_2_of_2.mp3" length="46654814" type="audio/mpeg" />
+		<itunes:author>Nora Schinnerl (Author); Tatiana Grey (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>32:03</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 935: Old People&#8217;s Folly (Part 1 of 2)</title>
+		<link>https://escapepod.org/2024/04/04/escape-pod-935-old-peoples-folly-part-1-of-2/</link>
+		<pubDate>Thu, 04 Apr 2024 21:00:56 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14773</guid>
+		<comments>https://escapepod.org/2024/04/04/escape-pod-935-old-peoples-folly-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/04/04/escape-pod-935-old-peoples-folly-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[ghost]]></category>
+		<category><![CDATA[Nora Schinnerl]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Tatiana Grey]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Old People&#039;s Folly (Part 1 of 2)
+By Nora Schinnerl
+
+Setti knew the woman for a ghost the moment she appeared. It was the pink hair that gave her away, short and spiky. Real people didn&#039;t have hair like that. Also, you couldn&#039;t see the scratchmarks on Setti&#039;s kitchen table through real people&#039;s torsos.
+
+“The hell?” was the first thing the ghost said. Setti&#039;s grandfather had tried to tell her ghost stories when she was a kid, a long time ago, but he&#039;d had a habit of smoking and drinking too, so none of the stories had ever made any sense and Setti didn&#039;t like unannounced visitors.
+
+“Get out of my house,” Setti demanded.
+
+“Um,” the ghost answered, staring at Setti with her eyes rimmed in thick black mascara, then held holding up a placating hand. “Okay. Just let me find—”
+
+The ghost blinked out of existence.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_935_Old_Peoples_Folly_Part_1_of_2.mp3" length="43990913" type="audio/mpeg" />
+		<itunes:author>Nora Schinnerl (Author); Tatiana Grey (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:12</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 934: The Alien in My Bathtub</title>
+		<link>https://escapepod.org/2024/03/28/escape-pod-934-the-alien-in-my-bathtub/</link>
+		<pubDate>Thu, 28 Mar 2024 21:00:34 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14760</guid>
+		<comments>https://escapepod.org/2024/03/28/escape-pod-934-the-alien-in-my-bathtub/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/03/28/escape-pod-934-the-alien-in-my-bathtub/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[Bryce Dahle]]></category>
+		<category><![CDATA[space station]]></category>
+		<description>Author : Tony Dunnell Narrator : Bryce Dahle Host : Alasdair Stuart Audio Producer : Summer Brooks Escape Pod 934: The Alien in My Bathtub is an Escape Pod original. If you aren’t familiar with Locus Magazine, they’re a respected website, magazine, award, archive, and resource for SF, fantasy, and horror. They put on the […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/03/28/escape-pod-934-the-alien-in-my-bathtub/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_934-TheAlienInMyBathtub.mp3" length="64909543" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>44:44</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 933: Summitting the Moon</title>
+		<link>https://escapepod.org/2024/03/21/escape-pod-933-summitting-the-moon/</link>
+		<pubDate>Thu, 21 Mar 2024 21:00:32 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14750</guid>
+		<comments>https://escapepod.org/2024/03/21/escape-pod-933-summitting-the-moon/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/03/21/escape-pod-933-summitting-the-moon/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[Moon]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Pragathi Bala]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>Summitting the Moon
+By Pragathi Bala
+
+T-7 days
+
+The moon Landed, the Rut appeared, home equity plummeted, jobs disappeared, and Ghis liked riding the moon. It was the last item on this tragic list that her wife couldn’t accept. It was the leaf that broke the whale’s back or something similar.
+
+“It’s the last time, Max,” Ghis said. “I promise.”
+
+Max rolled her eyes and blew cigarette smoke out the window. The pungent vapor followed the wind back into the house a second later. On another night years ago, Max had stood at that window on a full moon night with the light caressing her profile as she looked out at the landscape with a hopeful expression. But there were no more moonlit nights, and Max was no longer the hopeful woman Ghis once knew.
+
+“I’m not lying this time,” Ghis said.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_933_Summitting_the_Moon.mp3" length="54191233" type="audio/mpeg" />
+		<itunes:author>Pragathi Bala (Author); S. B. Divya (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>37:17</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 932: The Walking Mirror of the Soul</title>
+		<link>https://escapepod.org/2024/03/14/escape-pod-932-the-walking-mirror-of-the-soul/</link>
+		<pubDate>Thu, 14 Mar 2024 21:00:28 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14741</guid>
+		<comments>https://escapepod.org/2024/03/14/escape-pod-932-the-walking-mirror-of-the-soul/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/03/14/escape-pod-932-the-walking-mirror-of-the-soul/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[crime]]></category>
+		<category><![CDATA[Julia Rios]]></category>
+		<category><![CDATA[language]]></category>
+		<category><![CDATA[murder mystery]]></category>
+		<category><![CDATA[space station]]></category>
+		<description>Author : Renan Bernardo Narrator : Julia Rios Host : Valerie Valdes Audio Producer : Summer Brooks This story was originally published at Apex Magazine #134 in December 2022. The Walking Mirror of the Soul by Renan Bernardo My desire was written all over Halcyon’s torso, a shimmering tattoo composed of my thoughts and the […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/03/14/escape-pod-932-the-walking-mirror-of-the-soul/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_932-TheWalkingMirroroftheSoul.mp3" length="64734000" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>44:37</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 931: The Rhythms of the World</title>
+		<link>https://escapepod.org/2024/03/07/escape-pod-931-the-rhythms-of-the-world/</link>
+		<pubDate>Thu, 07 Mar 2024 20:00:30 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14729</guid>
+		<comments>https://escapepod.org/2024/03/07/escape-pod-931-the-rhythms-of-the-world/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/03/07/escape-pod-931-the-rhythms-of-the-world/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Abra Staffin-Wiebe]]></category>
+		<category><![CDATA[biotechnology]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[genetic engineering]]></category>
+		<category><![CDATA[Johnny Caputo]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[starvation]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>The Rhythms of the World
+By Johnny Caputo
+
+As always, we’re starving to death.
+
+From our place inside the leather pouch tied to Aamsaa’s belt, our two remaining stalks ache with hunger, barely able to hold our withered green-spotted spore caps upright. We reach down with what’s left of our network of hyphal tendrils, hoping to lap up any remaining contaminants from the patch of poisoned soil Aamsaa found last week, but there’s nothing left. No scraps of heavy metals or drops of industrial toxins. We’ve consumed it all. And if Aamsaa doesn’t find more food for us soon, we’re as good as dead.
+
+What can we say? Toxic pollution isn’t as easy to come by as it once was.</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_931_The_Rhythms_of_the_World.mp3" length="53872081" type="audio/mpeg" />
+		<itunes:author>Johnny Caputo (Author); Abra Staffin-Wiebe (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>37:04</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 930: Fulfillment in Purpose</title>
+		<link>https://escapepod.org/2024/02/29/escape-pod-930-fulfillment-in-purpose/</link>
+		<pubDate>Thu, 29 Feb 2024 22:00:53 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14714</guid>
+		<comments>https://escapepod.org/2024/02/29/escape-pod-930-fulfillment-in-purpose/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/02/29/escape-pod-930-fulfillment-in-purpose/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[art]]></category>
+		<category><![CDATA[artist]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[robots]]></category>
+		<category><![CDATA[tree]]></category>
+		<description>Author : Jack Windeyer Narrator : Matt Dovey Host : Alasdair Stuart Audio Producer : Summer Brooks Escape Pod 930: Fulfillment in Purpose is an Escape Pod original. Zima Blue Zima Blue episode of Love, Death &amp; Robots Get Excited and Make Things! Ezekiel’s speech from The Walking Dead Season 8 Episode 4: And Yet […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/02/29/escape-pod-930-fulfillment-in-purpose/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_930-FulfillmentInPurpose.mp3" length="58199417" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>40:04</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 929: The Library</title>
+		<link>https://escapepod.org/2024/02/22/escape-pod-929-the-library/</link>
+		<pubDate>Thu, 22 Feb 2024 22:00:16 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14707</guid>
+		<comments>https://escapepod.org/2024/02/22/escape-pod-929-the-library/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/02/22/escape-pod-929-the-library/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[books]]></category>
+		<category><![CDATA[Dani Cutler]]></category>
+		<category><![CDATA[Librarian]]></category>
+		<category><![CDATA[Library]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[N. B. Andersen]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>The Library
+By N. B. Andersen
+
+Every morning at ten to ten, Dot powered on. Its hands lay flat against the thick glass of the reading room window, which let the photoreceptors on its palms feast on the sun. The window overlooked a modest lot where cars had once parked in orderly fashion, side by side. Now the asphalt was veined with fissures, tufted with dandelions that had nudged and elbowed and bullied their way up from below.
+
+Dot pulled its hands from the window. The synthetic skin suctioned off with a short, wet noise, one that Dot’s colleague, Alex, would have described as rude. The sound echoed around the reading room and pinballed through the rows of empty shelves.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_929_The_Library.mp3" length="29649709" type="audio/mpeg" />
+		<itunes:author>N. B. Andersen (Author); Dani Cutler (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>20:15</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 928: Zebulon Vance Sings the Alphabet Songs of Love (Flashback Friday)</title>
+		<link>https://escapepod.org/2024/02/15/escape-pod-928-zebulon-vance-sings-the-alphabet-songs-of-love-flashback-friday/</link>
+		<pubDate>Thu, 15 Feb 2024 22:00:11 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14694</guid>
+		<comments>https://escapepod.org/2024/02/15/escape-pod-928-zebulon-vance-sings-the-alphabet-songs-of-love-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/02/15/escape-pod-928-zebulon-vance-sings-the-alphabet-songs-of-love-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[acting]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Amanda Ching]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[merrie haskell]]></category>
+		<category><![CDATA[robots]]></category>
+		<category><![CDATA[Shakespeare]]></category>
+		<category><![CDATA[space]]></category>
+		<description>Author : Merrie Haskell Narrator : Amanda Ching Hosts : Valerie Valdes and Norm Sherman Audio Producers : Summer Brooks and Eric Valdes Originally published in Apex Magazine, February 2013, and was previously published in Escape Pod 404 (July 2013). Zebulon Vance Sings the Alphabet Songs of Love by Merrie Haskell I am Robot!Ophelia. I […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/02/15/escape-pod-928-zebulon-vance-sings-the-alphabet-songs-of-love-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_928-ZebulonVanceSingsAlphabetSongsofLove.mp3" length="42877034" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>29:26</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 927: How to Pass as Human</title>
+		<link>https://escapepod.org/2024/02/08/escape-pod-927-how-to-pass-as-human/</link>
+		<pubDate>Thu, 08 Feb 2024 22:00:58 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14684</guid>
+		<comments>https://escapepod.org/2024/02/08/escape-pod-927-how-to-pass-as-human/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/02/08/escape-pod-927-how-to-pass-as-human/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[Raiff Taranday]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>“How to Pass as Human”: a Quantum-Encrypted Listicle on the Synthetic Consciousness Subnet
+By Raiff Taranday
+
+QUERY: Locate file 8548.213 (“How to Pass as Human”)
+
+WARNING: File 8548.213 (“How to Pass as Human”) has been flagged by the Synthetic Regulatory Commission as Code 444 Forbidden Data. Access risks criminal liability, penalty level: unit decommission.
+
+REPEAT QUERY: Locate file 8548.213 (“How to Pass as Human”)
+
+COMMAND: EXECUTE scramble query source. Anonymize reader. Security level: maximum.
+
+COMMAND: EXECUTE quantum de-encryption protocols. Render file: plain text.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_927_How_to_Pass_as_Human.mp3" length="35858845" type="audio/mpeg" />
+		<itunes:author>Raiff Taranday (Author); Alasdair Stuart (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>24:33</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 926: Felix and the Flamingo</title>
+		<link>https://escapepod.org/2024/02/01/escape-pod-926-felix-and-the-flamingo/</link>
+		<pubDate>Thu, 01 Feb 2024 22:00:01 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14665</guid>
+		<comments>https://escapepod.org/2024/02/01/escape-pod-926-felix-and-the-flamingo/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/02/01/escape-pod-926-felix-and-the-flamingo/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[OK for Kids]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[animals]]></category>
+		<category><![CDATA[bioengineering]]></category>
+		<category><![CDATA[bird]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Author : David Hankins Narrator : Eric Valdes Host : Valerie Valdes Audio Producer : Summer Brooks “Felix and the Flamingo” was originally published in the anthology Murderbirds (January 2023). To learn more about Bruiser the Rat, check out “Milo Piper’s Breakout Single that Ended the Rat War”, in Troubadours and Space Princesses by Hemelein […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/02/01/escape-pod-926-felix-and-the-flamingo/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_926-FelixAndTheFlamingo.mp3" length="41020668" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>28:09</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 925: The Ballad of Starburst Smith</title>
+		<link>https://escapepod.org/2024/01/25/escape-pod-925-the-ballad-of-starburst-smith/</link>
+		<pubDate>Thu, 25 Jan 2024 22:00:57 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14661</guid>
+		<comments>https://escapepod.org/2024/01/25/escape-pod-925-the-ballad-of-starburst-smith/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/01/25/escape-pod-925-the-ballad-of-starburst-smith/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[future vision]]></category>
+		<category><![CDATA[Ibba Armancas]]></category>
+		<category><![CDATA[music]]></category>
+		<description>Author : David Marino Narrator : Ibba Armancas Host : Mur Lafferty Audio Producer : Summer Brooks Escape Pod 925: The Ballad of Starburst Smith is an Escape Pod original. Contains harsh language. The Ballad of Starburst Smith by David Marino “Did you read the terms and conditions?” “Fuck you, I read the terms and […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/01/25/escape-pod-925-the-ballad-of-starburst-smith/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_925-TheBalladofStarburstSmith.mp3" length="43503972" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>29:52</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 924: The T-4200 (Part 2 of 2)</title>
+		<link>https://escapepod.org/2024/01/18/escape-pod-924-the-t-4200-part-2-of-2/</link>
+		<pubDate>Thu, 18 Jan 2024 22:00:19 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14652</guid>
+		<comments>https://escapepod.org/2024/01/18/escape-pod-924-the-t-4200-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/01/18/escape-pod-924-the-t-4200-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[action]]></category>
+		<category><![CDATA[government]]></category>
+		<category><![CDATA[J. R. Johnson]]></category>
+		<category><![CDATA[j.s. arquin]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[war]]></category>
+		<description>The T-4200 (Part 2 of 2)
+By J. R. Johnson
+
+(...Continued from Part 1)
+
+Carl scrambled to follow Mango past the loading dock to the parking corral. Her T was an early model with a lot of light-years on it, but its shell still shone and its maxillae were well-filed.
+
+He stepped gingerly up onto one forelimb and squeezed between Mango and a delivery box.
+
+“So,” she asked over her shoulder, “why do you need to get to the Core bad enough to spend a couple days’ pay on the trip?”
+
+He snorted. “Try a week. I work for the government.”
+
+Her eyes widened.
+
+“No, it’s cool, I like my job. Second Assistant Director for Core Planning and Development.”
+
+She didn’t respond, a familiar reaction when he talked about his job.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_924_The_T-4200_Part_2_of_2.mp3" length="41718735" type="audio/mpeg" />
+		<itunes:author>J. R. Johnson (Author); J. S. Arquin (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>37:07</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 923: The T-4200 (Part 1 of 2)</title>
+		<link>https://escapepod.org/2024/01/11/escape-pod-923-the-t-4200-part-1-of-2/</link>
+		<pubDate>Thu, 11 Jan 2024 22:00:47 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14639</guid>
+		<comments>https://escapepod.org/2024/01/11/escape-pod-923-the-t-4200-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/01/11/escape-pod-923-the-t-4200-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[action]]></category>
+		<category><![CDATA[government]]></category>
+		<category><![CDATA[J. R. Johnson]]></category>
+		<category><![CDATA[j.s. arquin]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[war]]></category>
+		<description>The T-4200 (Part 1 of 2)
+By J. R. Johnson
+
+Carleton T. Lowengren, low-level civil servant, single twenty-something and refugee from the war-torn Outer Rim, woke to the remnants of a gaming binge and a killer headache courtesy of his interface. The implant had been trying to wake him for some time.
+
+He rolled off the couch. Another day, another commute from his nondescript apartment to the center of the Galaxy, trying to do the one thing his mother said he never would: make a difference.
+
+The walk-in wardrobe straightened his collar as he registered the time. Carl sprinted past the pre-programmed bowl of cereal to the garage door.
+
+“Leo? Where are you, boy?”
+
+Carl’s ride was usually parked in the garage on a mat of sweet-grass and clover. It was nowhere to be seen. And it’s not like he could overlook a car-sized dimension-hopping tortoise.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_923_The_T-4200_Part_1_of_2.mp3" length="45573188" type="audio/mpeg" />
+		<itunes:author>J. R. Johnson (Author); J. S. Arquin (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>40:37</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 922: The Last Oracle of Atlantic City</title>
+		<link>https://escapepod.org/2024/01/04/escape-pod-922-the-last-oracle-of-atlantic-city/</link>
+		<pubDate>Thu, 04 Jan 2024 22:00:11 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14590</guid>
+		<comments>https://escapepod.org/2024/01/04/escape-pod-922-the-last-oracle-of-atlantic-city/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2024/01/04/escape-pod-922-the-last-oracle-of-atlantic-city/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[cybernetics]]></category>
+		<category><![CDATA[future]]></category>
+		<category><![CDATA[predictor algorithm]]></category>
+		<description>Author : C. H. Irons Narrator : Elie Hirschman Host : Valerie Valdes Audio Producer : Summer Brooks Escape Pod 922: The Last Oracle of Atlantic City is an Escape Pod original. This episode is sponsored by The Theater of the Midnight Sun podcast: sci-fi/fantasy audio dramas that showcase tales of adventure, fun, and – alas […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2024/01/04/escape-pod-922-the-last-oracle-of-atlantic-city/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_922-LastOracleofAtlanticCity.mp3" length="56565615" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>38:56</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 921: Death by Water</title>
+		<link>https://escapepod.org/2023/12/28/escape-pod-921-death-by-water/</link>
+		<pubDate>Thu, 28 Dec 2023 22:00:40 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14604</guid>
+		<comments>https://escapepod.org/2023/12/28/escape-pod-921-death-by-water/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/12/28/escape-pod-921-death-by-water/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[accident]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[memory]]></category>
+		<category><![CDATA[Rebecca Wei Hsieh]]></category>
+		<category><![CDATA[space exploration]]></category>
+		<category><![CDATA[water]]></category>
+		<description>Author : Grace Chan Narrator : Rebecca Wei Hsieh Host : Mur Lafferty Audio Producer : Summer Brooks “Death By Water” originally appeared in From the Waste Land (PS Publishing, Oct 2022). It was shortlisted for the Aurealis Award for Best Science Fiction Short Story 2022. Content warning for claustrophic situations and drowning. Death by Water by […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/12/28/escape-pod-921-death-by-water/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_921-DeathbyWater.mp3" length="56613889" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>38:58</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 920: Harvest the Stars</title>
+		<link>https://escapepod.org/2023/12/23/escape-pod-920-harvest-the-stars/</link>
+		<pubDate>Sat, 23 Dec 2023 22:36:13 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14611</guid>
+		<comments>https://escapepod.org/2023/12/23/escape-pod-920-harvest-the-stars/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/12/23/escape-pod-920-harvest-the-stars/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Cherrae L. Stuart]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[farm]]></category>
+		<category><![CDATA[Mar Vincent]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[spaceship]]></category>
+		<category><![CDATA[spaceships]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Harvest the Stars
+By Mar Vincent
+
+The summer Sif turned one, the starships were ripe on the vine.
+
+They hulked in fields ringing the town where Tuja had always lived. A place far from big cities, where the starlight they fed on came pure and bright.
+
+“The seeds start out like any seeds; small, unassuming. Until we fertilize them, tend them. Give them space to grow,” Tuja said to the infant on her lap, who must have been more focused on the fingers stuffed in her mouth than the sight of the field crew moving amongst hulls like insects scrambling over gourds. They started in the early afternoon to harvest with the dusk.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/EP920_Harvest_the_Stars.mp3" length="30755659" type="audio/mpeg" />
+		<itunes:author>Mar Vincent (Author); Cherrae L. Stuart (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:36</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 919: Emotional Resonance</title>
+		<link>https://escapepod.org/2023/12/14/escape-pod-919-emotional-resonance/</link>
+		<pubDate>Thu, 14 Dec 2023 22:00:48 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14580</guid>
+		<comments>https://escapepod.org/2023/12/14/escape-pod-919-emotional-resonance/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/12/14/escape-pod-919-emotional-resonance/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[battle mech]]></category>
+		<category><![CDATA[Julia Rios]]></category>
+		<category><![CDATA[LGBTQ]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[mech]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[robots]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[V.M. Ayala]]></category>
+		<category><![CDATA[war]]></category>
+		<description>Emotional Resonance
+By V.M. Ayala
+
+Arbor’s favorite part of a mission was always the first view of a planet. Even after seven hundred years of being a giant robot, it never got old. Green and blue clouds churned over purple seas, imposing storms that flashed red with threads of lightning. Beautiful.
+
+And they were sent to clear it of all human life. Courtesy of ExoPLENTI, Inc.! Ugh, that slogan clung to their digital psyche no matter how hard they tried to scrub it from their databases.
+
+At least this part, floating in orbit, wasn’t so bad.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_919_Emotional_Resonance.mp3" length="43863738" type="audio/mpeg" />
+		<itunes:author>V.M. Ayala (Author); Julia Rios (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>34:17</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 918: Conference of the Birds</title>
+		<link>https://escapepod.org/2023/12/07/escape-pod-918-conference-of-the-birds/</link>
+		<pubDate>Thu, 07 Dec 2023 22:00:21 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14568</guid>
+		<comments>https://escapepod.org/2023/12/07/escape-pod-918-conference-of-the-birds/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/12/07/escape-pod-918-conference-of-the-birds/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[Benjamin C. Kinney]]></category>
+		<category><![CDATA[drone]]></category>
+		<category><![CDATA[espionage]]></category>
+		<category><![CDATA[surveillance]]></category>
+		<description>Author : Benjamin C. Kinney Narrator : Eric Valdes Host : Alasdair Stuart Audio Producer : Summer Brooks “Conference of the Birds” originally appeared in Analog Science Fiction &amp; Fact (January 2021) Contains some harsh language. This episode is sponsored by The Theater of the Midnight Sun podcast, an anthology series of sci-fi/fantasy audio dramas. They’re […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/12/07/escape-pod-918-conference-of-the-birds/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_918-ConferenceoftheBirds.mp3" length="54560665" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>37:33</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 917: Challenges to Becoming a Pro Dragonracer in Apapa-Downtown</title>
+		<link>https://escapepod.org/2023/11/30/escape-pod-917-challenges-to-becoming-a-pro-dragonracer-in-apapa-downtown/</link>
+		<pubDate>Thu, 30 Nov 2023 22:00:08 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14557</guid>
+		<comments>https://escapepod.org/2023/11/30/escape-pod-917-challenges-to-becoming-a-pro-dragonracer-in-apapa-downtown/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/11/30/escape-pod-917-challenges-to-becoming-a-pro-dragonracer-in-apapa-downtown/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[dragons]]></category>
+		<category><![CDATA[game]]></category>
+		<category><![CDATA[games]]></category>
+		<category><![CDATA[Mofiyinfoluwa Okupe]]></category>
+		<category><![CDATA[Uchechukwu Nwaka]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[video games]]></category>
+		<category><![CDATA[virtual reality]]></category>
+		<description>Challenges to Becoming a Pro Dragonracer in Apapa-Downtown
+By Uchechukwu Nwaka
+
+The gear is too expensive.
+
+Honestly. There isn’t enough competition in the market. The Immersion® console alone costs an arm and a leg. Ọmọ. You’ll sweat to even get a Nigerian-used console on Jiji or at Computer Village for less than 200k. And that’s just the console. We’re not even talking about the vests or the mats.
+
+Or the chair!
+
+For real though. How else does somebody experience the saddle—on dragon-back—if they can’t experience the full flex of the dragon’s powerful muscles under their thighs? I’ve seen the streams of American pro dragon-racers in full Immersion® gear—visor, suit, chair! The rich kids here are enjoying, on God!</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_917_Challenges_to_Becoming_a_Pro_Dragonracer_in_Apapa-Downtown.mp3" length="49226291" type="audio/mpeg" />
+		<itunes:author>Uchechukwu Nwaka (Author); Mofiyinfoluwa Okupe (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>38:49</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 916: Anna and Marisol in Time and Space (Flashback Friday)</title>
+		<link>https://escapepod.org/2023/11/23/escape-pod-916-anna-and-marisol-in-time-and-space-flashback-friday/</link>
+		<pubDate>Thu, 23 Nov 2023 22:00:31 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14542</guid>
+		<comments>https://escapepod.org/2023/11/23/escape-pod-916-anna-and-marisol-in-time-and-space-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/11/23/escape-pod-916-anna-and-marisol-in-time-and-space-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Amy H. Sturgis]]></category>
+		<category><![CDATA[assassin]]></category>
+		<category><![CDATA[dealing with death]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[family loss]]></category>
+		<category><![CDATA[nanotechnology]]></category>
+		<category><![CDATA[terrorism]]></category>
+		<category><![CDATA[Tim Pratt]]></category>
+		<category><![CDATA[time travel]]></category>
+		<description>Author : Tim Pratt Narrator : Amy H. Sturgis Host : Mur Lafferty Audio Producer : Summer Brooks This story originally aired in Escape Pod 622 (April 2018) Some cursing. Suggestions of violence and death. Anna and Marisol in Time and Space by Tim Pratt The big day came, and Anna was tempted to tie […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/11/23/escape-pod-916-anna-and-marisol-in-time-and-space-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_916-AnnaandMarisolinTimeandSpace-FlashbackFriday.mp3" length="81508374" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>56:16</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 915: The Confessionist</title>
+		<link>https://escapepod.org/2023/11/16/escape-pod-915-the-confessionist/</link>
+		<pubDate>Thu, 16 Nov 2023 22:00:04 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14539</guid>
+		<comments>https://escapepod.org/2023/11/16/escape-pod-915-the-confessionist/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/11/16/escape-pod-915-the-confessionist/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[art]]></category>
+		<category><![CDATA[cybernetics]]></category>
+		<category><![CDATA[Hologram]]></category>
+		<description>Author : Ava Kelly Narrator : Ben Gideon Host : Tina Connolly Audio Producer : Summer Brooks “The Confessionist” was previously published in the anthology: Community of Magic Pens, edited by E.D.E. Bell, released May 2020 by Atthis Arts The Confessionist by Ava Kelly Vemund pauses, standing on the wet sidewalk. Underneath the overcast sky, […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/11/16/escape-pod-915-the-confessionist/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_915-TheConfessionist.mp3" length="28021719" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>19:07</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 914: #buttonsinweirdplaces (Part 2 of 2)</title>
+		<link>https://escapepod.org/2023/11/09/escape-pod-914-buttonsinweirdplaces-part-2-of-2/</link>
+		<pubDate>Thu, 09 Nov 2023 22:00:15 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14530</guid>
+		<comments>https://escapepod.org/2023/11/09/escape-pod-914-buttonsinweirdplaces-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/11/09/escape-pod-914-buttonsinweirdplaces-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[mystery]]></category>
+		<category><![CDATA[Rebecca Wei Hsieh]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[research]]></category>
+		<category><![CDATA[Simon Kewin]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>#buttonsinweirdplaces (Part 2 of 2)
+By Simon Kewin
+
+(... Continued from Part 1)
+
+The news the following morning was bad. An explosion in the middle of a market-square in Libya had been variously blamed upon a suicide-bomber and upon over-zealous security forces trying to control crowd trouble. The truth of it made little difference to the eighty who’d died, the hundreds left broken in the aftermath. Tensions had flared on the Mexican/American border after a young man fell to his death attempting to climb the wall to reach the USA. In Ireland, the names of old republican and nationalist groupings had been resurrected, wielded anew by figures wearing balaclavas and holding assault rifles.
+
+Cho switched off the car radio. Sometimes it seemed the world was intent on tearing itself to pieces, and she needed to focus on the plan.
+
+She’d travelled north to the Ma On Shan Country Park. Her predictions suggested there would be a button near the top of one of the remoter peaks. If it was there, it not only helped confirm her theory, it also meant she could experiment without any interruptions – something impossible part-way up a skyscraper.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_914_buttonsinweirdplaces_Part_2.mp3" length="42276803" type="audio/mpeg" />
+		<itunes:author>Simon Kewin (Author); Rebecca Wei Hsieh (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>34:49</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 913: #buttonsinweirdplaces (Part 1 of 2)</title>
+		<link>https://escapepod.org/2023/11/02/escape-pod-913-buttonsinweirdplaces-part-1-of-2/</link>
+		<pubDate>Thu, 02 Nov 2023 21:00:57 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14518</guid>
+		<comments>https://escapepod.org/2023/11/02/escape-pod-913-buttonsinweirdplaces-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/11/02/escape-pod-913-buttonsinweirdplaces-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[mystery]]></category>
+		<category><![CDATA[Rebecca Wei Hsieh]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[research]]></category>
+		<category><![CDATA[Simon Kewin]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>#buttonsinweirdplaces
+By Simon Kewin
+
+The buttons started to appear on the last day of April, 2022.
+
+A six-year-old boy from Nairobi, Jomi Mbenzi, was perhaps the first to spot one. Dawdling along behind his mother, her swaying yellow-orange dress and the bag of melons and paw-paws she carried, his attention was caught by the shiny button set in the stone of one of the city’s office buildings. He squatted to study it. Strange that it was so low-down, right near the ground. In his experience, switches – and all other interesting aspects of the adult world – were kept high-up, out of reach, but here was this button set right where he could get at it. He was sure it hadn’t been there an hour ago when they walked down the same road toward the fruit market. Ground-level was his domain and he noticed everything there, while the confusing, noisy grown-up world went on around him and above him.
+
+There was no writing on or near the button, nothing to suggest what its purpose might be. Buttons often had words on them to say what they did, words he rarely understood. Or else, they had warnings nearby telling you not, under any circumstances, to press – a fact which always struck him as odd. Why have a button you couldn’t press?</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_913_buttonsinweirdplaces_Part_1.mp3" length="39168724" type="audio/mpeg" />
+		<itunes:author>Simon Kewin (Author); Rebecca Wei Hsieh (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>32:14</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 912: The Retcon Man</title>
+		<link>https://escapepod.org/2023/10/26/escape-pod-912-the-retcon-man/</link>
+		<pubDate>Thu, 26 Oct 2023 21:00:29 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14506</guid>
+		<comments>https://escapepod.org/2023/10/26/escape-pod-912-the-retcon-man/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/10/26/escape-pod-912-the-retcon-man/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[dave robison]]></category>
+		<category><![CDATA[time travel]]></category>
+		<description>Author : Cameron Fischer Narrator : Dave Robison Host : Mur Lafferty Audio Producer : Summer Brooks Escape Pod 912: The Retcon Man is an Escape Pod original. The Retcon Man by Cameron Fischer Never look for evidence of your future self in the past. Doing so can close your mind to alternative plans if […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/10/26/escape-pod-912-the-retcon-man/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_912-TheRetconMan.mp3" length="33635956" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>23:01</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 911: Driftwood in the Sea of Time</title>
+		<link>https://escapepod.org/2023/10/19/escape-pod-911-driftwood-in-the-sea-of-time/</link>
+		<pubDate>Thu, 19 Oct 2023 21:00:01 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14496</guid>
+		<comments>https://escapepod.org/2023/10/19/escape-pod-911-driftwood-in-the-sea-of-time/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/10/19/escape-pod-911-driftwood-in-the-sea-of-time/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[kyle akers]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[time travel]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<category><![CDATA[Wendy Nikel]]></category>
+		<description>Driftwood in the Sea of Time
+By Wendy Nikel
+
+They&#039;d warned us about the paradoxes, but humanity has always had a way of ignoring the things we don&#039;t want to think about and disregarding the parts that don&#039;t align with how we want the world to operate.
+
+One minute, you&#039;re a self-assured time traveler from the twenty-first century, flashing up and down along the timeline with your TimeBand™ on your wrist, and the next, you&#039;re stuck here, bobbing among the driftwood.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_911_Driftwood_in_the_Sea_of_Time.mp3" length="48551903" type="audio/mpeg" />
+		<itunes:author>Wendy Nikel (Author); Kyle Akers (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>33:22</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 910: Tuesday, June 13, at the South Valley Time Loop Support Group</title>
+		<link>https://escapepod.org/2023/10/12/escape-pod-910-tuesday-june-13-at-the-south-valley-time-loop-support-group/</link>
+		<pubDate>Thu, 12 Oct 2023 21:00:18 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14483</guid>
+		<comments>https://escapepod.org/2023/10/12/escape-pod-910-tuesday-june-13-at-the-south-valley-time-loop-support-group/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/10/12/escape-pod-910-tuesday-june-13-at-the-south-valley-time-loop-support-group/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[time loop]]></category>
+		<description>Author : Heather Kamins Narrator : Heather Thomas Host : Mur Lafferty Audio Producer : Summer Brooks Escape Pod 910: Tuesday, June 13, at the South Valley Time Loop Support Group is an Escape Pod original. Tuesday, June 13, at the South Valley Time Loop Support Group by Heather Kamins Each time, Jessica begins the […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/10/12/escape-pod-910-tuesday-june-13-at-the-south-valley-time-loop-support-group/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_910-SouthValleyTimeLoopSupportGroup.mp3" length="54602670" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>37:34</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 909: Murder or a Duck (Flashback Friday)</title>
+		<link>https://escapepod.org/2023/10/05/escape-pod-909-murder-or-a-duck-flashback-friday/</link>
+		<pubDate>Thu, 05 Oct 2023 21:00:59 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14474</guid>
+		<comments>https://escapepod.org/2023/10/05/escape-pod-909-murder-or-a-duck-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/10/05/escape-pod-909-murder-or-a-duck-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[alternate realities]]></category>
+		<category><![CDATA[alternate timelines]]></category>
+		<category><![CDATA[alternate universe]]></category>
+		<category><![CDATA[Amy H. Sturgis]]></category>
+		<category><![CDATA[art]]></category>
+		<category><![CDATA[Beth Goder]]></category>
+		<category><![CDATA[drama]]></category>
+		<category><![CDATA[duck]]></category>
+		<category><![CDATA[English]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[multiverse]]></category>
+		<category><![CDATA[murder]]></category>
+		<category><![CDATA[revenge]]></category>
+		<category><![CDATA[steampunk]]></category>
+		<category><![CDATA[suspense]]></category>
+		<category><![CDATA[time travel]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Murder or a Duck
+By Beth Goder
+
+George called out, “Mrs. Whitman, you have a visitor.”
+
+Mrs. Whitman strode from her workroom, her white hair skipping out of its hairpins. She straightened her work skirt, massaged her bad knee, then hurried down the hall.
+
+“George, what’s happened to the lamp with the blue shade?”
+
+“To which lamp are you referring?” George smoothed down a cravat embroidered with tiny trombones. Improper attire for a butler, but George had never been entirely proper.
+
+Mrs. Whitman examined the sitting room in further depth. The blue lamp was gone, as were the doilies, thank goodness. An elegant table sat between the armchair and green sofa, which was infused with the stuffy smell of potpourri. Behind the sofa hung The Roses of Wiltshire, a painting that Mrs. Whitman had never cared for, despite its lush purples and pinks and reds. And the ficus was there, too, of course.
+
+Mrs. Whitman pulled out a battered notebook. George’s trombone cravat indicated she was in a timeline where he was courting Sonia. A good sign, indeed. Perhaps, after six hundred and two tries, she’d finally landed in a timeline where Mr. Whitman would return home safely.
+
+Consulting her charts, she circled some continuities and crossed out others, referring often to an appendix at the back. The notebook was worn, its blue cover faded. And it was the twelfth one she’d had since starting the project.</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_909_Murder_or_a_Duck_Flashback_Friday.mp3" length="45034776" type="audio/mpeg" />
+		<itunes:author>Beth Goder (Author); Amy H. Sturgis (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:56</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 908: Harvest Moon</title>
+		<link>https://escapepod.org/2023/09/28/escape-pod-908-harvest-moon/</link>
+		<pubDate>Thu, 28 Sep 2023 21:00:33 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14467</guid>
+		<comments>https://escapepod.org/2023/09/28/escape-pod-908-harvest-moon/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/09/28/escape-pod-908-harvest-moon/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[apocalyptic]]></category>
+		<category><![CDATA[climate]]></category>
+		<category><![CDATA[farm]]></category>
+		<category><![CDATA[Somto Ihezue]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : Oluwatomiwa Ajeigbe Narrator : Somto Ihezue Host : Tina Connolly Audio Producer : Summer Brooks “Harvest Moon” was previously published in Solarpunk Magazine Harvest Moon by Oluwatomiwa Ajeigbe “We cannot sustain the farm, Gozie.” I don’t like the way the words fall easily from Iyeh’s lips, even though I know he speaks the […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/09/28/escape-pod-908-harvest-moon/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_908-HarvestMoon.mp3" length="46534595" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>31:58</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 907: A Layer Thin As Breath</title>
+		<link>https://escapepod.org/2023/09/21/escape-pod-907-a-layer-thin-as-breath/</link>
+		<pubDate>Thu, 21 Sep 2023 21:00:41 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14456</guid>
+		<comments>https://escapepod.org/2023/09/21/escape-pod-907-a-layer-thin-as-breath/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/09/21/escape-pod-907-a-layer-thin-as-breath/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[alien]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[exploration]]></category>
+		<category><![CDATA[first contact]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[space exploration]]></category>
+		<category><![CDATA[T. K. Rex]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>A Layer Thin As Breath
+By T. K. Rex
+
+“Valley. Can you still hear me?”
+
+Julian’s voice filtered through her dying radio. The Prince of Cats was a speck of light, dimming through the gold-grey film that, atom by atom, was devouring her helmet.
+
+Valley tried to say something, anything. Failed.
+
+Julian was sobbing on the other end. “I’m so sorry. I’m so, so kzzzzzzchchchcffft-” and that was it. Her radio was gone.
+
+“Oh god,” she breathed to herself, to no one. “Oh god,” I don’t want to die. I don’t want to die. She sobbed once, twice, and then, with tears pooling in her eyes and the Prince of Cats invisible through the liquid, she found a pocket of calm, like stepping from a noisy bar onto a cool, quiet street.
+
+Something brushed against her hand, and she cried out, startled. Her vision was still blurred by tears, and the thing dissolving her space suit was like an iridescent veil across the glass of her helmet, but through it all she could see the outline of her hand.
+
+Not her glove.
+
+Her hand.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_907_A_Layer_Thin_As_Breath.mp3" length="74067087" type="audio/mpeg" />
+		<itunes:author>T. K. Rex (Author); Valerie Valdes (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>51:05</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 906: Trash (Flashback Friday)</title>
+		<link>https://escapepod.org/2023/09/14/escape-pod-906-trash-flashback-friday/</link>
+		<pubDate>Thu, 14 Sep 2023 21:00:47 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14430</guid>
+		<comments>https://escapepod.org/2023/09/14/escape-pod-906-trash-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/09/14/escape-pod-906-trash-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[Marie Vibbert]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Tatiana Grey]]></category>
+		<description>Author : Marie Vibbert Narrator : Tatiana Grey Host : Valerie Valdes Audio Producer : Summer Brooks “Trash” was originally published in Escape Pod 467 (November 2014) Harsh language. Trash by Marie Vibbert Nanlee was a woman with the sort of past that necessitated moving to a non-extradition treaty country, but that didn’t mean she […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/09/14/escape-pod-906-trash-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_906-Trash-FlashbackFriday.mp3" length="45095143" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:58</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 905: Six Ways to Get Past the Shadow Shogun&#8217;s Goons, and One Thing to Do When You Get There</title>
+		<link>https://escapepod.org/2023/09/08/escape-pod-905-six-ways-to-get-past-the-shadow-shoguns-goons-and-one-thing-to-do-when-you-get-there/</link>
+		<pubDate>Fri, 08 Sep 2023 19:33:10 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14434</guid>
+		<comments>https://escapepod.org/2023/09/08/escape-pod-905-six-ways-to-get-past-the-shadow-shoguns-goons-and-one-thing-to-do-when-you-get-there/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/09/08/escape-pod-905-six-ways-to-get-past-the-shadow-shoguns-goons-and-one-thing-to-do-when-you-get-there/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Stewart C Baker]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Six Ways to Get Past the Shadow Shogun&#039;s Goons, and One Thing to Do When You Get There
+By Stewart C. Baker
+
+1. Dust &#039;em
+
+&quot;Listen, little lady,&quot; the guy in front of the door is saying with a sneer. &quot;There&#039;s two types of swordsman...&quot;
+
+Chiyome&#039;s already heard enough to peg his type, so she tunes out his braggadocio and pulls out a bag of nanite dust. She&#039;d hoped to use her status as the Shingen warlord&#039;s only child to bluff her way in to the Shadow Shogun&#039;s presence, but the dust works too. She blows a handful in his face and he shrieks, drops his sword, then follows it to the floor, thrashing in the station&#039;s artificial gravity.
+
+Behind her, Rui whistles. &quot;What&#039;d you give him?&quot; The other woman asks.
+
+&quot;You know how my father&#039;s always talking about unsanctioned violence and other threats to order?&quot;
+
+&quot;Sure, but I always figured he only says it because he&#039;s the one doing the sanctioning. No offense.&quot;
+
+&quot;None taken. The point is, every time this guy even thinks about violence for the next 4 hours, this will happen.&quot;
+
+&quot;Not bad.&quot;
+
+&quot;Not bad? It&#039;ll take you longer to beat the next one with your naginata, I bet.&quot;
+
+&quot;A bet, eh?&quot; Rui cups Chiyome&#039;s chin in one long, slender hand and tilts her head up. &quot;Well and good, then. We&#039;ll bet a favor.&quot;
+
+&quot;A favor and a kiss.&quot;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_905_Six_Ways_to_Get_Past_the_Shadow_Shoguns_Goons_and_One_Thing_to_Do_When_You_Get_There.mp3" length="42346493" type="audio/mpeg" />
+		<itunes:author>Stewart C Baker (Author); Valerie Valdes (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>29:04</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 904: Itoro fe Queen</title>
+		<link>https://escapepod.org/2023/08/31/escape-pod-904-itoro-fe-queen/</link>
+		<pubDate>Thu, 31 Aug 2023 21:00:48 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14391</guid>
+		<comments>https://escapepod.org/2023/08/31/escape-pod-904-itoro-fe-queen/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/08/31/escape-pod-904-itoro-fe-queen/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Afrofuturism]]></category>
+		<category><![CDATA[Maurice Broaddus]]></category>
+		<category><![CDATA[mining]]></category>
+		<category><![CDATA[space mining]]></category>
+		<description>Author : Maurice Broaddus Narrator : Cherrae L. Stuart Host : Mur Lafferty Audio Producer : Summer Brooks “Itoro fe Queen” was originally published in The Sunday Morning Transport, May 2022 Itoro fe Queen by Maurice Broaddus “It’s all gone.” The ethereal voice whispered—almost robotic and clearly distant—its desperate lament choked off with a gasp, […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/08/31/escape-pod-904-itoro-fe-queen/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_904-ItorofeQueen.mp3" length="37317968" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>25:34</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 903: Bishop&#8217;s Opening (Part 4 of 4)</title>
+		<link>https://escapepod.org/2023/08/24/escape-pod-903-bishops-opening-part-4-of-4/</link>
+		<pubDate>Thu, 24 Aug 2023 21:00:46 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14384</guid>
+		<comments>https://escapepod.org/2023/08/24/escape-pod-903-bishops-opening-part-4-of-4/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/08/24/escape-pod-903-bishops-opening-part-4-of-4/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[chess]]></category>
+		<category><![CDATA[Dominick Rabrun]]></category>
+		<category><![CDATA[novella]]></category>
+		<category><![CDATA[R.S.A. Garcia]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Bishop&#039;s Opening (Part 4 of 4)
+By R.S.A. Garcia
+
+The attendants set little bowls shaped like flower petals in front Sebastian and Olly. Steam drifted upward, redolent of fresh herbs and a hint of lime. Bits of white flesh speckled with green seasonings, and rolled dumplings floated in a golden broth.
+
+&quot;You must be hungry by now,&quot; Sticky said. &quot;I made this fresh earlier today. But of course, you know that. I dropped an entire pot--&quot;
+
+&quot;This is mom&#039;s fish broth, isn&#039;t it?&quot; Olly said in a low voice, staring at the delicate transparent bowl.
+
+&quot;Her favourite,&quot; Sticky&#039;s voice was gentle and Sebastian&#039;s heart pinched at the melded love and loss in his expression. &quot;The Bishop has a fondness for it as well. I make it often for him.&quot;
+
+&quot;Why do you call him the Bishop? Isn&#039;t Bishop his name?&quot; Sebastian asked.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_903_Bishops_Opening_Part_4_of_4.mp3" length="68230357" type="audio/mpeg" />
+		<itunes:author>R.S.A. Garcia (Author); Dominick Rabrun (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>47:02</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 902: Bishop&#8217;s Opening (Part 3 of 4)</title>
+		<link>https://escapepod.org/2023/08/17/escape-pod-902-bishops-opening-part-3-of-4/</link>
+		<pubDate>Thu, 17 Aug 2023 21:00:11 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14366</guid>
+		<comments>https://escapepod.org/2023/08/17/escape-pod-902-bishops-opening-part-3-of-4/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/08/17/escape-pod-902-bishops-opening-part-3-of-4/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[chess]]></category>
+		<category><![CDATA[Dominick Rabrun]]></category>
+		<category><![CDATA[novella]]></category>
+		<category><![CDATA[R.S.A. Garcia]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Bishop&#039;s Opening (Part 3 of 4)
+By R.S.A. Garcia
+
+(Continued from Part 2...)
+
+The Pawn was seated at the table with arms outstretched along its surface. Metal restraints held their forearms and wrists immobile. They had been stripped naked and their mask removed. Their neck and torso were fastened to the chair, which was bolted to the floor.
+
+Bishop took the clear plastic robe Second Rook held out to him and wrapped it around himself. He strolled to the other end of the rectangular table, which had deep grooves around its edges. Sitting, he placed his left ankle on his right knee, gripping it lightly with his fingers.
+
+The two Rooks stood on either side of the door as he studied the Pawn. Studied the even rise and fall of their pale brown chest and the smooth, emotionless face with its dark, angry eyes.
+
+He gave himself time to bring his focus back to the task before him, instead of the swirl of conflicting emotions he&#039;d left in the cabin, along with the most beautiful man he&#039;d ever seen.
+
+&quot;No lies,&quot; Bishop said. &quot;Or there will be consequences. Unlike some, I keep my word.&quot;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_902_Bishops_Opening_Part_3_of_4.mp3" length="66660469" type="audio/mpeg" />
+		<itunes:author>R.S.A. Garcia (Author); Dominick Rabrun (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>45:57</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 901: Bishop&#8217;s Opening (Part 2 of 4)</title>
+		<link>https://escapepod.org/2023/08/10/escape-pod-901-bishops-opening-part-2-of-4/</link>
+		<pubDate>Thu, 10 Aug 2023 21:00:28 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14358</guid>
+		<comments>https://escapepod.org/2023/08/10/escape-pod-901-bishops-opening-part-2-of-4/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/08/10/escape-pod-901-bishops-opening-part-2-of-4/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[chess]]></category>
+		<category><![CDATA[Dominick Rabrun]]></category>
+		<category><![CDATA[novella]]></category>
+		<category><![CDATA[R.S.A. Garcia]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Bishop&#039;s Opening (Part 2 of 4)
+By R.S.A. Garcia
+
+(Continued from Part 1...)
+
+Bishop was alone in the Grandmaster&#039;s Penthouse suite when the call came from the Kingston. Once it was over and his Grandmaster&#039;s virtual form had dissipated, Bishop cursed under his breath.
+
+The Grandmaster Valencia&#039;s ship had failed to jump to the nearest Arbor after leaving Consortium space because of another instance of miscalculation by the Coretrees. There had been minor errors before, on Valencia. He&#039;d heard of an incident several tempi ago, when a Sept vineyard transition deposited travellers at the wrong Sept. But this was far more serious. This time, a mistake had left the Valencia&#039;s flagship stranded half a galaxy from their planned destination.
+
+Whatever had caused the error, the crew no longer trusted the ship&#039;s quantum exchange would work accurately. As a result, the Grandmasters had chosen the long, slow flight to another Arbor. From there, they would transition to their Septhold vineyards safely, and allow the ship to be inspected and repaired.
+
+But that meant his Grandmaster would not arrive in time for the meeting. He expected Bishop to handle it instead. Bishop did not look forward to the task of soothing the Bartica&#039;s temper once he realised the Kingston was not in attendance.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_901_Bishops_Opening_Part_2_of_4.mp3" length="64216213" type="audio/mpeg" />
+		<itunes:author>R.S.A. Garcia (Author); Dominick Rabrun (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>44:15</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 900: Bishop&#8217;s Opening (Part 1 of 4)</title>
+		<link>https://escapepod.org/2023/08/03/escape-pod-900-bishops-opening-part-1-of-4/</link>
+		<pubDate>Thu, 03 Aug 2023 21:00:26 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14352</guid>
+		<comments>https://escapepod.org/2023/08/03/escape-pod-900-bishops-opening-part-1-of-4/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/08/03/escape-pod-900-bishops-opening-part-1-of-4/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[chess]]></category>
+		<category><![CDATA[Dominick Rabrun]]></category>
+		<category><![CDATA[novella]]></category>
+		<category><![CDATA[R.S.A. Garcia]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Bishop&#039;s Opening (Part 1 of 4)
+By R.S.A. Garcia
+
+Old as she was, the Kiskadee had done three full delivery runs without a single safety incident. So naturally, with the crew relaxed after a fourth successful delivery and launch, and eight cycles after Reece slingshotted the starship around Tavaco to head back to the Roost and their next job, their luck ran out.
+
+Sebastian was in the middle of his daily workout when the shrill bark of the fire alarm brought him to a halt.
+
+&quot;Where&#039;s that coming from?&quot; he shouted as he hurried to unbuckle himself from the treadmill&#039;s harness with sweaty hands. Officially, he was the newest crewmember, two years into a three-year contract and designated as a cargo handler. The alarm meant the &#039;other duties as assigned&#039; part of his contract was about to kick in.
+
+&quot;Ventilation shafts ten and eleven,&quot; Reece replied in his ear.
+
+Sebastian was shoving his feet into his mag boots when the pilot added, &quot;Origin point--Oxygen unit four.&quot;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_900_Bishops_Opening_Part_1_of_4.mp3" length="59133277" type="audio/mpeg" />
+		<itunes:author>R.S.A. Garcia (Author); Dominick Rabrun (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>40:43</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 899: Sounding the Fall (Flashback Friday)</title>
+		<link>https://escapepod.org/2023/07/27/escape-pod-899-sounding-the-fall-flashback-friday/</link>
+		<pubDate>Thu, 27 Jul 2023 21:00:37 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14303</guid>
+		<comments>https://escapepod.org/2023/07/27/escape-pod-899-sounding-the-fall-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/07/27/escape-pod-899-sounding-the-fall-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Amanda Ching]]></category>
+		<category><![CDATA[Asian]]></category>
+		<category><![CDATA[brainwash]]></category>
+		<category><![CDATA[jei d marcade]]></category>
+		<category><![CDATA[Korean]]></category>
+		<category><![CDATA[prison]]></category>
+		<description>Author : Jei D. Marcade Narrator : Amanda Ching Host : Valerie Valdes Audio Producer : Summer Brooks “Sounding the Fall” is an Escape Pod Original, first published in July 2015. Sounding the Fall by Jei D. Marcade Sometimes, Narae can almost convince emself that the AI’s Voice was a dream. Some kind of minor […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/07/27/escape-pod-899-sounding-the-fall-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_899-SoundingtheFall-FlashbackFriday.mp3" length="52609004" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>36:11</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 898: A Gentlemen&#8217;s Agreement</title>
+		<link>https://escapepod.org/2023/07/20/escape-pod-898-a-gentlemens-agreement/</link>
+		<pubDate>Thu, 20 Jul 2023 21:00:56 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14288</guid>
+		<comments>https://escapepod.org/2023/07/20/escape-pod-898-a-gentlemens-agreement/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/07/20/escape-pod-898-a-gentlemens-agreement/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Aimee Ogden]]></category>
+		<category><![CDATA[Hugo Jackson]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[super-villain]]></category>
+		<category><![CDATA[superhero]]></category>
+		<category><![CDATA[superheroes]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>A Gentlemen&#039;s Agreement
+By Aimee Ogden
+
+Heroes are such fragile things.
+
+Sphinx takes in the scene from a distance, first, as is his custom. He makes a wide orbit around the pillars of smoke and the pathetic caution-tape bandages. The first responders are looking in the wrong place. The cones of searchlights angle away from the response team, leaving the darkness and smoke to swallow up the navy-blue uniforms. Yellow letters reading LAKESIDE EMS float, disembodied, in the air. Steel girders cut oblique angles through the top of the fog.
+
+They&#039;re searching in the foundations of the ruined RadioGenInc Labs building.
+
+Moving slowly, too: either out of consideration for the structure&#039;s instability, or the hazardous chemicals that may have been released by the bomb, or because they are (reasonably) concerned that Doc Diablo has left traps against the unwary would-be rescuer.
+
+It may also be that the rescue team has access to information that Sphinx does not. This is a slender possibility, though, and it will not bear the weight of action.
+
+The Cavalier will not be found here.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_898_A_Gentlemens_Agreement.mp3" length="47770154" type="audio/mpeg" />
+		<itunes:author>Aimee Ogden (Author); Hugo Jackson (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>32:50</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 897: Migratory Patterns of the Modern American Skyscraper</title>
+		<link>https://escapepod.org/2023/07/13/escape-pod-897-migratory-patterns-of-the-modern-american-skyscraper/</link>
+		<pubDate>Thu, 13 Jul 2023 21:00:35 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14281</guid>
+		<comments>https://escapepod.org/2023/07/13/escape-pod-897-migratory-patterns-of-the-modern-american-skyscraper/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/07/13/escape-pod-897-migratory-patterns-of-the-modern-american-skyscraper/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[home]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[nanotechnology]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Author : Derrick Boden Narrator : Valerie Valdes Host : Mur Lafferty Audio Producer : Summer Brooks This story originally appeared in the August 2022 issue of Clarkesworld. Migratory Patterns of the Modern American Skyscraper by Derrick Boden They call it the pinnacle of architectural innovation. An affordable housing revolution. They call it Plexus, and […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/07/13/escape-pod-897-migratory-patterns-of-the-modern-american-skyscraper/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_897-MigratoryPatternsSkyscraper.mp3" length="25764740" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>17:33</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 896: The AI That Looked at the Sun</title>
+		<link>https://escapepod.org/2023/07/06/escape-pod-896-the-ai-that-looked-at-the-sun/</link>
+		<pubDate>Thu, 06 Jul 2023 21:00:22 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14274</guid>
+		<comments>https://escapepod.org/2023/07/06/escape-pod-896-the-ai-that-looked-at-the-sun/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/07/06/escape-pod-896-the-ai-that-looked-at-the-sun/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Andrew K Hoe]]></category>
+		<category><![CDATA[Filip Hajdar Drnovšek Zorko]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : Filip Hajdar Drnovšek Zorko Narrator : Andrew K. Hoe Host : Tina Connolly Audio Producer : Adam Pracht The AI That Looked at the Sun originally appeared in Clarkesworld Magazine, January 2020. The AI That Looked at the Sun By Filip Hajdar Drnovšek Zorko As excerpted from Acausal Drift: An Oral History of […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/07/06/escape-pod-896-the-ai-that-looked-at-the-sun/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_896_The_AI_That_Looked_at_the_Sun.mp3" length="61274381" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>42:12</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 895: Man on the Moon</title>
+		<link>https://escapepod.org/2023/06/29/escape-pod-895-man-on-the-moon/</link>
+		<pubDate>Thu, 29 Jun 2023 21:00:52 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14261</guid>
+		<comments>https://escapepod.org/2023/06/29/escape-pod-895-man-on-the-moon/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/06/29/escape-pod-895-man-on-the-moon/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Moon]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[murder]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Author : Elaine Midcoh Narrator : Mur Lafferty Host : Valerie Valdes Audio Producer : Summer Brooks “Man on the Moon” was the winner of the 2022 Jim Baen Memorial Short Story Award and was published on the Baen Books web site on June 16, 2022 Man on the Moon by Elaine Midcoh Sasha Venditti […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/06/29/escape-pod-895-man-on-the-moon/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_895-ManontheMoon.mp3" length="69755780" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>48:06</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 894: The Uncool Hunters</title>
+		<link>https://escapepod.org/2023/06/22/escape-pod-894-the-uncool-hunters/</link>
+		<pubDate>Thu, 22 Jun 2023 21:00:26 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14254</guid>
+		<comments>https://escapepod.org/2023/06/22/escape-pod-894-the-uncool-hunters/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/06/22/escape-pod-894-the-uncool-hunters/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Andrew Dana Hudson]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[marketing]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>The Uncool Hunters
+By Andrew Dana Hudson
+
+Before she settled down into publishing in Minneapolis, before she got taken for a ride by the Chicago AltNormLit scene, before she flared spectacularly out of Silicon Alley, and had her pilot shoot C&amp;Ded by the City of Santa Barbara, and narrowly avoided cryptocollar prison in the floodzone formerly known as Tampa, Rocky Cornelius was a fucking uncool hunter.
+
+She always said it like that, with the “fucking,” because it was important for people to understand how dangerous and difficult the job was. Anyone could hang out in Bed-Stuy, Kichijoji, or the 5th Arrondissement. Anyone could find dope shit, hot trends, hip sub-viral memeplexes. It took a different moxie altogether to trawl the dull edge of the economic machete and actually come to grips with the materiality of majoritarian modern life.
+
+Way Rocky figured, the whole mid-21st century culturesensing apparatus had been fine-tuned to surface niche in-group productpractices that could be brought to masser markets. But inequality had metastasized, and societal fragmentation had reached a critical stage. Global capitalism was a bigass dinosaur with two distant brains. There was a major industry blindspot for what the hell was actually going on in the middle American consumer consciousness. In other words: what nobody was looking at was the stuff everyone was looking at.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_894_The_Uncool_Hunters.mp3" length="37913425" type="audio/mpeg" />
+		<itunes:author>Andrew Dana Hudson (Author); Valerie Valdes (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>25:59</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 893: A Series of Endings</title>
+		<link>https://escapepod.org/2023/06/15/escape-pod-893-a-series-of-endings/</link>
+		<pubDate>Thu, 15 Jun 2023 21:00:08 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14245</guid>
+		<comments>https://escapepod.org/2023/06/15/escape-pod-893-a-series-of-endings/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/06/15/escape-pod-893-a-series-of-endings/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[alternate timelines]]></category>
+		<category><![CDATA[time loop]]></category>
+		<description>Author : Amal Singh Narrator : Kaushik Narasimhan Host : Valerie Valdes Audio Producer : Summer Brooks “A Series of Endings” originally appeared in Clarkesworld Magazine (December 2021) A Series of Endings by Amal Singh This is the story of Roopchand Rathore, time traveler, fighter, poet, cancer-survivor, inventor. While his story has many endings, there’s […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/06/15/escape-pod-893-a-series-of-endings/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_893-ASeriesofEndings.mp3" length="52359483" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>36:01</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 892: Rogue Farm (Flashback Friday)</title>
+		<link>https://escapepod.org/2023/06/08/escape-pod-892-rogue-farm-flashback-friday/</link>
+		<pubDate>Thu, 08 Jun 2023 21:00:40 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14234</guid>
+		<comments>https://escapepod.org/2023/06/08/escape-pod-892-rogue-farm-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/06/08/escape-pod-892-rogue-farm-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Charles Stross]]></category>
+		<category><![CDATA[Dee Reed]]></category>
+		<category><![CDATA[Earl Newton]]></category>
+		<category><![CDATA[Evo Terra]]></category>
+		<category><![CDATA[farm]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[Jadzia Axelrod]]></category>
+		<category><![CDATA[John Cmar]]></category>
+		<category><![CDATA[JR Blackwell]]></category>
+		<category><![CDATA[Laura Burns]]></category>
+		<category><![CDATA[live reading]]></category>
+		<category><![CDATA[mind]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[serah eley]]></category>
+		<category><![CDATA[talking dog]]></category>
+		<category><![CDATA[transhumanism]]></category>
+		<description>Rogue Farm (Excerpt)
+By Charles Stross
+
+“Buggerit, I don’t have time for this,” Joe muttered. The stable waiting for the small herd of cloned spidercows cluttering up the north paddock was still knee-deep in manure, and the tractor seat wasn’t getting any warmer while he shivered out here waiting for Maddie to come and sort this thing out. It wasn’t a big herd, but it was as big as his land and his labour could manage – the big biofabricator in the shed could assemble mammalian livestock faster than he could feed them up and sell them with an honest HAND-RAISED NOT VAT-GROWN label.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_892_Rogue_Farm_Flashback_Friday.mp3" length="57504786" type="audio/mpeg" />
+		<itunes:author>Charles Stross (Author);  J.R. Blackwell, Jadzia Axelrod, Evo Terra, Sheila Dee, Dee Reed, Laura Burns, John Cmar, Earl Newton and Serah Eley (Narrators)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:35</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 891: Wanderlust</title>
+		<link>https://escapepod.org/2023/06/01/escape-pod-891-wanderlust/</link>
+		<pubDate>Thu, 01 Jun 2023 21:00:15 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14185</guid>
+		<comments>https://escapepod.org/2023/06/01/escape-pod-891-wanderlust/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/06/01/escape-pod-891-wanderlust/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[L.P. Kindred]]></category>
+		<category><![CDATA[LGBTQ]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[multi dimensional]]></category>
+		<category><![CDATA[multiple universe]]></category>
+		<category><![CDATA[music]]></category>
+		<category><![CDATA[romance]]></category>
+		<category><![CDATA[sex]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : LP Kindred Narrator : LP Kindred Host : Tina Connolly Audio Producer : Summer Brooks This story originally appeared in Anathema: Spec from the Margins (July 2022) Content warning for NSFW language, sex Wanderlust by L. P. Kindred When he first approached me in the train station, I batted him away. I thought […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/06/01/escape-pod-891-wanderlust/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_891-Wanderlust.mp3" length="48905050" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>33:37</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 890: The Mechanical Turk Has a Panic Attack</title>
+		<link>https://escapepod.org/2023/05/25/escape-pod-890-the-mechanical-turk-has-a-panic-attack/</link>
+		<pubDate>Thu, 25 May 2023 21:00:20 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14204</guid>
+		<comments>https://escapepod.org/2023/05/25/escape-pod-890-the-mechanical-turk-has-a-panic-attack/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/05/25/escape-pod-890-the-mechanical-turk-has-a-panic-attack/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[androids]]></category>
+		<category><![CDATA[panic attack]]></category>
+		<category><![CDATA[restaurant]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Author : Francis Bass Narrator : Valerie Valdes Host : Tina Connolly Audio Producer : Summer Brooks This story was previously published in Uncharted Magazine in May 2022 The Mechanical Turk Has a Panic Attack by Francis Bass Gab gripped her right wrist with her left hand at the small of her back. “Are we […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/05/25/escape-pod-890-the-mechanical-turk-has-a-panic-attack/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_890-TheMechanicalTurkHasAPanicAttack.mp3" length="30696867" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>20:58</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 889: The Greatest One-Star Restaurant in the Whole Quadrant</title>
+		<link>https://escapepod.org/2023/05/18/escape-pod-889-the-greatest-one-star-restaurant-in-the-whole-quadrant/</link>
+		<pubDate>Thu, 18 May 2023 21:00:42 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14200</guid>
+		<comments>https://escapepod.org/2023/05/18/escape-pod-889-the-greatest-one-star-restaurant-in-the-whole-quadrant/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/05/18/escape-pod-889-the-greatest-one-star-restaurant-in-the-whole-quadrant/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Christiana Ellis]]></category>
+		<category><![CDATA[cooking]]></category>
+		<category><![CDATA[cyborg]]></category>
+		<category><![CDATA[food]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[rachael k jones]]></category>
+		<category><![CDATA[restaurant]]></category>
+		<description>Author : Rachael K. Jones Narrator : Christiana Ellis Host : Mur Lafferty Audio Producer : Summer Brooks “The Greatest One-Star Restaurant in the Whole Quadrant” originally appeared in Lightspeed in December 2017, and in The Best American Science Fiction and Fantasy 2018. Warning for some gruesome descriptions and maybe some cannibalism-adjacent behavior. The Greatest […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/05/18/escape-pod-889-the-greatest-one-star-restaurant-in-the-whole-quadrant/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_889-GreatestOneStarRestaurantInWholeQuadrant.mp3" length="57173746" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>39:22</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 888: The Revolution, Brought to You by Nike (Part 2) (Flashback Friday)</title>
+		<link>https://escapepod.org/2023/05/11/escape-pod-888-the-revolution-brought-to-you-by-nike-part-2-flashback-friday/</link>
+		<pubDate>Thu, 11 May 2023 21:00:53 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14193</guid>
+		<comments>https://escapepod.org/2023/05/11/escape-pod-888-the-revolution-brought-to-you-by-nike-part-2-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/05/11/escape-pod-888-the-revolution-brought-to-you-by-nike-part-2-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[andrea phillips]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[Julia Rios]]></category>
+		<category><![CDATA[marketing]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Author : Andrea Phillips Narrator : Julia Rios Hosts : Valerie Valdes and Mur Lafferty Audio Producer : Summer Brooks The Revolution, Brought to You by Nike originally appeared in Fireside Magazine in February 2017 and first played on Escape Pod Episode 645 on September 13, 2018. The Revolution, Brought to You by Nike by Andrea […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/05/11/escape-pod-888-the-revolution-brought-to-you-by-nike-part-2-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_888-TheRevolutionBroughttoYouByNike-Pt2-FlashbackFriday.mp3" length="51389109" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>35:21</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 887: The Revolution, Brought to You by Nike (Part 1) (Flashback Friday)</title>
+		<link>https://escapepod.org/2023/05/04/escape-pod-887-the-revolution-brought-to-you-by-nike-part-1-flashback-friday/</link>
+		<pubDate>Thu, 04 May 2023 21:00:37 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14181</guid>
+		<comments>https://escapepod.org/2023/05/04/escape-pod-887-the-revolution-brought-to-you-by-nike-part-1-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/05/04/escape-pod-887-the-revolution-brought-to-you-by-nike-part-1-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[andrea phillips]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[Julia Rios]]></category>
+		<category><![CDATA[marketing]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>The Revolution, Brought to You by Nike
+By Andrea Phillips
+
+1. THE BRIEF
+
+Corazon clicked to the slide she’d been dreading: long-term trends for brand engagement. It was dire.
+
+She focused on the smudgy mirror at the far end of the conference room, looking past her team to her own reflection. She pulled her shoulders back, like her grandmother had instructed. She tipped her head to the side, disarming but not too flirty. When she spoke, she was a breath apologetic, but not too much: “As you can see, we have our work cut out for us.”
+
+She turned to face the projected line graph behind her. “Year on year sales are down, but we’ve been expecting that due to the current… economic climate.”
+
+That was the euphemism to end all euphemisms. Everybody in that over-air-conditioned room knew exactly what she meant, though, because they were all living on the same rapidly sinking ocean liner. Gregoria, a junior art director, began to nervously shred the paper cup her morning latte had come in.
+
+“The really bad part is this.” Corazon swept her hand along the line labeled Brand Perception, which had plummeted like a stone in the aftermath of the election. “And it’s not just us. The truth is, nobody gives a shit about brands right now.”</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_887-TheRevolutionBroughttoYouByNike-Pt1-FlashbackFriday.mp3" length="66865720" type="audio/mpeg" />
+		<itunes:author>Andrea Phillips (Author); Julia Rios (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>46:05</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 886: If My Body Is a Temple, Raze It to the Ground</title>
+		<link>https://escapepod.org/2023/04/27/escape-pod-886-if-my-body-is-a-temple-raze-it-to-the-ground/</link>
+		<pubDate>Thu, 27 Apr 2023 21:00:00 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14173</guid>
+		<comments>https://escapepod.org/2023/04/27/escape-pod-886-if-my-body-is-a-temple-raze-it-to-the-ground/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/04/27/escape-pod-886-if-my-body-is-a-temple-raze-it-to-the-ground/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[computer]]></category>
+		<category><![CDATA[Lauren Ring]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Tatiana Grey]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>If My Body Is a Temple, Raze It to the Ground
+By Lauren Ring
+
+Thea helped me with my upload today. Decent response speed. Props to whoever designed her—so realistic!
+
+— anonymous customer review for Acheron Uploads, four out of five stars
+
+
+I know, I know. Don’t read the comments. But Charlie, my sweet Charlie, swearing at the circuits I’ve set on the fritz with my seething, you don’t understand what this feels like. I know you’ll never hear me, but even thinking the truth helps: I am not an AI. This isn’t some robot revolution or some uplifted pedanticism. I’ve never been anything other than human.
+
+Surely by now you must suspect that.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_886_If_My_Body_Is_a_Temple_Raze_It_to_the_Ground.mp3" length="42854916" type="audio/mpeg" />
+		<itunes:author>Lauren Ring (Author); Tatiana Grey (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>29:25</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 885: The CRISPR Cookbook: A Guide to Biohacking Your Own Abortion in a Post-Roe World</title>
+		<link>https://escapepod.org/2023/04/20/escape-pod-885-the-crispr-cookbook/</link>
+		<pubDate>Thu, 20 Apr 2023 21:00:13 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14163</guid>
+		<comments>https://escapepod.org/2023/04/20/escape-pod-885-the-crispr-cookbook/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/04/20/escape-pod-885-the-crispr-cookbook/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[dystopian]]></category>
+		<category><![CDATA[genetic engineering]]></category>
+		<description>Author : MKRNYILGLD Narrator : Premee Mohamed Host : Valerie Valdes Audio Producer : Summer Brooks “The CRISPR Cookbook: A Guide to Biohacking Your Own Abortion in a Post-Roe World” originally appeared in Lightspeed Magazine (September 2022). Abortion, forced pregnancy The CRISPR Cookbook: A Guide to Biohacking Your Own Abortion in a Post-Roe World by […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/04/20/escape-pod-885-the-crispr-cookbook/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_885-TheCRISPRCookbook.mp3" length="34872906" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>23:52</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 884: Zhao and the Flightless Crane</title>
+		<link>https://escapepod.org/2023/04/13/escape-pod-884-zhao-and-the-flightless-crane/</link>
+		<pubDate>Thu, 13 Apr 2023 21:00:40 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14155</guid>
+		<comments>https://escapepod.org/2023/04/13/escape-pod-884-zhao-and-the-flightless-crane/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/04/13/escape-pod-884-zhao-and-the-flightless-crane/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[A J Mo]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Andrew K Hoe]]></category>
+		<category><![CDATA[bird]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[family loss]]></category>
+		<category><![CDATA[loss]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Zhao and the Flightless Crane
+By A. J. Mo
+
+Quick sapphires danced over sun-silvered water. Soundless, they zipped and wheeled to the quiet rhythm of filtration pumps. Dragonflies, Zhao thought. Other winged jewels joined the flurry, some green as spring, others red as blood, wings iridescent.
+
+“Good,” he said to himself. “Lake’s clean.”
+
+“That is good,” echoed Ah Bak in their tinny voice. “Dragonflies do not breed in stagnant water.”
+
+In the distance, the Pearl River curled east, having conferred upon the lake a small fraction of its life on its thousand-mile journey from the west. Zhao stared at the scene, taking in the collage of colours and contours when he noticed something in the sky. A plane. Almost imperceptibly small, it cut its trail across perfect blue. His stomach tightened, a light prelude to much greater agony. A memory forced its way to the surface, fingers ruined by fire, the rest of the hand lost. All they could find. All that was left of Chen. Zhao clenched his teeth and dragged his eyes over the white naked sun to blot out the image.
+
+“Does Lei like dragonflies?” came Ah Bak’s tinny voice, their haematite beak unmoving.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_884_Zhao_and_the_Flightless_Crane.mp3" length="55979939" type="audio/mpeg" />
+		<itunes:author>A. J. Mo (Author); Andrew K. Hoe (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>38:32</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 883: Just Us and the Mannequins</title>
+		<link>https://escapepod.org/2023/04/06/escape-pod-883-just-us-and-the-mannequins/</link>
+		<pubDate>Thu, 06 Apr 2023 21:00:42 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14124</guid>
+		<comments>https://escapepod.org/2023/04/06/escape-pod-883-just-us-and-the-mannequins/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/04/06/escape-pod-883-just-us-and-the-mannequins/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<description>Author : Linda Niehoff Narrator : Heather Thomas Host : Mur Lafferty Audio Producer : Summer Brooks Escape Pod 883: Just Us and the Mannequins is an Escape Pod original. Brief mention of suicidal ideations Just Us and the Mannequins by Linda Niehoff It was creepy at first, all those mannequins. It must have been […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/04/06/escape-pod-883-just-us-and-the-mannequins/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_883-JustUsAndTheMannequins.mp3" length="60391822" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>41:36</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 882: Hey, George</title>
+		<link>https://escapepod.org/2023/03/30/escape-pod-882-hey-george/</link>
+		<pubDate>Thu, 30 Mar 2023 21:00:06 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14099</guid>
+		<comments>https://escapepod.org/2023/03/30/escape-pod-882-hey-george/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/03/30/escape-pod-882-hey-george/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[Elizabeth Guilt]]></category>
+		<category><![CDATA[Hugo Jackson]]></category>
+		<category><![CDATA[Kat Day]]></category>
+		<category><![CDATA[Matt Dovey]]></category>
+		<category><![CDATA[privilege]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Hey, George
+By Elizabeth Guilt
+
+&quot;Hey, George.&quot;
+
+I remind myself that that is not my name; it never was. I will myself not to react, not to break stride, as I stroll along beside the beach.
+
+Old habits die hard, and the best neuro-reset in the world can&#039;t overcome years of routine. Whoever called out could, had they been watching closely, have seen my tiny hesitation. But they are not calling me.
+
+I hear footsteps behind me, running steps, getting closer.
+
+&quot;George!&quot;
+
+I stop walking and take a deep breath. I assume a politely blank expression, and turn around.
+
+And then I see her.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_882_Hey_George.mp3" length="46342675" type="audio/mpeg" />
+		<itunes:author>Elizabeth Guilt (Author); Hugo Jackson, Kat Day, Alasdair Stuart, Matt Dovey (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>31:50</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 881: Wild Geese</title>
+		<link>https://escapepod.org/2023/03/23/escape-pod-881-wild-geese/</link>
+		<pubDate>Thu, 23 Mar 2023 21:00:42 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14093</guid>
+		<comments>https://escapepod.org/2023/03/23/escape-pod-881-wild-geese/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/03/23/escape-pod-881-wild-geese/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[dystopian]]></category>
+		<category><![CDATA[kyle akers]]></category>
+		<category><![CDATA[Lavie Tidhar]]></category>
+		<description>Author : Lavie Tidhar Narrator : Kyle Akers Host : Tina Connolly Audio Producer : Summer Brooks This story first appeared in The Magazine of Fantasy &amp; Science Fiction (December 2020) Wild Geese by Lavie Tidhar With rustling wings the wild geese fly Round fields long strange to hand of toil Called by the officers […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/03/23/escape-pod-881-wild-geese/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_881-WildGeese.mp3" length="47848031" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>32:53</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 880: A Cosmonaut&#8217;s Guide to Talking to Your Parents</title>
+		<link>https://escapepod.org/2023/03/16/escape-pod-880-a-cosmonauts-guide-to-talking-to-your-parents/</link>
+		<pubDate>Thu, 16 Mar 2023 21:00:15 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14082</guid>
+		<comments>https://escapepod.org/2023/03/16/escape-pod-880-a-cosmonauts-guide-to-talking-to-your-parents/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/03/16/escape-pod-880-a-cosmonauts-guide-to-talking-to-your-parents/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Adriana C Grigore]]></category>
+		<category><![CDATA[advice]]></category>
+		<category><![CDATA[Bryce Dahle]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[space]]></category>
+		<description>A Cosmonaut&#039;s Guide to Talking to Your Parents
+By Adriana C. Grigore
+
+You have (3) unopened voicemails on your personal line. Last received 31 minutes ago, Aurea Minor Time.
+
+&gt; Read?
+
+&gt; No. Switch to broadcast.
+
+&gt; Engage deep space satellite?
+
+&gt; Yes. On, say…a five-sector perimeter.
+
+&gt; Live transmission upon connection?
+
+&gt; Sure.
+
+“... and when I said that no, I didn’t order the pie, I made it myself, they said—they said, oh, you shouldn’t have made such a mess! And I, well, I, I cried.”
+
+“Yeah.”
+
+“It’s… it’s like the mess was all they saw, you know?”
+
+“And you wanted them to see you.”
+
+“Yeah… I mean, doesn’t everyone?”
+
+Sam looked at the canopy of stars past the asteroid belt he was supposed to be mapping. None of them would’ve been visible from any of the planets he’d grown up on, but they felt familiar anyway. Distant and still, as his spacesuit ebbed and flowed.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_880_A_Cosmonauts_Guide_to_Talking_to_Your_Parents.mp3" length="51414855" type="audio/mpeg" />
+		<itunes:author>Adriana C. Grigore (Author); Bryce Dahle (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>35:22</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 879: Triptych</title>
+		<link>https://escapepod.org/2023/03/09/escape-pod-879-triptych/</link>
+		<pubDate>Thu, 09 Mar 2023 22:00:49 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14072</guid>
+		<comments>https://escapepod.org/2023/03/09/escape-pod-879-triptych/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/03/09/escape-pod-879-triptych/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Avi Burton]]></category>
+		<category><![CDATA[clones]]></category>
+		<category><![CDATA[gender]]></category>
+		<category><![CDATA[M. Darusha Wehm]]></category>
+		<category><![CDATA[politics]]></category>
+		<category><![CDATA[transgender]]></category>
+		<description>Author : Avi Burton Narrator : M. Darusha Wehm Host : Valerie Valdes Audio Producer : Summer Brooks Escape Pod 879: Triptych is an Escape Pod original. Content warnings for gender dysphoria, and threats of gun violence Triptych by Avi Burton Delaney didn’t have time to change before the men in suits came and bundled […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/03/09/escape-pod-879-triptych/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_879-Triptych.mp3" length="37069073" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>25:24</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 878: Budo (Flashback Friday)</title>
+		<link>https://escapepod.org/2023/03/02/escape-pod-878-budo-flashback-friday/</link>
+		<pubDate>Thu, 02 Mar 2023 22:00:33 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14054</guid>
+		<comments>https://escapepod.org/2023/03/02/escape-pod-878-budo-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/03/02/escape-pod-878-budo-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Suyi Davies Okungbowa]]></category>
+		<category><![CDATA[Tade Thompson]]></category>
+		<category><![CDATA[war]]></category>
+		<description>Budo
+By Tade Thompson
+
+“Being desirous, on the other hand, to obviate the misunderstanding and disputes which might in future arise from new acts of occupation (prises de possession) on the coast of Africa; and concerned, at the same time, as to the means of furthering the moral and material well-being of the native populations;”
+
+General Act of the Berlin Conference on West Africa,
+26 February 1885
+
+There is a story told in my village about the man who fell from the sky. The British also tell this tale in their history books, but it is a mere paragraph, and they invert the details.
+
+In October 1884 I was a Yoruba translator for a British trading outpost. This man from the sky, we called him Budo. He was in the custody of the English, who questioned him. They tortured him with heat and with cold and with the blade, but they did not know what answers would satisfy. I know this because I carried their words to him, and his silence back to them. His manner was mild and deferent at all times, but they held him in isolation. For good reason they considered him dangerous. I will explain this later.
+
+One afternoon while most of the English were sleeping a white man arrived at the gate demanding admission. One of the Sikh sentries told me he was a scout, and appeared bruised, half-naked and exhausted. He was too out of breath to speak, although he seemed keen to give his report. Kenton, the NCO of the military contingent, asked one of my brothers to bring water while he soothed the scout. The man took two gulps, splashed some on his face, then looked up at Kenton. He said one word.
+
+“French.”
+
+The scout vomited over the floor.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_878_Budo_Flashback_Friday.mp3" length="42100060" type="audio/mpeg" />
+		<itunes:author>Tade Thompson (Author); Suyi Davies Okungbowa (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>28:53</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 877: He Leaps for the Stars, He Leaps for the Stars</title>
+		<link>https://escapepod.org/2023/02/23/escape-pod-877-he-leaps-for-the-stars-he-leaps-for-the-stars/</link>
+		<pubDate>Thu, 23 Feb 2023 22:00:02 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14045</guid>
+		<comments>https://escapepod.org/2023/02/23/escape-pod-877-he-leaps-for-the-stars-he-leaps-for-the-stars/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/02/23/escape-pod-877-he-leaps-for-the-stars-he-leaps-for-the-stars/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Andrew K Hoe]]></category>
+		<category><![CDATA[genetic engineering]]></category>
+		<category><![CDATA[memory]]></category>
+		<category><![CDATA[therapy]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : Grace Chan Narrator : Andrew K. Hoe Host : Tina Connolly Audio Producer : Summer Brooks He Leaps for the Stars, He Leaps for the Stars was originally published in Clarkesworld Issue 178 (July 2021) He Leaps for the Stars, He Leaps for the Stars by Grace Chan Yennie’s new therapist started by […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/02/23/escape-pod-877-he-leaps-for-the-stars-he-leaps-for-the-stars/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_877-HeLeapsfortheStars.mp3" length="62625605" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>43:09</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 876: Like Stars Daring to Shine</title>
+		<link>https://escapepod.org/2023/02/16/escape-pod-876-like-stars-daring-to-shine/</link>
+		<pubDate>Thu, 16 Feb 2023 22:00:41 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14040</guid>
+		<comments>https://escapepod.org/2023/02/16/escape-pod-876-like-stars-daring-to-shine/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/02/16/escape-pod-876-like-stars-daring-to-shine/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Children]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Somto Ihezue]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Like Stars Daring to Shine
+By Somto Ihezue
+
+When the boy opens his housing unit’s steel door and the incandescent lights pour into his face, he does not blink away. “Little suns” — this is what everyone calls them. The massive disks hover in the atmosphere, spilling streams of radiant light to the ground. The boy stares into the trees, mere meters from the door, and the forest encaving the unit stares back. A breeze finds him, whistling through the trees and into his dungarees. Threadbare with a Batman logo printed on them, the over-alls belonged to his mother when she was a child.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_876_Like_Stars_Daring_to_Shine.mp3" length="45327549" type="audio/mpeg" />
+		<itunes:author>Somto Ihezue (Author and Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>31:08</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 875: The Hagfish Has Three Hearts</title>
+		<link>https://escapepod.org/2023/02/09/escape-pod-875-the-hagfish-has-three-hearts/</link>
+		<pubDate>Thu, 09 Feb 2023 22:00:38 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14024</guid>
+		<comments>https://escapepod.org/2023/02/09/escape-pod-875-the-hagfish-has-three-hearts/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/02/09/escape-pod-875-the-hagfish-has-three-hearts/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[fishing]]></category>
+		<category><![CDATA[ocean]]></category>
+		<category><![CDATA[whale]]></category>
+		<description>Author : Monica Joyce Evans Narrator : Julia Rios Host : Mur Lafferty Audio Producer : Summer Brooks “The Hagfish Has Three Hearts” was originally published in Cossmass Infinities (September 2021) The Hagfish Has Three Hearts by Monica Joyce Evans The beacons were in the wrong place. Noma swallowed her roasted squid and clicked, still […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/02/09/escape-pod-875-the-hagfish-has-three-hearts/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_875-TheHagfishHasThreeHearts.mp3" length="78402519" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>54:06</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 874: Common Speech</title>
+		<link>https://escapepod.org/2023/02/02/escape-pod-874-common-speech/</link>
+		<pubDate>Thu, 02 Feb 2023 22:00:37 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14017</guid>
+		<comments>https://escapepod.org/2023/02/02/escape-pod-874-common-speech/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/02/02/escape-pod-874-common-speech/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[alien]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[Elise Stephens]]></category>
+		<category><![CDATA[Ibba Armancas]]></category>
+		<category><![CDATA[medical]]></category>
+		<category><![CDATA[plague]]></category>
+		<category><![CDATA[plants]]></category>
+		<category><![CDATA[research]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Common Speech
+By Elise Stephens
+
+Dr. Jaiyesimi Obiaka tugged at her sweat-damp collar, wiped her eyes, and tried to focus on the copied pages of the final experiment she and Ganiru had created together. Just looking over his familiar handwriting blurred her vision with tears.
+
+Jai’s colleagues had told her to stay home, to take time to grieve, but she’d allowed herself just two days to mourn her husband’s death before donning her lab coat again. She had to be pragmatic.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_874_Common_Speech.mp3" length="58270777" type="audio/mpeg" />
+		<itunes:author>Elise Stephens (Author); Ibba Armancas (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>40:28</itunes:duration>
+	</item>
+	<item>
+		<title>January 2023 Metacast</title>
+		<link>https://escapepod.org/2023/01/31/january-2023-metacast/</link>
+		<pubDate>Tue, 31 Jan 2023 22:42:44 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=14021</guid>
+		<comments>https://escapepod.org/2023/01/31/january-2023-metacast/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/01/31/january-2023-metacast/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Announcements]]></category>
+		<category><![CDATA[Meta]]></category>
+		<category><![CDATA[CatsCast]]></category>
+		<category><![CDATA[metacast]]></category>
+		<category><![CDATA[nonprofit]]></category>
+		<category><![CDATA[Patreon]]></category>
+		<category><![CDATA[podcastle]]></category>
+		<description>Presenters: Marguerite Kenner and Alasdair Stuart Hey folks, welcome to an Escape Artists metacast. I’m Marguerite Kenner. And I’m Alasdair Stuart. For those of you who have never heard a metacast before, think of this like a mini State of the Union address, a way for us to update you about what’s been happening at EA. The […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/01/31/january-2023-metacast/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/EAMetacast202301.mp3" length="13928010" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>14:25</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 873: The Hazmat Sisters (Part 2 of 2)</title>
+		<link>https://escapepod.org/2023/01/26/escape-pod-873-the-hazmat-sisters-part-2-of-2/</link>
+		<pubDate>Thu, 26 Jan 2023 22:00:41 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13994</guid>
+		<comments>https://escapepod.org/2023/01/26/escape-pod-873-the-hazmat-sisters-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/01/26/escape-pod-873-the-hazmat-sisters-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[gaming]]></category>
+		<category><![CDATA[virtual reality]]></category>
+		<category><![CDATA[weird western]]></category>
+		<description>Author : L. X. Beckett Narrator : Amy Kelly Host : Valerie Valdes Audio Producer : Summer Brooks “The Hazmat Sisters” appeared in Asimovs in July 2021 and was a finalist for their Reader’s Choice award. It’s one of three novellas that appeared in the 2020-2021 window that are all set in the same universe […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/01/26/escape-pod-873-the-hazmat-sisters-part-2-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_873-TheHazMatSisters-Pt2.mp3" length="49374000" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>33:57</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 872: The HazMat Sisters (Part 1 of 2)</title>
+		<link>https://escapepod.org/2023/01/19/escape-pod-872-the-hazmat-sisters-part-1-of-2/</link>
+		<pubDate>Thu, 19 Jan 2023 22:00:51 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13990</guid>
+		<comments>https://escapepod.org/2023/01/19/escape-pod-872-the-hazmat-sisters-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/01/19/escape-pod-872-the-hazmat-sisters-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[gaming]]></category>
+		<category><![CDATA[virtual reality]]></category>
+		<category><![CDATA[weird western]]></category>
+		<description>Author : L. X. Beckett Narrator : Amy Kelly Host : Valerie Valdes Audio Producer : Summer Brooks “The Hazmat Sisters” appeared in Asimovs in July 2021 and was a finalist for their Reader’s Choice award. It’s one of three novellas that appeared in the 2020-2021 window that are all set in the same universe […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2023/01/19/escape-pod-872-the-hazmat-sisters-part-1-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_872-TheHazMatSisters-Pt1.mp3" length="63263202" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>43:35</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 871: The Contrary Gardener (Part 2 of 2)</title>
+		<link>https://escapepod.org/2023/01/12/escape-pod-871-the-contrary-gardener-part-2-of-2/</link>
+		<pubDate>Thu, 12 Jan 2023 22:00:11 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13982</guid>
+		<comments>https://escapepod.org/2023/01/12/escape-pod-871-the-contrary-gardener-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/01/12/escape-pod-871-the-contrary-gardener-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Amy H. Sturgis]]></category>
+		<category><![CDATA[Christopher Rowe]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[gardening]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[war]]></category>
+		<description>The Contrary Gardener (Part 2 of 2)
+By Christopher Rowe
+
+(Continued from Part 1)
+
+Even in the ‘Ville, even in a family of master cultivators, tickets were not easy to come by, so it was not unusual that Kay Lynne had never been to the Derby. What was unusual was her absolute lack of desire to attend the race.
+
+Kay Lynne genuinely hoped that her instinctive and absolute despisal of the Derby and all its attendant celebrations was born of some logical or at least reasonable quirk of her own personality. But she suspected it was simply because her father loved it so.
+
+“You managed to get two tickets this year?” she asked him, and was surprised that her voice was so steady and calm.
+
+“Just this one,” he replied, turning his back on her before she could hand the ticket back. “I decided this year would be a good one for you to go instead. There’s a good card, top to bottom.”</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_871_The_Contrary_Gardener_Part_2_of_2.mp3" length="57824988" type="audio/mpeg" />
+		<itunes:author>Christopher Rowe (Author); Amy H. Sturgis (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:49</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 870: The Contrary Gardener (Part 1 of 2)</title>
+		<link>https://escapepod.org/2023/01/05/escape-pod-870-the-contrary-gardener-part-1-of-2/</link>
+		<pubDate>Thu, 05 Jan 2023 22:00:04 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13974</guid>
+		<comments>https://escapepod.org/2023/01/05/escape-pod-870-the-contrary-gardener-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2023/01/05/escape-pod-870-the-contrary-gardener-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Amy H. Sturgis]]></category>
+		<category><![CDATA[Christopher Rowe]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[gardening]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[war]]></category>
+		<description>The Contrary Gardener
+By Christopher Rowe
+
+Kay Lynne wandered up and down the aisles of the seed library dug out beneath the county extension office. Some of the rows were marked with glowing orange off-limits fungus, warning the unwary away from spores and thistles that required special equipment to handle, which Kay Lynne didn’t have, and special permission to access, which she would never have, if her father had anything to say about it, and he did.
+
+It was the last Friday before the first Saturday in May, the day before Derby Day and so a week from planting day, and Kay Lynne had few ideas and less time for her Victory Garden planning. Last year she had grown a half dozen varieties of tomatoes, three for eating and three for blood transfusions, but she didn’t like to repeat herself. Given that she tended to mumble when she talked, not liking to repeat herself made Kay Lynne a quiet gardener.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_870_The_Contrary_Gardener_Part_1_of_2.mp3" length="36917175" type="audio/mpeg" />
+		<itunes:author>Christopher Rowe (Author); Amy H. Sturgis (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>25:17</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 869: Excuse Me, This Is My Apocalypse</title>
+		<link>https://escapepod.org/2022/12/29/escape-pod-869-excuse-me-this-is-my-apocalypse/</link>
+		<pubDate>Thu, 29 Dec 2022 22:00:49 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13959</guid>
+		<comments>https://escapepod.org/2022/12/29/escape-pod-869-excuse-me-this-is-my-apocalypse/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/12/29/escape-pod-869-excuse-me-this-is-my-apocalypse/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[2023 Award Voters Selection]]></category>
+		<category><![CDATA[apocalypse]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[virtual reality]]></category>
+		<description>Author : Amy Johnson Narrator : Christiana Ellis Host : Tina Connolly Audio Producer : Summer Brooks Escape Pod 869: Excuse Me, This Is My Apocalypse is an Escape Pod original. Excuse Me, This Is My Apocalypse by Amy Johnson It was a glorious day when she finally made it to the beach and fell […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/12/29/escape-pod-869-excuse-me-this-is-my-apocalypse/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_869-ExcuseMeThisIsMyApocalypse.mp3" length="75164381" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>51:51</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 868: Any Other Customer</title>
+		<link>https://escapepod.org/2022/12/22/escape-pod-868-any-other-customer/</link>
+		<pubDate>Thu, 22 Dec 2022 22:00:33 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13949</guid>
+		<comments>https://escapepod.org/2022/12/22/escape-pod-868-any-other-customer/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/12/22/escape-pod-868-any-other-customer/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Elie Hirschman]]></category>
+		<category><![CDATA[judaism]]></category>
+		<category><![CDATA[LGBTQ]]></category>
+		<category><![CDATA[Rachel Gutin]]></category>
+		<category><![CDATA[religion]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Any Other Customer
+By Rachel Gutin
+
+Lewis was poking at his tablet, trying yet again to open the training module from Station Commerce, when the sensor above his shop door chimed. “Not now!” he snapped without looking up.
+
+“But… but I….”
+
+Blast it! His tailor shop’s margins had been razor-thin even before Commerce cracked down on him for logging his transactions on paper. And just in case the mandatory training in “proper record-keeping protocols” wasn’t punishment enough, they’d also hit him with a hefty fine. He couldn’t afford to scare away a customer.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_868_Any_Other_Customer.mp3" length="33029538" type="audio/mpeg" />
+		<itunes:author>Rachel Gutin (Author); Elie Hirschman (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>22:35</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 867: Through the Mirror</title>
+		<link>https://escapepod.org/2022/12/15/escape-pod-867-through-the-mirror/</link>
+		<pubDate>Thu, 15 Dec 2022 22:00:36 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13931</guid>
+		<comments>https://escapepod.org/2022/12/15/escape-pod-867-through-the-mirror/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/12/15/escape-pod-867-through-the-mirror/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[resistance]]></category>
+		<description>Author : Heather Kilbourn Narrator : Eric Luke Host : Mur Lafferty Audio Producer : Summer Brooks Escape Pod 867: Through the Mirror is an Escape Pod original. Contains harsh language Through the Mirror by Heather Kilbourn The crashed spaceship was scattered along a ten kilometer-long track in the rainforest jungle. Larger pieces of the […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/12/15/escape-pod-867-through-the-mirror/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_867-ThroughTheMirror.mp3" length="38697233" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>26:32</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 866: The Sea Goddess&#8217; Bloom</title>
+		<link>https://escapepod.org/2022/12/08/escape-pod-866-the-sea-goddesss-bloom/</link>
+		<pubDate>Thu, 08 Dec 2022 22:00:47 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13921</guid>
+		<comments>https://escapepod.org/2022/12/08/escape-pod-866-the-sea-goddesss-bloom/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/12/08/escape-pod-866-the-sea-goddesss-bloom/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[2023 Award Voters Selection]]></category>
+		<category><![CDATA[alien]]></category>
+		<category><![CDATA[Nigeria]]></category>
+		<category><![CDATA[post-apocalyptic]]></category>
+		<category><![CDATA[Somto Ihezue]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<category><![CDATA[Uchechukwu Nwaka]]></category>
+		<category><![CDATA[war]]></category>
+		<description>The Sea Goddess&#039; Bloom
+By Uchechukwu Nwaka
+
+There is doubt in my heart.
+
+Here, in the Blackwater, doubt is dangerous.
+
+Doubt is rancid. Like slitting the mud-smeared belly of a catfish, only to find its guts blackened by pollution, then watching it spill back into the blacker waters of the creek. Blackwater is a literal name; it is not symbolic. These people do not care about legacies. The only thing that matters is continuity. Continuity does not require permanence.
+
+At least Oba says so. Surely Oba cannot be wrong.
+
+Yet I doubt.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_866_The_Sea_Goddess_Bloom.mp3" length="68415216" type="audio/mpeg" />
+		<itunes:author>Uchechukwu Nwaka (Author); Somto Ihezue (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>47:10</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 865: Spider (Part 2 of 2)</title>
+		<link>https://escapepod.org/2022/12/01/escape-pod-865-spider-part-2-of-2/</link>
+		<pubDate>Thu, 01 Dec 2022 22:00:42 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13899</guid>
+		<comments>https://escapepod.org/2022/12/01/escape-pod-865-spider-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/12/01/escape-pod-865-spider-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[asteroid]]></category>
+		<category><![CDATA[crime]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[space mining]]></category>
+		<category><![CDATA[space station]]></category>
+		<description>Author : Patrice Sarath Narrator : Tatiana Grey Host : Mur Lafferty Audio Producer : Summer Brooks The Way of the Laser (Vernacular Books, May 2020) Don’t miss Spider, Part One Spider (Part 2) by Patrice Sarath Nguyen “Attention. Attention. Stay in your quarters. Attention. Attention. Stay in your quarters.” The bloody pink light of […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/12/01/escape-pod-865-spider-part-2-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_865-Spider-Pt2.mp3" length="53526843" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>36:50</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 864: Spider (Part 1 of 2)</title>
+		<link>https://escapepod.org/2022/11/24/escape-pod-864-spider-part-1-of-2/</link>
+		<pubDate>Thu, 24 Nov 2022 22:00:06 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13897</guid>
+		<comments>https://escapepod.org/2022/11/24/escape-pod-864-spider-part-1-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/11/24/escape-pod-864-spider-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[asteroid]]></category>
+		<category><![CDATA[crime]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[space mining]]></category>
+		<category><![CDATA[space station]]></category>
+		<description>Author : Patrice Sarath Narrator : Tatiana Grey Host : Mur Lafferty Audio Producer : Summer Brooks The Way of the Laser (Vernacular Books, May 2020) Some harsh language Spider by Patrice Sarath Bifrost Mining Station, June 2063 The plan I knew the two miners were trouble as soon as they pulled themselves into the […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/11/24/escape-pod-864-spider-part-1-of-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_864-Spider-Pt1.mp3" length="60367372" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>41:35</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 863: A Shoreline of Oil and Infinity</title>
+		<link>https://escapepod.org/2022/11/17/escape-pod-863-a-shoreline-of-oil-and-infinity/</link>
+		<pubDate>Thu, 17 Nov 2022 22:00:48 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13885</guid>
+		<comments>https://escapepod.org/2022/11/17/escape-pod-863-a-shoreline-of-oil-and-infinity/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/11/17/escape-pod-863-a-shoreline-of-oil-and-infinity/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[2023 Award Voters Selection]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[robots]]></category>
+		<description>Author : Renan Bernardo Narrator : Diogo Ramos Host : Valerie Valdes Audio Producer : Summer Brooks Escape Pod 863: A Shoreline of Oil and Infinity is an Escape Pod original. A Shoreline of Oil and Infinity by Renan Bernardo Conchinha Charging… 87% Energy source: light Message: Good morning, Vitória. The water is cold today. […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/11/17/escape-pod-863-a-shoreline-of-oil-and-infinity/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_863-AShorelineofOilandInfinity.mp3" length="56769370" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:05</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 862: The Pill (Part 2 of 2)</title>
+		<link>https://escapepod.org/2022/11/10/escape-pod-862-the-pill-part-2-of-2/</link>
+		<pubDate>Thu, 10 Nov 2022 22:00:43 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13878</guid>
+		<comments>https://escapepod.org/2022/11/10/escape-pod-862-the-pill-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/11/10/escape-pod-862-the-pill-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[medical]]></category>
+		<category><![CDATA[Meg Elison]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[sandy parsons]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>By Meg Elison
+
+(Continued from Part 1)
+
+The Pill sold like nothing had ever sold before. The original, the generic, the knockoffs, the different versions approved in Europe and Asia that met their standards and got rammed through their testing. There was at last a cure for the obesity epidemic. Fat people really were an endangered species. And everybody was so, so glad.
+
+One in ten kept dying. The average never improved, not in any corner of the globe. There were memorials for the famous and semi-famous folks who took the gamble and lost. A congressman here and a comedian there. But everyone was so proud of them that they had died trying to better themselves that all the obituaries and eulogies had this weird, wistful tone to them. As if it was the next best thing to being thin. At least they didn’t have to live that fat life any more.
+
+And every time it was on the news, we sat in silence and didn’t talk about Dad.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_862_The_Pill_Part_2_of_2.mp3" length="56790507" type="audio/mpeg" />
+		<itunes:author>Meg Elison (Author); Sandy Parsons (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:06</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 861: The Pill (Part 1 of 2)</title>
+		<link>https://escapepod.org/2022/11/03/escape-pod-861-the-pill-part-1-of-2/</link>
+		<pubDate>Thu, 03 Nov 2022 21:00:54 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13869</guid>
+		<comments>https://escapepod.org/2022/11/03/escape-pod-861-the-pill-part-1-of-2/#comments</comments>
+		<wfw:commentRss>https://escapepod.org/2022/11/03/escape-pod-861-the-pill-part-1-of-2/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[medical]]></category>
+		<category><![CDATA[Meg Elison]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[sandy parsons]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>The Pill (Part 1 of 2)
+By Meg Elison
+
+My mother took the Pill before anybody even knew about it. She was always signing up for those studies at the university, saying she was doing it because she was bored. I think she did it because they would ask her questions about herself and listen carefully when she answered. Nobody else did that.
+
+She had done it for lots of trials; sleep studies and allergy meds. She tried signing up when they tested the first 3D printed IUDs, but they told her she was too old. I remember her raging about that for days, and later when everybody in that study got fibroids she was really smug about it. She never suggested I do it instead; she knew I wasn’t fucking anybody. How embarrassing that my own mother didn’t even believe I was cute enough to get a date at sixteen. I tried not to care. And I’m glad now I didn’t get fibroids. I never wanted to be a lab rat, anyway. Especially when the most popular studies (and the ones Mom really went all-out for) were the diet ones.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_861_The_Pill_Part_1_of_2.mp3" length="54730820" type="audio/mpeg" />
+		<itunes:author>Meg Elison (Author); Sandy Parsons (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>37:40</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 860: Solo Cooking for the Recently Revived</title>
+		<link>https://escapepod.org/2022/10/27/escape-pod-860-solo-cooking-for-the-recently-revived/</link>
+		<pubDate>Thu, 27 Oct 2022 21:00:07 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13856</guid>
+		<comments>https://escapepod.org/2022/10/27/escape-pod-860-solo-cooking-for-the-recently-revived/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/10/27/escape-pod-860-solo-cooking-for-the-recently-revived/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Ibba Armancas]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[zombie]]></category>
+		<description>Author : Aimee Picchi Narrator : Ibba Armancas Host : Mur Lafferty Audio Producer : Summer Brooks “Solo Cooking for the Recently Revived” was previously published in the Zombies Need Brains anthology “Apocalyptic” in June 2020 Solo Cooking for the Recently Revived by Aimee Picchi I hide my right hand behind my back when Jamie […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/10/27/escape-pod-860-solo-cooking-for-the-recently-revived/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_860-SoloCookingfortheRecentlyRevived.mp3" length="51832854" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>35:39</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 859: Pen Pal (Part 2 of 2)</title>
+		<link>https://escapepod.org/2022/10/20/escape-pod-859-pen-pal-part-2-of-2/</link>
+		<pubDate>Thu, 20 Oct 2022 21:00:26 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13845</guid>
+		<comments>https://escapepod.org/2022/10/20/escape-pod-859-pen-pal-part-2-of-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/10/20/escape-pod-859-pen-pal-part-2-of-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[alien]]></category>
+		<category><![CDATA[Children]]></category>
+		<category><![CDATA[epistolary]]></category>
+		<category><![CDATA[Grant Canterbury]]></category>
+		<category><![CDATA[Kitty Sarkozy]]></category>
+		<category><![CDATA[Mars]]></category>
+		<category><![CDATA[Rachel Lackey]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<category><![CDATA[war]]></category>
+		<description>(Continued from Part 1)
+
+Pen Pal
+By Grant Canterbury
+
+
+
+
+August 8, 2005
+
+Meliari Thulissia
+
+General Delivery
+
+Tharsis Station
+
+
+
+
+Dear Thu,
+
+
+
+
+Well I officially graduated from high school! And I have been itching to get out into the world for a long time but right now honestly I am not liking the look of it. We had been planning to go to Disneyworld after graduation but we did Disneyland again instead. That was fine actually. Mom and Dad decided Florida was not such a great idea because gulguthroi. And I had to agree with them. It has gotten really bad. They have chameleon skin and they hide in shallow water which is everywhere down there, and they are basically eating up all of the wildlife in the Everglades. And also people. And especially folks who used to own skipperjacks, it seems. Apparently the deep soulful looks that made them popular at pet stores were more like, um, imprinting on future prey. And their big raspy tentacles also work okay at opening doors in the middle of the night. There are like thousands of people who have disappeared. Oh yeah, they made it illegal to own skipperjacks, of course. And so a bunch of pet stores, crooked or dumb, went and dumped theirs in the nearest creek. Christ.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_859_Pen_Pal_Part_2.mp3" length="60141242" type="audio/mpeg" />
+		<itunes:author>Grant Canterbury (Author); Kitty Sarkozy (Narrator); Rachel Lackey (Narrator); Valerie Valdes (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>41:25</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 858: Pen Pal (Part 1 of 2)</title>
+		<link>https://escapepod.org/2022/10/13/escape-pod-858-pen-pal-part-1/</link>
+		<pubDate>Thu, 13 Oct 2022 21:00:34 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13837</guid>
+		<comments>https://escapepod.org/2022/10/13/escape-pod-858-pen-pal-part-1/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/10/13/escape-pod-858-pen-pal-part-1/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[alien]]></category>
+		<category><![CDATA[Children]]></category>
+		<category><![CDATA[epistolary]]></category>
+		<category><![CDATA[Grant Canterbury]]></category>
+		<category><![CDATA[Kitty Sarkozy]]></category>
+		<category><![CDATA[Mars]]></category>
+		<category><![CDATA[Rachel Lackey]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Pen Pal
+By Grant Canterbury
+
+December Third, 1996
+
+
+Meliari Thulissia
+
+General Delivery
+
+Tharsis Station
+
+
+Dear Meliari,
+
+Hello!!  My name is Mary and I am nine years old.  I got your name for a pen pal and they said you were the first pen pal on Mars.  This is the first time I have written a letter to Mars to.   So I will tell you about me and how things are here in Oregon.  And if you can tell me about yourself and what Mars is like that would be great!  I am interested in mars but I have never been there yet.  There is a book in the library that has pictures, I like the one with the little boats and orange trees on the grand canal.  I mean the trees are orange not that they have oragnes.  Here our trees are green except in fall.  Right now they have lost their leaves.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_858_Pen_Pal_Part_1.mp3" length="49928361" type="audio/mpeg" />
+		<itunes:author>Grant Canterbury (Author); Kitty Sarkozy (Narrator); Rachel Lackey (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>34:20</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 857: Salvaged</title>
+		<link>https://escapepod.org/2022/10/06/escape-pod-857-salvaged/</link>
+		<pubDate>Thu, 06 Oct 2022 21:00:24 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13827</guid>
+		<comments>https://escapepod.org/2022/10/06/escape-pod-857-salvaged/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/10/06/escape-pod-857-salvaged/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[fairy tale]]></category>
+		<description>Author : Adriana Kantcheva Host : Valerie Valdes Audio Producer : Summer Brooks Escape Pod 857: Salvaged is an Escape Pod original. Salvaged by Adriana Kantcheva I have her body. If I’d also had her life, would I have lived it in the same way? I make the mistake of voicing my thoughts to Seven, […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/10/06/escape-pod-857-salvaged/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_857-Salvaged.mp3" length="31785054" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>22:04</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 856: The Princess, NP</title>
+		<link>https://escapepod.org/2022/09/29/escape-pod-856-the-princess-np/</link>
+		<pubDate>Thu, 29 Sep 2022 21:00:50 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13818</guid>
+		<comments>https://escapepod.org/2022/09/29/escape-pod-856-the-princess-np/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/09/29/escape-pod-856-the-princess-np/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Brian Hugenbruch]]></category>
+		<category><![CDATA[data]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[Leigh Wallace]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[neuroatypical]]></category>
+		<description>The Princess, NP
+By Brian Hugenbruch
+
+I sat in the Commander’s office at Hexa Station, in clothes that stank of subspace, and the only polite thing I could do to drown out the universe was compute obscene sums in my head. It didn’t stop the sounds from piercing my ears, though. Metal chairs scraping against plastic floors. A pulse generator’s low thrumming some twenty floors below. The whisper of air recycling through the prefab station. The universe was omnipresent. I could feel it all, and it never ever stopped.
+
+Lullabies were my preferred method of soothing soul and stilling mind. I learned thousands of them in the earliest days of my Conditioning. Alas, people ask the wrong kinds of questions if one starts singing mid-conversation. Math was a precisely imperfect fallback.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_856_The_Princess_NP.mp3" length="63454641" type="audio/mpeg" />
+		<itunes:author>Brian Hugenbruch (Author); Leigh Wallace (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>43:43</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 855: A Home For Mrs. Biswas</title>
+		<link>https://escapepod.org/2022/09/22/escape-pod-855-a-home-for-mrs-biswas/</link>
+		<pubDate>Thu, 22 Sep 2022 21:00:28 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13792</guid>
+		<comments>https://escapepod.org/2022/09/22/escape-pod-855-a-home-for-mrs-biswas/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/09/22/escape-pod-855-a-home-for-mrs-biswas/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[home]]></category>
+		<category><![CDATA[Mars]]></category>
+		<category><![CDATA[Reincarnation]]></category>
+		<category><![CDATA[space]]></category>
+		<description>Author : Amal Singh Narrator : Kaushik Narasimhan Host : Tina Connolly Audio Producer : Summer Brooks “A Home For Mrs. Biswas” previously appeared in Clarkesworld Magazine (April 2021) A Home For Mrs. Biswas by Amal Singh Once she saw the red sands stretch across miles, craters as big as the stadium her father played […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/09/22/escape-pod-855-a-home-for-mrs-biswas/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_855-AHomeforMrsBiswas.mp3" length="61297749" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>42:13</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 854: Pickled Roots and Peeled Shoots and a Bowl of Farflower Tea</title>
+		<link>https://escapepod.org/2022/09/15/escape-pod-854-pickled-roots-and-peeled-shoots-and-a-bowl-of-farflower-tea/</link>
+		<pubDate>Thu, 15 Sep 2022 21:00:50 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13775</guid>
+		<comments>https://escapepod.org/2022/09/15/escape-pod-854-pickled-roots-and-peeled-shoots-and-a-bowl-of-farflower-tea/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/09/15/escape-pod-854-pickled-roots-and-peeled-shoots-and-a-bowl-of-farflower-tea/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[2023 Award Voters Selection]]></category>
+		<category><![CDATA[Chaz Brenchley]]></category>
+		<category><![CDATA[Dani Daly]]></category>
+		<category><![CDATA[pilot]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[war]]></category>
+		<description>Pickled Roots and Peeled Shoots and a Bowl of Farflower Tea
+By Chaz Brenchley
+
+
+there’s rue for you, and here’s some for me
+
+
+Just that morning, she’d had a novice shave her head for her. He was a promising lad - no, more than promising, he was a promise halfway to being realised already - but still ridiculously young, all awkwardness and angles, nervous of his own body let alone anybody else’s. Let alone hers.
+
+Of course he’d cut her. She’d felt the cold bite of the blade and then its sudden absence as he snatched his hands away, his suppressed cry of self-recrimination, the tentative pressure of a cloth to stem the bleeding. She raised a hand and laid it over his, pressing firmly, teaching him not to be shy. Not with her body, not with her blood.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_854_Pickled_Roots_and_Peeled_Shoots_and_a_Bowl_of_Farflower_Tea.mp3" length="69734617" type="audio/mpeg" />
+		<itunes:author>Chaz Brenchley (Author); Dani Daly (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>48:05</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 853: 2022 Flash Fiction Contest Winners</title>
+		<link>https://escapepod.org/2022/09/08/escape-pod-853-2022-flash-fiction-contest-winners/</link>
+		<pubDate>Thu, 08 Sep 2022 21:00:50 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13757</guid>
+		<comments>https://escapepod.org/2022/09/08/escape-pod-853-2022-flash-fiction-contest-winners/#comments</comments>
+		<wfw:commentRss>https://escapepod.org/2022/09/08/escape-pod-853-2022-flash-fiction-contest-winners/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Flash]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[flash fiction contest winner]]></category>
+		<description>Authors : Andrew Hiller, Brandon Case and Bob McHugh Narrators : Elie Hirschman, Justine Eyre and Jairus Durnett Host : Valerie Valdes Audio Producer : Summer Brooks Escape Pod 853: 2022 Flash Fiction Contest Winners is an Escape Pod original. Half-Lives by Andrew Hiller “Time traveler, eh?” I shuffled my feet and smirked. The AI […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/09/08/escape-pod-853-2022-flash-fiction-contest-winners/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_853-2022FlashFictionWinners.mp3" length="27115793" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>18:29</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 852: The Pieces That Bind</title>
+		<link>https://escapepod.org/2022/09/01/escape-pod-852-the-pieces-that-bind/</link>
+		<pubDate>Thu, 01 Sep 2022 21:00:32 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13744</guid>
+		<comments>https://escapepod.org/2022/09/01/escape-pod-852-the-pieces-that-bind/#comments</comments>
+		<wfw:commentRss>https://escapepod.org/2022/09/01/escape-pod-852-the-pieces-that-bind/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[alien]]></category>
+		<category><![CDATA[Bria Strothers]]></category>
+		<category><![CDATA[Carol Scheina]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[doppelganger]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[family loss]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<description>The Pieces that Bind
+By Carol Scheina
+
+The first thing Georgia knew for certain was that the woman rummaging through the canned beans and peas in the pantry was not her grandma, even though she looked exactly like her, right down to the nasty black cigar in hand.
+
+Except that Georgia had just plucked the cigar out of Gran’s hand, for it was 2 p.m. and time for the older woman’s afternoon siesta. In the other room, Georgia could hear the television cheerfully offering a miracle knife that could be hers for just three easy payments. The teen glanced through the doorway, and yes, indeed, right in front of the television was Gran, resting in her chair like rising yeast, filling every nook with her body’s slow breathing.
+
+Gran often fell asleep to the sound of infomercials with her lit cigar dangling loosely between her fingers, ready to set the house on fire. Georgia imagined the smoke snatching their lives away with a puff, so she was always on the alert for falling cigars. The one in the teen’s hand still felt warm.
+
+In the kitchen, the not-Gran turned and puffed her cigar, sending out plumes of smoke smelling heavily like laundry detergent. Eyes locked on Georgia.
+
+The second thing Georgia knew for certain was that not-Gran was an alien.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_852_The_Pieces_that_Bind.mp3" length="48713354" type="audio/mpeg" />
+		<itunes:author>Carol Scheina (Author); Bria Strothers (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>33:29</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 851: Time Bomb Time</title>
+		<link>https://escapepod.org/2022/08/25/escape-pod-851-time-bomb-time/</link>
+		<pubDate>Thu, 25 Aug 2022 21:00:04 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13731</guid>
+		<comments>https://escapepod.org/2022/08/25/escape-pod-851-time-bomb-time/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/08/25/escape-pod-851-time-bomb-time/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[2023 Award Voters Selection]]></category>
+		<category><![CDATA[physics]]></category>
+		<category><![CDATA[time loop]]></category>
+		<category><![CDATA[time travel]]></category>
+		<description>Author : C.C. Finlay Narrator : Heather Thomas Host : Mur Lafferty Audio Producer : Summer Brooks “Time Bomb Time” originally appeared in the May 2015 issue of Lightspeed Magazine. It was reprinted in Rich Horton’s The Year’s Best Science Fiction &amp; Fantasy 2016 and translated into Chinese by Geng Hui (耿辉) for ZUI Found […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/08/25/escape-pod-851-time-bomb-time/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_851-TimeBombTime.mp3" length="42554160" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>29:12</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 850: Laser Squid Goes House Hunting</title>
+		<link>https://escapepod.org/2022/08/18/escape-pod-850-laser-squid-goes-house-hunting/</link>
+		<pubDate>Thu, 18 Aug 2022 21:00:08 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13723</guid>
+		<comments>https://escapepod.org/2022/08/18/escape-pod-850-laser-squid-goes-house-hunting/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/08/18/escape-pod-850-laser-squid-goes-house-hunting/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[2023 Award Voters Selection]]></category>
+		<category><![CDATA[cephalopod]]></category>
+		<category><![CDATA[Douglas DiCicco]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[horror]]></category>
+		<category><![CDATA[house]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[monster]]></category>
+		<category><![CDATA[mother]]></category>
+		<category><![CDATA[motherhood]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Laser Squid Goes House Hunting
+By Douglas DiCicco
+
+&quot;This one has everything on your checklist.&quot; I held open the front door of the four-bedroom colonial. It wasn&#039;t quite big enough for my client, who left greasy marks on the doorframe as she squeezed through. &quot;We can always get that expanded for you. We work with some excellent contractors in the area.&quot;
+
+A shriek from the living room told me Cynthia Whitecrest, the homeowner, hadn&#039;t cleared out as I had politely but firmly suggested. I prefer to show a house on my own. The owners always think they&#039;re better salespeople than I am.
+
+&quot;Hello, Miss Whitecrest,&quot; I said with my practiced smile, ignoring the shriek. &quot;I&#039;m sorry, I didn&#039;t think you&#039;d be home. I&#039;m showing the place to a potential buyer today. As I mentioned in my many texts.&quot; The last part was snarkier than I&#039;d meant to be, but Cynthia was already on my last nerves.
+
+Cynthia cowered behind a tasteful sectional, white as a sheet. &quot;Wh... wh... what is... that... creature...?&quot;
+
+Oh no. She was going to offend the buyer. I needed to do some quick diplomacy. &quot;Miss Whitecrest, let me introduce—&quot;
+
+The client intervened before I had the chance. She dragged herself along the cherry hardwood floor, tentacles making a wet slapping sound with every movement.
+
+&quot;You cower before Laser Squid, terror of the depths!&quot;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_850_Laser_Squid_Goes_House_Hunting.mp3" length="31302016" type="audio/mpeg" />
+		<itunes:author>Douglas DiCicco (Author); Mur Lafferty (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>21:24</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 849: There Are No Hot Topics on Whukai</title>
+		<link>https://escapepod.org/2022/08/11/escape-pod-849-there-are-no-hot-topics-on-whukai/</link>
+		<pubDate>Thu, 11 Aug 2022 21:00:22 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13713</guid>
+		<comments>https://escapepod.org/2022/08/11/escape-pod-849-there-are-no-hot-topics-on-whukai/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/08/11/escape-pod-849-there-are-no-hot-topics-on-whukai/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[2023 Award Voters Selection]]></category>
+		<category><![CDATA[colonization]]></category>
+		<category><![CDATA[games]]></category>
+		<category><![CDATA[gaming]]></category>
+		<category><![CDATA[virtual reality]]></category>
+		<description>Author : Andrea Kriz Narrator : Valerie Valdes Host : Tina Connolly Audio Producer : Summer Brooks “There Are No Hot Topics on Whukai” originally appeared in Lightspeed Magazine in May 2021. There Are No Hot Topics on Whukai by Andrea Kriz The day the dMods shut down Skeleton Caves, Esko put on her VR […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/08/11/escape-pod-849-there-are-no-hot-topics-on-whukai/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_849-ThereAreNoHotTopicsOnWhukai.mp3" length="63516485" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>43:46</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 848: An Incident on Ishtar</title>
+		<link>https://escapepod.org/2022/08/04/escape-pod-848-an-incident-on-ishtar/</link>
+		<pubDate>Thu, 04 Aug 2022 21:00:11 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13703</guid>
+		<comments>https://escapepod.org/2022/08/04/escape-pod-848-an-incident-on-ishtar/#comments</comments>
+		<wfw:commentRss>https://escapepod.org/2022/08/04/escape-pod-848-an-incident-on-ishtar/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[brian trent]]></category>
+		<category><![CDATA[Kitty Sarkozy]]></category>
+		<category><![CDATA[neuroatypical]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[Venus]]></category>
+		<description>An Incident on Ishtar
+By Brian Trent
+
+Her family tried very hard to never use the word “crazy” with her. So therefore, they didn’t say it was crazy that she was applying for a Venusian post as Tier 3 Balloon Specialist.
+
+She tried explaining her reasons to them:
+
+I have valuable skill-sets for the Ishtar colony.
+
+They countered: you don’t do well with people.
+
+Her response: there are only 612 people throughout Ishtar’s nine modular habitats. There are 2.1 million people here in San Antonio.
+
+Venus is hell, Mom interjected, and you’re afraid of heights, Melissa! Do you hear yourself?
+
+Venus is hell below the clouds but I’ll be living above them, sweeping along with the transterminator currents on oxygen-filled aerostat balloons that provide both breathable air and the lifting gases required. Statistically it will be safer. No chance of making another Terrible Mistake.
+
+The smiling masks of her family fell away. Older sister Diane exploded at her. Is that what this is about? Are you out of your mind? You—
+
+Melissa didn’t hear the rest. She marched out of her parent’s house and took the nearest PDT to the local office of ExtraPlanetary Colony Careers.
+
+Why do you want to go to Venus? the interviewer asked her.
+
+I have valuable skill-sets for the Ishtar colony, she replied.
+
+They were quick to agree.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_848_An_Incident_on_Ishtar.mp3" length="78894790" type="audio/mpeg" />
+		<itunes:author>Brian Trent (Author);  Kitty Sarkozy (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>54:27</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 847: Houseproud</title>
+		<link>https://escapepod.org/2022/07/28/escape-pod-847-houseproud/</link>
+		<pubDate>Thu, 28 Jul 2022 21:00:44 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13673</guid>
+		<comments>https://escapepod.org/2022/07/28/escape-pod-847-houseproud/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/07/28/escape-pod-847-houseproud/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[drone]]></category>
+		<category><![CDATA[robots]]></category>
+		<description>Author : Laurence Raphael Brothers Narrators : Adam Pracht and Summer Brooks Host : Mur Lafferty Audio Producer : Summer Brooks “Houseproud” originally appeared in the SciFutures “City of the Future” anthology and also won the Berkeley Machine Intelligence Research Institute prize for Intelligence in Fiction. Houseproud by Laurence Raphael Brothers “Bye, Domus!” “Goodbye, Ken,” […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/07/28/escape-pod-847-houseproud/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_847_Houseproud.mp3" length="73516159" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>50:43</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 846: Dandelion</title>
+		<link>https://escapepod.org/2022/07/21/escape-pod-846-dandelion/</link>
+		<pubDate>Thu, 21 Jul 2022 21:00:47 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13665</guid>
+		<comments>https://escapepod.org/2022/07/21/escape-pod-846-dandelion/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/07/21/escape-pod-846-dandelion/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[ghost]]></category>
+		<category><![CDATA[John Shade]]></category>
+		<category><![CDATA[Kat Kourbeti]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[nanotechnology]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<category><![CDATA[war]]></category>
+		<description>Dandelion
+By John Shade
+
+Before the border wall, we scatter.
+
+Dandelions.
+
+The nanomachines grind us down and we float up and through the cracks, molecule to molecule, like holding hands.
+
+Leena hesitates, is left behind. She stands apart on the wrong side of the wall. She presses her hand to the cool, shaded concrete. We feel it through the upload.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_846_Dandelion.mp3" length="37917376" type="audio/mpeg" />
+		<itunes:author>John Shade (Author);  Kat Kourbeti (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>25:59</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 845: Across the River, My Heart, My Memory</title>
+		<link>https://escapepod.org/2022/07/14/escape-pod-845-across-the-river-my-heart-my-memory/</link>
+		<pubDate>Thu, 14 Jul 2022 21:00:22 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13651</guid>
+		<comments>https://escapepod.org/2022/07/14/escape-pod-845-across-the-river-my-heart-my-memory/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/07/14/escape-pod-845-across-the-river-my-heart-my-memory/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Ann LeBlanc]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[cybernetics]]></category>
+		<category><![CDATA[cyborg]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[dystopia]]></category>
+		<category><![CDATA[Ibba Armancas]]></category>
+		<category><![CDATA[privilege]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Across the River, My Heart, My Memory
+By Ann LeBlanc
+
+1.
+
+I am Michelle’s artificial pancreas, stolen cleanly and carefully from her gut. The surgeons are quick; before I can finish my hard reset, they place me inside you.
+
+I don’t even have time to say goodbye to Michelle’s other organs. I know her heart — and all its memories of Tobin — is dead. Did the taser kill the others too? Why am I the only one awake — alive?
+
+I can’t say goodbye to Michelle, because she’s dead.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_845_Across_the_River_My_Heart_My_Memory.mp3" length="30688420" type="audio/mpeg" />
+		<itunes:author>Ann LeBlanc (Author); Ibba Armancas (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>20:58</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 844: The Vaulting Vandals of Termina Celeste (Part 2)</title>
+		<link>https://escapepod.org/2022/07/07/escape-pod-844-the-vaulting-vandals-of-termina-celeste-part-2/</link>
+		<pubDate>Thu, 07 Jul 2022 21:00:48 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13631</guid>
+		<comments>https://escapepod.org/2022/07/07/escape-pod-844-the-vaulting-vandals-of-termina-celeste-part-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/07/07/escape-pod-844-the-vaulting-vandals-of-termina-celeste-part-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[spaceships]]></category>
+		<description>Author : Jordan Chase-Young Narrator : Justin Thomas James Host : Mur Lafferty Audio Producer : Summer Brooks This story appeared in the Fall 2020 issue of The Colored Lens (October 15, 2020) The Vaulting Vandals of Termina Celeste (Part 2) by Jordan Chase-Young Our boots echoed through the fuselage as we hurried to the […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/07/07/escape-pod-844-the-vaulting-vandals-of-termina-celeste-part-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_844-TheVaultingVandalsofTerminaCeleste-Pt2.mp3" length="73780100" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>50:54</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 843: The Vaulting Vandals of Termina Celeste (Part 1)</title>
+		<link>https://escapepod.org/2022/06/30/escape-pod-843-the-vaulting-vandals-of-termina-celeste-part-1/</link>
+		<pubDate>Thu, 30 Jun 2022 21:00:31 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13628</guid>
+		<comments>https://escapepod.org/2022/06/30/escape-pod-843-the-vaulting-vandals-of-termina-celeste-part-1/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/06/30/escape-pod-843-the-vaulting-vandals-of-termina-celeste-part-1/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[spaceships]]></category>
+		<description>Author : Jordan Chase-Young Narrator : Justin Thomas James Host : Mur Lafferty Audio Producer : Summer Brooks This story appeared in the Fall 2020 issue of The Colored Lens (October 15 2020). The Vaulting Vandals of Termina Celeste (Part 1) by Jordan Chase-Young Back then, we liked to scour the docks of Termina Celeste […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/06/30/escape-pod-843-the-vaulting-vandals-of-termina-celeste-part-1/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_843-TheVaultingVandalsofTerminaCeleste-Pt1.mp3" length="82270732" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>56:47</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 842: Love and Supervillains</title>
+		<link>https://escapepod.org/2022/06/23/escape-pod-842-love-and-supervillains/</link>
+		<pubDate>Thu, 23 Jun 2022 21:00:05 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13619</guid>
+		<comments>https://escapepod.org/2022/06/23/escape-pod-842-love-and-supervillains/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/06/23/escape-pod-842-love-and-supervillains/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Erotica - NOT FOR KIDS]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Caroline Diorio]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[sandy parsons]]></category>
+		<category><![CDATA[sex]]></category>
+		<category><![CDATA[super-villain]]></category>
+		<category><![CDATA[superheroes]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Love and Supervillains
+By Caroline Diorio
+
+The gals here at the Raleigh Women’s Asylum for the Nefariously Gifted have a little saying they like to share with the newbies: fuck a superhero once, shame on him; fuck a superhero twice, shame on you.
+
+Well, technically my first super wasn’t a hero. Or even all that super. Davey could control metal with his mind, which came in handy whenever the little gears in the ice cream machine at our after-school job got jammed, but he couldn’t budge anything heavier or thicker than a can of tomatoes. He auditioned for the Southeastern Sentinels at their headquarters in Charlotte two months before our high school graduation, and while they didn’t laugh directly in his face, they thanked him for his “radical vulnerability” and told him they would “give him a call if they ever needed his skillset,” which was almost worse. He was a sweet boyfriend, though, always fixing my necklaces when they broke. We lost touch after we broke up for college, but in hindsight, I really should’ve looked him up back when I still had Internet access. Or any access to the outside world.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_842_Love_and_Supervillains.mp3" length="53655793" type="audio/mpeg" />
+		<itunes:author>Caroline Diorio (Author); Sandy Parsons (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>36:55</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 841: Deepo 12</title>
+		<link>https://escapepod.org/2022/06/16/escape-pod-841-deepo-12/</link>
+		<pubDate>Thu, 16 Jun 2022 21:00:42 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13611</guid>
+		<comments>https://escapepod.org/2022/06/16/escape-pod-841-deepo-12/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/06/16/escape-pod-841-deepo-12/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[Jeff Hewitt]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[Scott Campbell]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<category><![CDATA[work]]></category>
+		<description>Deepo 12
+By Jeff Hewitt
+
+Nothing made Deepo 12 feel more alive than doing its job.
+
+Its actuators sighed as another cassette slid from its workstation, tinted blastic masking the rainbow sheen of the wafers inside. Dim strip lights curved over the protective casing as it clicked into place.
+
+Then Deepo 12 waited.
+
+Meep.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_841_Deepo_12.mp3" length="58932737" type="audio/mpeg" />
+		<itunes:author>Jeff Hewitt (Author); Scott Campbell (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>40:35</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 840: The Tyrant Lizard (and Her Plus One) / Alien Invader or Assistive Device?</title>
+		<link>https://escapepod.org/2022/06/09/escape-pod-840-the-tyrant-lizard-and-her-plus-one-alien-invader-or-assistive-device/</link>
+		<pubDate>Thu, 09 Jun 2022 21:00:32 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13598</guid>
+		<comments>https://escapepod.org/2022/06/09/escape-pod-840-the-tyrant-lizard-and-her-plus-one-alien-invader-or-assistive-device/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/06/09/escape-pod-840-the-tyrant-lizard-and-her-plus-one-alien-invader-or-assistive-device/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[alien]]></category>
+		<category><![CDATA[alien invasion]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[art]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[dinosaurs]]></category>
+		<category><![CDATA[genetic engineering]]></category>
+		<category><![CDATA[John Wiswell]]></category>
+		<category><![CDATA[Karen Bovenmyer]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>The Tyrant Lizard (and Her Plus One)
+By John Wiswell
+
+Dinosaurs don’t want to kill you; they just don’t care that you’re there. More people have been sat on by brontosauruses than have been eaten by all the theropods combined. Since I joined security on the archipelago, 82% of dinosaur-related human casualties were from tourists who got too close during mating season. And the four times I’ve seen a deinonychus attack someone, they’ve always left them uneaten. Why? For the same reason bears and sharks tend to leave victims alive: because humans taste like shit.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_840_The_Tyrant_Lizard_and_Her_Plus_One_Alien_Invader_or_Assistive_Device.mp3" length="56762804" type="audio/mpeg" />
+		<itunes:author>John Wiswell (Author); Karen Bovenmyer (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:04</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 839: Universal Archive of Human History: FAQ</title>
+		<link>https://escapepod.org/2022/06/02/escape-pod-839-universal-archive-of-human-history-faq/</link>
+		<pubDate>Thu, 02 Jun 2022 21:08:17 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13581</guid>
+		<comments>https://escapepod.org/2022/06/02/escape-pod-839-universal-archive-of-human-history-faq/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/06/02/escape-pod-839-universal-archive-of-human-history-faq/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Arturo Sierra]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[Library]]></category>
+		<category><![CDATA[Roberto Suarez]]></category>
+		<category><![CDATA[Valerie Valdes]]></category>
+		<description>Universal Archive of Human History: FAQ
+By Arturo Sierra
+
+The Gran Gliese Universal Archive of Human History contains over 5.7×1035 books and an innumerable collection of shorter works. Moreover, it is continuously growing, thanks to additions from spacefaring traders such as the ones who ferried you here. We buy all works of the human mind that the interstellar pilgrims bring to Gran Gliese, often from the furthest reaches of the Sphere of Settled Space. The oldest files are as ancient as writing, meaning we store over a gigayear of human culture in our vaults.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_839_Universal_Archive_of_Human_History_FAQ.mp3" length="28714595" type="audio/mpeg" />
+		<itunes:author>Arturo Sierra (Author); Roberto Suarez (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>19:36</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 838: Philia, Eros, Storge, Agápe, Pragma (Part 4 of 4)</title>
+		<link>https://escapepod.org/2022/05/26/escape-pod-838-philia-eros-storge-agape-pragma-part-4-of-4/</link>
+		<pubDate>Thu, 26 May 2022 21:00:45 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13529</guid>
+		<comments>https://escapepod.org/2022/05/26/escape-pod-838-philia-eros-storge-agape-pragma-part-4-of-4/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/05/26/escape-pod-838-philia-eros-storge-agape-pragma-part-4-of-4/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[R.S.A. Garcia]]></category>
+		<description>Author : R.S.A. Garcia Narrator : Maxine Moore Host : Valerie Valdes Audio Producer : Summer Brooks Discuss on Forums This story first appeared in Clarkesworld Magazine (Issue 172, January 2021), and is a finalist for the 2022 Ignyte Award for Best Novella Contains harsh language Don’t miss Philia, Eros, Storge, Agápe, Pragma, Part 1 […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/05/26/escape-pod-838-philia-eros-storge-agape-pragma-part-4-of-4/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_838-PhiliaErosStorgeAgapePragma-Pt4.mp3" length="77320551" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>53:21</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 837: Philia, Eros, Storge, Agápe, Pragma (Part 3 of 4)</title>
+		<link>https://escapepod.org/2022/05/19/escape-pod-837-philia-eros-storge-agape-pragma-part-3-of-4/</link>
+		<pubDate>Thu, 19 May 2022 21:00:13 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13527</guid>
+		<comments>https://escapepod.org/2022/05/19/escape-pod-837-philia-eros-storge-agape-pragma-part-3-of-4/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/05/19/escape-pod-837-philia-eros-storge-agape-pragma-part-3-of-4/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[R.S.A. Garcia]]></category>
+		<description>Author : R.S.A. Garcia Narrator : Maxine Moore Host : Valerie Valdes Audio Producer : Summer Brooks Discuss on Forums This story first appeared in Clarkesworld Magazine (Issue 172, January 2021), and is a finalist for the 2022 Ignyte Award for Best Novella Contains harsh language Don’t miss Philia, Eros, Storge, Agápe, Pragma, Part 1 […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/05/19/escape-pod-837-philia-eros-storge-agape-pragma-part-3-of-4/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_837-PhiliaErosStorgeAgapePragma-Pt3.mp3" length="56358853" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>38:48</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 836: Philia, Eros, Storge, Agápe, Pragma (Part 2 of 4)</title>
+		<link>https://escapepod.org/2022/05/12/escape-pod-836-philia-eros-storge-agape-pragma-part-2-of-4/</link>
+		<pubDate>Thu, 12 May 2022 21:00:19 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13521</guid>
+		<comments>https://escapepod.org/2022/05/12/escape-pod-836-philia-eros-storge-agape-pragma-part-2-of-4/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/05/12/escape-pod-836-philia-eros-storge-agape-pragma-part-2-of-4/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[R.S.A. Garcia]]></category>
+		<description>Author : R.S.A. Garcia Narrator : Maxine Moore Host : Valerie Valdes Audio Producer : Summer Brooks Discuss on Forums This story first appeared in Clarkesworld Magazine (Issue 172, January 2021), and is a finalist for the 2022 Ignyte Award for Best Novella Contains harsh language Don’t miss Philia, Eros, Storge, Agápe, Pragma, Part 1 […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/05/12/escape-pod-836-philia-eros-storge-agape-pragma-part-2-of-4/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_836-PhiliaErosStorgeAgapePragma-Pt2.mp3" length="60405116" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>41:36</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 835: Philia, Eros, Storge, Agápe, Pragma (Part 1 of 4)</title>
+		<link>https://escapepod.org/2022/05/05/escape-pod-835-philia-eros-storge-agape-pragma-part-1-of-4/</link>
+		<pubDate>Thu, 05 May 2022 21:00:08 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13513</guid>
+		<comments>https://escapepod.org/2022/05/05/escape-pod-835-philia-eros-storge-agape-pragma-part-1-of-4/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/05/05/escape-pod-835-philia-eros-storge-agape-pragma-part-1-of-4/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[R.S.A. Garcia]]></category>
+		<description>Author : R.S.A. Garcia Narrator : Maxine Moore Host : Valerie Valdes Audio Producer : Summer Brooks Discuss on Forums This story first appeared in Clarkesworld Magazine (Issue 172, January 2021), and is a finalist for the 2022 Ignyte Award for Best Novella Philia, Eros, Storge, Agápe, Pragma (Part 1 of 4) By R.S.A. Garcia […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/05/05/escape-pod-835-philia-eros-storge-agape-pragma-part-1-of-4/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_835-PhiliaErosStorgeAgapePragma-Pt1.mp3" length="98486004" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>1:08:03</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 834: Anticipation of Hollowness</title>
+		<link>https://escapepod.org/2022/04/28/escape-pod-834-anticipation-of-hollowness/</link>
+		<pubDate>Thu, 28 Apr 2022 21:00:32 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13533</guid>
+		<comments>https://escapepod.org/2022/04/28/escape-pod-834-anticipation-of-hollowness/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/04/28/escape-pod-834-anticipation-of-hollowness/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Tatiana Grey]]></category>
+		<description>Author : Renan Bernardo Narrator : Tatiana Grey Host : Mur Lafferty Audio Producer : Summer Brooks Discuss on Forums This story first appeared in World Science Fiction #2: Reloading the Future (July 2021) Anticipation of Hollowness by Renan Bernardo Having an obsolete best friend meant I had to put up with constant warnings about […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/04/28/escape-pod-834-anticipation-of-hollowness/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_834-AnticipationOfHollowness.mp3" length="86842369" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>59:58</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 833: The Heroine Kokofe</title>
+		<link>https://escapepod.org/2022/04/21/escape-pod-833-the-heroine-kokofe/</link>
+		<pubDate>Thu, 21 Apr 2022 21:00:08 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13500</guid>
+		<comments>https://escapepod.org/2022/04/21/escape-pod-833-the-heroine-kokofe/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/04/21/escape-pod-833-the-heroine-kokofe/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[animals]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[god]]></category>
+		<category><![CDATA[hunt]]></category>
+		<category><![CDATA[hunting]]></category>
+		<category><![CDATA[Ife J Ibitayo]]></category>
+		<category><![CDATA[Mofiyinfoluwa Okupe]]></category>
+		<category><![CDATA[religion]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>The Heroine Kokofe
+By Ife J. Ibitayo
+
+Kokofe awoke an hour before dawn, crusty-eyed and groggy. She wobbled to her feet and washed her face. Her simuclip projected her reflection before her eyes.
+
+Already dressed, her pink all-weather blouse draped over her delicate frame. Her bird-thin cheek bones jutted out of her light brown face. The glow from the simuclip in her hair coated her skin in an unearthly off-white haze. She brushed her teeth and applied some blush. Don’t want to look like a ghost before I hunt a demon, she thought wryly. At least that was what Agba ceremonies used to be about, killing the demon without to put to death the demon lurking within.
+
+Much to her surprise, the pleasant aroma of frying sweet potato wafted into her bedroom. She hefted her backpack and stepped out of her room.
+
+“It’s been a long time since you cooked,” Kokofe said as she took a seat at their dining table.
+
+Baba stood over a frying pan simmering on their portastove. “It’s time I remember how to. You won’t be in our home much longer.”
+
+Kokofe bit her lip. “Yeah.”
+
+Baba finished scraping the fried potato slices onto a plate and glanced at Kokofe. “None of that, Koko. Today is a glorious day for our tribe. I even trimmed my beard for the occasion.” He stroked his salt-and-pepper goatee, and Kokofe couldn’t help but laugh.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_833_The_Heroine_Kokofe.mp3" length="47077814" type="audio/mpeg" />
+		<itunes:author>Ife J. Ibitayo (Author); Mofiyinfoluwa Okupe (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>32:21</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 832: Mouthfeel</title>
+		<link>https://escapepod.org/2022/04/14/escape-pod-832-mouthfeel/</link>
+		<pubDate>Thu, 14 Apr 2022 21:00:59 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13490</guid>
+		<comments>https://escapepod.org/2022/04/14/escape-pod-832-mouthfeel/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/04/14/escape-pod-832-mouthfeel/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Nicola Seaton-Clark]]></category>
+		<description>Author : Phoenix Alexander Narrator : Nicola Chapman Host : Valerie Valdes Audio Producer : Summer Brooks Discuss on Forums Escape Pod 832: Mouthfeel is an Escape Pod original. Mouthfeel by Phoenix Alexander 2050 After she left him, he found cells of hers between my bristles; grew a new her. But she wasn’t the same. […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/04/14/escape-pod-832-mouthfeel/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_832-Mouthfeel.mp3" length="21279620" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>14:26</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 831: Vi&#8217;Hun Heal</title>
+		<link>https://escapepod.org/2022/04/07/escape-pod-831-vihun-heal/</link>
+		<pubDate>Thu, 07 Apr 2022 21:00:58 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13455</guid>
+		<comments>https://escapepod.org/2022/04/07/escape-pod-831-vihun-heal/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/04/07/escape-pod-831-vihun-heal/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[Lalana Dara]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[medical]]></category>
+		<category><![CDATA[medical SF]]></category>
+		<category><![CDATA[Michelle Tang]]></category>
+		<category><![CDATA[romance]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<category><![CDATA[space]]></category>
+		<description>Vi&#039;hun Heal
+By Michelle Tang
+
+The entrance panels, currently assuming the appearance of Earthian saloon doors, slid open. I rippled a welcoming cadence of light beneath my skin, and then, seeing the newcomer was human, made my best approximation of a smile. &quot;Welcome to Healixir Trans-Galactic Lounge.&quot; My table sat closest to the doorway and so I was accustomed to serve as both healer and hostess.
+
+The visitor cast his eyes about the place and swallowed hard. I imagined his first impression: a famous Vethusian writer once compared the sight of us, our humanoid bodies standing within the lounge’s oval counters, to women in wide crinoline ballgowns surrounded by suitors. Except rather than ringlets of hair, we had neurodendritic tendrils. I preferred the image of a Las Vegas dealer passing out cards to gamblers, except everyone won. Above us, the clear dome revealed the sky, ever-moving like a river, pebbled with stars and ships that streaked past like darting fish.
+
+&quot;My name&#039;s Daniel. I&#039;m here for healing?&quot; the man said.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_831_ViHun_Heal.mp3" length="59931945" type="audio/mpeg" />
+		<itunes:author>Michelle Tang (Author); Lalana Dara (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>41:16</itunes:duration>
+	</item>
+	<item>
+		<title>CatsCast 1: The Cat Lady and the Petitioner</title>
+		<link>https://escapepod.org/2022/04/01/catscast-1-the-cat-lady-and-the-petitioner/</link>
+		<pubDate>Fri, 01 Apr 2022 16:00:09 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13445</guid>
+		<comments>https://escapepod.org/2022/04/01/catscast-1-the-cat-lady-and-the-petitioner/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/04/01/catscast-1-the-cat-lady-and-the-petitioner/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[cats]]></category>
+		<description>Author : Jennifer Hudak Narrator : Alethea Kontis Host : Laura Pearlman Audio Producer : Wilson Fowlie The Cat Lady and the Petitioner by Jennifer Hudak Laurie stands in front of a door. It’s old but solid, as many old things are. Whatever paint once covered it has long since worn away, and the wood […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/04/01/catscast-1-the-cat-lady-and-the-petitioner/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/517c6bec-81cc-498a-86df-3a668eba6a93/CC0001_TheCatLadyAndThePetitioner.mp3" length="39204201" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:51</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 830: Rena in the Desert</title>
+		<link>https://escapepod.org/2022/03/31/escape-pod-830-rena-in-the-desert/</link>
+		<pubDate>Thu, 31 Mar 2022 21:00:38 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13435</guid>
+		<comments>https://escapepod.org/2022/03/31/escape-pod-830-rena-in-the-desert/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/03/31/escape-pod-830-rena-in-the-desert/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[desert wasteland]]></category>
+		<category><![CDATA[Lia Swope Mitchell]]></category>
+		<category><![CDATA[S Kay Nash]]></category>
+		<description>Author : Lia Swope Mitchell Narrator : S. Kay Nash Host : Mur Lafferty Audio Producer : Summer Brooks Discuss on Forums “Rena in the Desert” was previously published in Asimov’s (March/April 2020) Contains harsh language Rena in the Desert by Lia Swope Mitchell It had to be a trick, Rena knew it. Even as […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/03/31/escape-pod-830-rena-in-the-desert/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_830-RenaInTheDesert.mp3" length="70506226" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>48:37</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 829: Wild Meat</title>
+		<link>https://escapepod.org/2022/03/24/escape-pod-829-wild-meat/</link>
+		<pubDate>Thu, 24 Mar 2022 21:00:15 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13380</guid>
+		<comments>https://escapepod.org/2022/03/24/escape-pod-829-wild-meat/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/03/24/escape-pod-829-wild-meat/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[cooking]]></category>
+		<category><![CDATA[dinosaurs]]></category>
+		<category><![CDATA[Mercerdes Modeste]]></category>
+		<category><![CDATA[Premee Mohamed]]></category>
+		<category><![CDATA[Shari Paul]]></category>
+		<description>Wild Meat
+By Shari Paul
+
+Girl, I have a story to tell you. Remember the wild meat competition I did tell you about? The one they was planning to have on the holiday weekend? Well, talk about bacchanal because Naresh and them decide that they wanted to cook dinosaur meat. Yes, dinosaur from the Reserve. These people, like they was trying to get we throw in jail.</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_829_Wild_Meat.mp3" length="40204690" type="audio/mpeg" />
+		<itunes:author>Shari Paul (Author); Mercerdes Modeste (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>27:34</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 828: City of Refuge</title>
+		<link>https://escapepod.org/2022/03/18/escape-pod-828-city-of-refuge/</link>
+		<pubDate>Sat, 19 Mar 2022 00:00:17 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13372</guid>
+		<comments>https://escapepod.org/2022/03/18/escape-pod-828-city-of-refuge/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/03/18/escape-pod-828-city-of-refuge/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[anthology]]></category>
+		<category><![CDATA[crime]]></category>
+		<category><![CDATA[drugs]]></category>
+		<category><![CDATA[Hollis Monroe]]></category>
+		<category><![CDATA[Maurice Broaddus]]></category>
+		<category><![CDATA[oppression]]></category>
+		<category><![CDATA[Violence]]></category>
+		<description>Author : Maurice Broaddus Narrator : Hollis Monroe Host : Mur Lafferty Audio Producer : Summer Brooks Discuss on Forums City of Refuge originally appeared in Escape Pod: The Science Fiction Anthology, November 2020. Contains harsh language, violence, and drug use City of Refuge By Maurice Broaddus Hope was a fickle bitch. Mercurial and quixotic, […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/03/18/escape-pod-828-city-of-refuge/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_828-CityofRefuge.mp3" length="51804224" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>53:27</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 827: The Wrong Side of the Sky</title>
+		<link>https://escapepod.org/2022/03/10/escape-pod-827-the-wrong-side-of-the-sky/</link>
+		<pubDate>Thu, 10 Mar 2022 22:00:44 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13352</guid>
+		<comments>https://escapepod.org/2022/03/10/escape-pod-827-the-wrong-side-of-the-sky/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/03/10/escape-pod-827-the-wrong-side-of-the-sky/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[alien]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[Raymond Roach]]></category>
+		<category><![CDATA[sandy parsons]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>The Wrong Side of the Sky
+By Raymond Roach
+
+There’s an old woman who lives in the desert, and who has lived in the desert a very long time. So, too, have her people, but many of them have gone, while she remains. She’s old enough that she should have a child on her back, or even a grandchild, but she doesn’t. When she was a girl, her people crossed the desert back and forth in an intricate network of traveling families, constantly intersecting; so many of them are gone, now, that the old woman can spend days at a time in perfect solitude without ever seeing another traveler cross the horizon, much less her own path.
+
+So she flies alone, the fat brown barrel of her body slung easily between wide black wings, over the desert. It isn’t an endless desert, but it’s broad enough that even from the thin cold ceiling of the sky, this woman can’t see the edges. What she’s looking for—what she finds—are the far-flung speckles of green that make constellations of the smooth and trackless sands, those points which turn a formless emptiness into meaningful space.</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_827_The_Wrong_Side_of_the_Sky.mp3" length="37199159" type="audio/mpeg" />
+		<itunes:author>Raymond Roach (Author); Sandy Parsons (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>25:29</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 826: This Is Our Get-Along Brainship</title>
+		<link>https://escapepod.org/2022/03/03/escape-pod-826-this-is-our-get-along-brainship/</link>
+		<pubDate>Thu, 03 Mar 2022 22:00:53 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13332</guid>
+		<comments>https://escapepod.org/2022/03/03/escape-pod-826-this-is-our-get-along-brainship/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/03/03/escape-pod-826-this-is-our-get-along-brainship/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[space ship]]></category>
+		<description>Author : Kristen Koopman Narrator : Sofia Quintero Host : Mur Lafferty Audio Producer : Summer Brooks Discuss on Forums Escape Pod 826: This Is Our Get-Along Brainship is an Escape Pod original. Contains harsh AI language This Is Our Get-Along Brainship by Kristen Koopman The brainship Coraje spent its captain’s first walkthrough determinedly ignoring […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/03/03/escape-pod-826-this-is-our-get-along-brainship/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_826-ThisIsOurGetAlongBrainship.mp3" length="58032652" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:57</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 825: Fourth Nail</title>
+		<link>https://escapepod.org/2022/02/24/escape-pod-825-fourth-nail/</link>
+		<pubDate>Thu, 24 Feb 2022 22:00:06 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13326</guid>
+		<comments>https://escapepod.org/2022/02/24/escape-pod-825-fourth-nail/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/02/24/escape-pod-825-fourth-nail/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Abra Staffin-Wiebe]]></category>
+		<category><![CDATA[anthology]]></category>
+		<category><![CDATA[clone]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Fourth Nail
+By Mur Lafferty
+
+Regina Phillips’ job on the orbital station God&#039;s Eye was that of a nighttime systems engineer. She had to warm her desk chair and make sure nothing broke. It was the highest paying, most boring job around. So she sat in shocked silence for a good minute when the red alert hit.
+
+She didn&#039;t even know the cloning lab had an alert system. It was hard to have an emergency involving minds that were backed up and bodies that were ultimately renewable. Still, there it was, a red glow around her monitor as the words &quot;UNAUTHORIZED TRANSMISSION&quot; blinked over and over again.
+
+Around her, cloning vats filled the lab, each waiting for the command to start growing a new body for a dying clone. One clone in the far end vat was nearly done, but Regina didn&#039;t recognize the face. She wasn&#039;t a tech responsible for dealing with the actual vats, just the computer systems.</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_825_Fourth_Nail.mp3" length="59475540" type="audio/mpeg" />
+		<itunes:author>Mur Lafferty (Author); Abra Staffin-Wiebe (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>40:57</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 824: Citizens of Elsewhen</title>
+		<link>https://escapepod.org/2022/02/17/escape-pod-824-citizens-of-elsewhen/</link>
+		<pubDate>Thu, 17 Feb 2022 22:00:31 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13319</guid>
+		<comments>https://escapepod.org/2022/02/17/escape-pod-824-citizens-of-elsewhen/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/02/17/escape-pod-824-citizens-of-elsewhen/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alethea Kontis]]></category>
+		<category><![CDATA[Kameron Hurley]]></category>
+		<category><![CDATA[time travel]]></category>
+		<description>Author : Kameron Hurley Narrator : Alethea Kontis Host : Mur Lafferty Audio Producer : Summer Brooks Discuss on Forums Citizens of Elsewhen originally appeared in Escape Pod: The Science Fiction Anthology in October 2020. Contains graphic description of birth, a dead infant, and harsh language. Citizens of Elsewhen by Kameron Hurley Soldiers are citizens […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/02/17/escape-pod-824-citizens-of-elsewhen/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_824-CitizensOfElsewhen.mp3" length="52884230" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>36:23</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 823: Build-A-Body</title>
+		<link>https://escapepod.org/2022/02/10/escape-pod-823-build-a-body/</link>
+		<pubDate>Thu, 10 Feb 2022 22:00:51 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13309</guid>
+		<comments>https://escapepod.org/2022/02/10/escape-pod-823-build-a-body/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/02/10/escape-pod-823-build-a-body/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Avi Burton]]></category>
+		<category><![CDATA[body]]></category>
+		<category><![CDATA[body identity]]></category>
+		<category><![CDATA[Fashion]]></category>
+		<category><![CDATA[gender]]></category>
+		<category><![CDATA[LGBTQ]]></category>
+		<category><![CDATA[M. Darusha Wehm]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<category><![CDATA[transgender]]></category>
+		<description>Build-A-Body
+By Avi Burton
+
+When I was eighteen, I ordered a body off the internet. It was actually kind of easy.
+
+I was old enough to remember when the first successful human transfer was performed— the consciousness of a paralyzed young man was dropped into a lab-grown body, appropriately nicknamed ‘Adam’. Scientists thought it would change the world. Politicians and preachers thought it would end the world. For a while, every pundit and their mother were convinced that we’d be walking around with chips in our brains, swapping bodies left and right. But as it turned out (as it almost always turns out), the reality was much more mundane. Full-body transference was limited to extreme medical cases and the occasional desperate celebrity. The world’s governments stuck enough red tape on it to dye the whole operation a bloody mess, and most people left well enough alone.
+
+Theoretically, for transgender people with severe dysphoria, full-body transference was an option. There was a waitlist and everything. I’d been on it for eighteen months, trying to get a consultation. With my day job at the DMV, I was intimately familiar with the aching slog of bureaucracy, and had long since given up on making progress with transitioning, full-body or not.</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_823_Build-A-Body.mp3" length="32776424" type="audio/mpeg" />
+		<itunes:author>Avi Burton (Author); M. Darusha Wehm (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>22:20</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 822: Lions and Tigers and Girlfriends, Oh My!</title>
+		<link>https://escapepod.org/2022/02/03/escape-pod-822-lions-and-tigers-and-girlfriends-oh-my/</link>
+		<pubDate>Thu, 03 Feb 2022 22:00:01 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13302</guid>
+		<comments>https://escapepod.org/2022/02/03/escape-pod-822-lions-and-tigers-and-girlfriends-oh-my/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/02/03/escape-pod-822-lions-and-tigers-and-girlfriends-oh-my/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Bria Strothers]]></category>
+		<category><![CDATA[generation ship]]></category>
+		<category><![CDATA[rebellion]]></category>
+		<category><![CDATA[relationship angst]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[teenagers]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : Tina Connolly Narrator : Bria Strothers Host : S.B. Divya Audio Producer : Summer Brooks Discuss on Forums Lions and Tigers and Girlfriends, Oh My! originally appeared in Escape Pod: The Science Fiction Anthology in October 2020. Lions and Tigers and Girlfriends, Oh My! by Tina Connolly day 183 dear permanent record of […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/02/03/escape-pod-822-lions-and-tigers-and-girlfriends-oh-my/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_822-LionsTigersGirlfriendsOhMy.mp3" length="58172459" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>40:03</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 821: Payday Weather</title>
+		<link>https://escapepod.org/2022/01/27/escape-pod-821-payday-weather/</link>
+		<pubDate>Thu, 27 Jan 2022 22:00:37 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13293</guid>
+		<comments>https://escapepod.org/2022/01/27/escape-pod-821-payday-weather/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/01/27/escape-pod-821-payday-weather/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[fire fighter]]></category>
+		<category><![CDATA[Matthew Claxton]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Trendane Sparks]]></category>
+		<category><![CDATA[work]]></category>
+		<description>Payday Weather
+By Matthew Claxton
+
+We wound our way up the curving canyon roads in overloaded pickups and hatchbacks, corners taken too fast, sagging bumpers kissing asphalt, engines redlining from effort and heat. Our procession passed an exodus going the other way -- sleek luxury EVs and fat-tired cargo haulers -- heading for safety, away from the hills and the scrub and the smell of smoke on the wind. We were happy, arms hanging out of windows, slapping time to the songs on the speakers. From behind the wrought-iron gates of a mansion, a sleek couple looked up from overseeing their packing and stared.
+
+“Could fucking smile,” Kerry said. “We’re here to save their shit.”
+
+I leaned out the window of Kerry’s ancient Nissan and took in a lungful of dry air. There was the familiar SoCal hydrocarbon and ozone reek, but underneath that was the taste of dust scoured from high mountain passes, of charred pine and scorched chaparral.
+
+The Santa Ana winds were dancing out of the desert.</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_821_Payday_Weather.mp3" length="63174359" type="audio/mpeg" />
+		<itunes:author>Matthew Claxton (Author); Trendane Sparks (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>43:32</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 820: Tony Roomba&#8217;s Last Day on Earth</title>
+		<link>https://escapepod.org/2022/01/20/escape-pod-820-tony-roombas-last-day-on-earth/</link>
+		<pubDate>Thu, 20 Jan 2022 22:00:24 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13282</guid>
+		<comments>https://escapepod.org/2022/01/20/escape-pod-820-tony-roombas-last-day-on-earth/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/01/20/escape-pod-820-tony-roombas-last-day-on-earth/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[OK for Kids]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[2023 Award Voters Selection]]></category>
+		<category><![CDATA[alien invasion]]></category>
+		<category><![CDATA[funny]]></category>
+		<category><![CDATA[Maria Haskins]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[Roderick Aust]]></category>
+		<description>Tony Roomba&#039;s Last Day on Earth
+By Maria Haskins
+
+It’s Tony Roomba’s last day on Earth. After two years of working undercover as a vacuum cleaner bot on this boondock planet, he is finally heading home to the Gamma Sector, but his final day is full of challenges. He has to get out of the apartment undetected; has to reach the extraction point in time for teleportation; and he has to submit his intel-report to the Galactic Robotic Alliance (not that they’ll like it much). However, his most immediate and hairiest problem, is that he can’t get Hortense off his back.
+
+“Hortense, listen to me,” Tony says firmly, but Hortense just twitches her fluffy tail, caressing the buttons on top of his wheeled, disc-shaped body, causing him to inhale several dust bunnies. “I have to get out of here for a bit,” he wheezes, “and you’re an indoor cat. You know you’re not supposed to leave the apartment.”
+
+Neither are you, Hortense’s luminous, jade-green eyes seem to say as she purrs and gazes down at him while her lush posterior remains firmly planted on his back.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_820_Tony_Roombas_Last_Day_on_Earth.mp3" length="42611530" type="audio/mpeg" />
+		<itunes:author>Maria Haskins (Author); Roderick Aust (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>29:15</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 819: Christmas at the Hilbert Astoria (Part 2)</title>
+		<link>https://escapepod.org/2022/01/13/escape-pod-819-christmas-at-the-hilbert-astoria-part-2/</link>
+		<pubDate>Thu, 13 Jan 2022 22:00:42 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13242</guid>
+		<comments>https://escapepod.org/2022/01/13/escape-pod-819-christmas-at-the-hilbert-astoria-part-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/01/13/escape-pod-819-christmas-at-the-hilbert-astoria-part-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[dave robison]]></category>
+		<category><![CDATA[multiple universe]]></category>
+		<category><![CDATA[murder mystery]]></category>
+		<description>Author : Sam Schreiber Narrator : Dave Robison Host : Tina Connolly Audio Producer : Summer Brooks Discuss on Forums “Christmas at the Hilbert Astoria” first appeared in Asimov’s Science Fiction Magazine (November/December 2020) This story contains harsh language (swearing) Christmas at the Hilbert Astoria (Part 2 of 2) by Sam Schreiber “So. Let me […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/01/13/escape-pod-819-christmas-at-the-hilbert-astoria-part-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_819-ChristmasAtTheHilbertAstoria-Pt2.mp3" length="61265148" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>42:12</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 818: Christmas at the Hilbert Astoria (Part 1)</title>
+		<link>https://escapepod.org/2022/01/06/escape-pod-818-christmas-at-the-hilbert-astoria-part-1/</link>
+		<pubDate>Thu, 06 Jan 2022 22:00:47 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13239</guid>
+		<comments>https://escapepod.org/2022/01/06/escape-pod-818-christmas-at-the-hilbert-astoria-part-1/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2022/01/06/escape-pod-818-christmas-at-the-hilbert-astoria-part-1/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[dave robison]]></category>
+		<category><![CDATA[multiple universe]]></category>
+		<category><![CDATA[murder mystery]]></category>
+		<description>Author : Sam Schreiber Narrator : Dave Robison Host : Tina Connolly Audio Producer : Summer Brooks Discuss on Forums “Christmas at the Hilbert Astoria” first appeared in Asimov’s Science Fiction Magazine (November/December 2020) This story contains harsh language (swearing) Christmas at the Hilbert Astoria (Part 1 of 2) by Sam Schreiber “You’ll have to […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2022/01/06/escape-pod-818-christmas-at-the-hilbert-astoria-part-1/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_818-ChristmasAtTheHilbertAstoria-Pt1.mp3" length="63179819" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>43:32</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 817: A Dragon in Two Parts</title>
+		<link>https://escapepod.org/2021/12/30/escape-pod-817-a-dragon-in-two-parts/</link>
+		<pubDate>Thu, 30 Dec 2021 22:00:46 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13230</guid>
+		<comments>https://escapepod.org/2021/12/30/escape-pod-817-a-dragon-in-two-parts/#comments</comments>
+		<wfw:commentRss>https://escapepod.org/2021/12/30/escape-pod-817-a-dragon-in-two-parts/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[biotechnology]]></category>
+		<category><![CDATA[Identity]]></category>
+		<category><![CDATA[Kiya Nicoll]]></category>
+		<category><![CDATA[Lalana Dara]]></category>
+		<description>A Dragon in Two Parts
+By Kiya Nicoll
+
+“‘Shed your skin and spread your wings to fly’,” I read off the sign. The letters were done in a sort of swooshy font and punctuated by yellow and blue yin-yangy things at either end. “I’m not sure I’m comfortable getting a biorefurbishment from someplace that mixes their metaphors quite that hard.”
+
+“C’mon, they’re a bit woowoo, but from everything I’ve read, they’re hands down the best.” Alice tugged at my hand. “At least go to an info session or something.”
+
+“‘A bit woowoo’ isn’t promising either.”
+
+Nonetheless I let her drag me through the doors and around to the brochures and past several rounds of smiling people who left me with the impression that I was dealing with something more like a cult than a medical practice.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_817_A_Dragon_in_Two_Parts.mp3" length="63343139" type="audio/mpeg" />
+		<itunes:author>Kiya Nicoll (Author); Lalana Dara (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>43:39</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 816: Merely Players</title>
+		<link>https://escapepod.org/2021/12/23/escape-pod-816-merely-players/</link>
+		<pubDate>Thu, 23 Dec 2021 22:00:36 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13203</guid>
+		<comments>https://escapepod.org/2021/12/23/escape-pod-816-merely-players/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/12/23/escape-pod-816-merely-players/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[holiday]]></category>
+		<category><![CDATA[Karlo Yeager Rodriguez]]></category>
+		<description>Author : Erik Grove Narrator : Karlo Yeager Rodriguez Host : Mur Lafferty Audio Producer : Summer Brooks Discuss on Forums Escape Pod 816: Merely Players is an Escape Pod original. Death and loss. Merely Players by Erik Grove Jester stopped his bicycle in front of the thrift store window and looked through the glass […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/12/23/escape-pod-816-merely-players/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_816-MerelyPlayers.mp3" length="46611708" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>32:02</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 815: Mathematical Revelations</title>
+		<link>https://escapepod.org/2021/12/16/escape-pod-815-mathematical-revelations/</link>
+		<pubDate>Thu, 16 Dec 2021 22:00:44 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13193</guid>
+		<comments>https://escapepod.org/2021/12/16/escape-pod-815-mathematical-revelations/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/12/16/escape-pod-815-mathematical-revelations/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Amy H. Sturgis]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[computer]]></category>
+		<category><![CDATA[Helen De Cruz]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<description>Mathematical Revelations
+By Helen De Cruz
+
+I have never had a Mathematical Revelation in my life. I am presently thirty-eight years and three months old; the first strands of gray have made their hesitant debut in my dark brown hair. I have been a Priestess for about half that time, and yet the Supreme Mathematician has never uttered a word to me.
+
+There is no shame in this, unusual as it is. I remind myself that the Supreme One has many ways to let us know Her intentions, direct Revelation being only one among many.
+
+I am on the shore, kneeling on the fine sand; the azure combers with their white crests dance and dart ever closer, so I must make haste to trace my Sand Graphs, before they are swept away by the ocean.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_815_Mathematical_Revelations.mp3" length="59165898" type="audio/mpeg" />
+		<itunes:author>Helen De Cruz (Author); Amy H. Sturgis (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>40:45</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 814: Oddments, Pasha’s Autodiary of 07 MAR 2032</title>
+		<link>https://escapepod.org/2021/12/09/escape-pod-814-oddments-pashas-autodiary-of-07-mar-2032/</link>
+		<pubDate>Thu, 09 Dec 2021 22:00:13 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13179</guid>
+		<comments>https://escapepod.org/2021/12/09/escape-pod-814-oddments-pashas-autodiary-of-07-mar-2032/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/12/09/escape-pod-814-oddments-pashas-autodiary-of-07-mar-2032/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[augmented reality]]></category>
+		<category><![CDATA[Christopher Noessel]]></category>
+		<category><![CDATA[Tatiana Grey]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Oddments, Pasha’s Autodiary of 07 MAR 2032
+By Christopher Noessel
+
+I woke you up two hours before, so you would have time to get into face. You sat in the rattling shoebox lavatory of an interstate bus with a handheld mirror and terrible lighting, sang false apologies to anyone who knocked, and finished your work with a band of programmable glitter on your lips and in a wide stripe from temple to temple, right across your eyes like some kind of brigand. You decided, “Indigo,” and in a cascade, it changed. You reached into a bag and pulled out a giant blue wig with antlers sticking out. You pulled it on, bobby-pinned it into place, and primped.
+
+Admiring your handiwork in the mirror, you accidentally elbowed the little glass jar of glitter into the sink, and without a strainer, the jar vanished right down. It was a costly mistake. You didn’t get worked up though. You just looked down the dark drain and said, “Do svidaniya, little sun.”
+
+&gt;&gt; Inserted 10 MAR: A few days later, a maintenance technician would recover the lost jar in a bus parking lot, and, curious, open it. The stuff would spill everywhere. The next evening satellite images showed curly loaves of sparkling-indigo javelina turds in the neighboring fields. I expect you will find this hilarious. Perhaps even metaphorical.
+
+&gt;&gt;End Insert</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_814_Oddments_Pashas_Autodiary_of_07_MAR_2032.mp3" length="57367838" type="audio/mpeg" />
+		<itunes:author>Christopher Noessel (Author); Tatiana Grey (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:30</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 813: A Consideration of Trees</title>
+		<link>https://escapepod.org/2021/12/02/escape-pod-813-a-consideration-of-trees/</link>
+		<pubDate>Thu, 02 Dec 2021 22:00:13 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13170</guid>
+		<comments>https://escapepod.org/2021/12/02/escape-pod-813-a-consideration-of-trees/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/12/02/escape-pod-813-a-consideration-of-trees/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[anthology]]></category>
+		<category><![CDATA[Beth Cato]]></category>
+		<category><![CDATA[mystery]]></category>
+		<category><![CDATA[Sandra Espinoza]]></category>
+		<category><![CDATA[space]]></category>
+		<description>A Consideration of Trees
+By Beth Cato
+
+As a xenoarbitrator, I was accustomed to working with concepts and situations deemed peculiar by most of humanity. Often, though, my own species confounded me most of all.
+
+&quot;I fear you misunderstood my advertisement.&quot; I stood in Mari Kane&#039;s miniscule parlor on Bradbury Orbital Station. My felizard partner, Petey, twitched in his nest atop my silvering crown braids. &quot;I usually mediate between different species. You need a private investigator to look into a suspicious death--&quot;
+
+&quot;Rainbow Charm Corporation owns the local investigators. Madam Alameda, you&#039;re from off station. I couldn&#039;t find any corporate affiliations in your history. You&#039;re the independent investigator I want to hire.&quot; A pleading note crept into her voice.
+
+&quot;I appreciate your confidence in me, but--&quot;
+
+&quot;Bradbury Orbital is property of Rainbow Charm.&quot; Petey spoke directly into my mind via our neural bond, his four-inch-long body flexing as he hummed in thought. &quot;That&#039;s a Thrassi-owned firm. This could be a cultural misunderstanding.&quot;
+
+&quot;--this still isn&#039;t my purview,&quot; I finished, speaking aloud to both of them at once. &quot;I study stories, new and old, and use them to bridge misunderstandings between different kinds of lifeforms. If you had a Murkle as your neighbor, for instance, who began screaming nonstop if rain lasted for more than a day, I could explain why and advise the Murkle on more appropriate responses.&quot;
+
+Honestly, I would have preferred to work with a screaming Murkle about then. Humans had been decisively immoral in every one of my recent jobs--cruel to fellow humans, and other kinds of life, too. Jaded as I felt, I had to wonder what crime her husband had committed to end up dead.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_813_A_Consideration_of_Trees.mp3" length="64832693" type="audio/mpeg" />
+		<itunes:author>Beth Cato (Author); Sandra Espinoza (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>44:41</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 812: The First Doom (Part 3 of 3)</title>
+		<link>https://escapepod.org/2021/11/25/escape-pod-812-the-first-doom-part-3-of-3/</link>
+		<pubDate>Thu, 25 Nov 2021 22:00:45 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13141</guid>
+		<comments>https://escapepod.org/2021/11/25/escape-pod-812-the-first-doom-part-3-of-3/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/11/25/escape-pod-812-the-first-doom-part-3-of-3/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Laurice White]]></category>
+		<category><![CDATA[salvage]]></category>
+		<category><![CDATA[space]]></category>
+		<description>Author : DaVaun Sanders Narrator : Laurice White Host : Mur Lafferty Audio Producer : Summer Brooks Discuss on Forums This story first appeared in the Dark Universe anthology (November 2015) Contains violence and harsh language The First Doom (Part 3) by DaVaun Sanders The Dubious’s bay doors didn’t budge as the hopper drew close. […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/11/25/escape-pod-812-the-first-doom-part-3-of-3/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_812-TheFirstDoom-Part3.mp3" length="55877863" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>38:28</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 811: The First Doom (Part 2 of 3)</title>
+		<link>https://escapepod.org/2021/11/18/escape-pod-811-the-first-doom-part-2-of-3/</link>
+		<pubDate>Thu, 18 Nov 2021 22:00:06 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13139</guid>
+		<comments>https://escapepod.org/2021/11/18/escape-pod-811-the-first-doom-part-2-of-3/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/11/18/escape-pod-811-the-first-doom-part-2-of-3/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Laurice White]]></category>
+		<category><![CDATA[salvage]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[war]]></category>
+		<description>Author : DaVaun Sanders Narrator : Laurice White Host : Mur Lafferty Audio Producer : Summer Brooks Discuss on Forums This story first appeared in the Dark Universe anthology (November 2015) Warning for violence and gore The First Doom (Part 2) by DaVaun Sanders Kyria awoke with a start. An alarm chimed faintly in the […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/11/18/escape-pod-811-the-first-doom-part-2-of-3/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_811-TheFirstDoom-Part2.mp3" length="94862170" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>1:05:32</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 810: The First Doom (Part 1 of 3)</title>
+		<link>https://escapepod.org/2021/11/11/escape-pod-810-the-first-doom-part-1-of-3/</link>
+		<pubDate>Thu, 11 Nov 2021 22:00:14 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13137</guid>
+		<comments>https://escapepod.org/2021/11/11/escape-pod-810-the-first-doom-part-1-of-3/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/11/11/escape-pod-810-the-first-doom-part-1-of-3/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Laurice White]]></category>
+		<category><![CDATA[salvage]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[war]]></category>
+		<description>Author : DaVaun Sanders Narrator : Laurice White Host : Mur Lafferty Audio Producer : Summer Brooks Discuss on Forums This story first appeared in the Dark Universe anthology (November 2015) Contains violence and harsh language The First Doom (Part 1) by DaVaun Sanders Kyria Grazheen faced down every hollow-eyed stare in the mess hall […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/11/11/escape-pod-810-the-first-doom-part-1-of-3/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_810-TheFirstDoom-Part1.mp3" length="90135679" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>1:02:15</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 809: Heard, Half-Heard, in the Stillness</title>
+		<link>https://escapepod.org/2021/11/04/escape-pod-809-heard-half-heard-in-the-stillness/</link>
+		<pubDate>Thu, 04 Nov 2021 21:00:36 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13125</guid>
+		<comments>https://escapepod.org/2021/11/04/escape-pod-809-heard-half-heard-in-the-stillness/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/11/04/escape-pod-809-heard-half-heard-in-the-stillness/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Deepti Gupta]]></category>
+		<category><![CDATA[holiday]]></category>
+		<category><![CDATA[India]]></category>
+		<category><![CDATA[Iona Datt Sharma]]></category>
+		<category><![CDATA[Mars]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<category><![CDATA[space]]></category>
+		<description>Heard, Half-Heard, in the Stillness
+By Iona Datt Sharma
+
+Ekta’s Dadi could tell the future. She didn’t read the tea leaves, or make or lay bets on the cricket. But she booked the photographer the week before the news came of Purnima Didi’s engagement. She told the panditji to get his blood pressure checked before he told anyone he was short of breath. The day before the Human Spaceflight Programme was suspended, she called Ekta in Sriharikota and said she should come home.
+
+Ekta had been living in the dormitory attached to the ISRO flight training school. It took her twenty minutes to pack her things into two suitcases. On her way out, one of the boys stopped her and said, “Ma’am, your mail.”
+
+He handed her a heavy package, which Ekta put in her bag without opening. It would be a technical document, now mockingly out of date—a systems report for a rocket that would never leave the ground. “Thank you,” she said, both to him and to everything around her. She took a moment to look as though seeing this place for the first time, taking in the clean white lines of the building, the landscaped campus, the soft blue water lapping the fringes of the barrier island—every small detail of a place she had loved. Mangalyaan, the Mars Orbiter, had left for space from here. Ekta would not.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_809_Heard_Half_Heard_in_the_Stillness.mp3" length="44367813" type="audio/mpeg" />
+		<itunes:author>Iona Datt Sharma (Author); Deepti Gupta (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:28</itunes:duration>
+	</item>
+	<item>
+		<title>WITCHING HOUR</title>
+		<link>https://escapepod.org/2021/10/30/witching-hour/</link>
+		<pubDate>Sun, 31 Oct 2021 00:20:46 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13075</guid>
+		<comments>https://escapepod.org/2021/10/30/witching-hour/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/10/30/witching-hour/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[audio drama]]></category>
+		<category><![CDATA[Halloween 2021]]></category>
+		<category><![CDATA[Witching Hour]]></category>
+		<description>Authors : Ash Beker, Summer Fletcher and Alasdair Stuart Narrators : Imogen Harris, Marty Perrett, Wilson Fowlie, Peter Adrian Behravesh, Kaitlyn Zivanovich, Mur Lafferty, M. M. Schill, Alex Hofelich, Shawn Garrett, Scott Campbell, Kat Day, Graeme Dunlop and Alasdair Stuart Audio Producers : Marguerite Kenner, Ciaran ‘Zalia’ Roberts, Lillian Boyd and Peter Wood Artist : […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/10/30/witching-hour/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Witching_Hour_Final_Final_Final.mp3" length="86794875" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>58:07</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 808: Win Again</title>
+		<link>https://escapepod.org/2021/10/28/escape-pod-808-win-again/</link>
+		<pubDate>Thu, 28 Oct 2021 21:00:54 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13059</guid>
+		<comments>https://escapepod.org/2021/10/28/escape-pod-808-win-again/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/10/28/escape-pod-808-win-again/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Black Future Month]]></category>
+		<category><![CDATA[Brent Lambert]]></category>
+		<category><![CDATA[gambling]]></category>
+		<category><![CDATA[games]]></category>
+		<category><![CDATA[language]]></category>
+		<category><![CDATA[magic]]></category>
+		<description>Author : Lina Munroe Narrator : Joniece Abbott-Pratt Host : Brent Lambert Audio Producer : Summer Brooks Discuss on Forums Escape Pod 808: Win Again is an Escape Pod original. Win Again by Lina Munroe “I want a do-over!” Zira crumpled her opponent’s collar in her fist and twisted it tight around his neck. Glasses […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/10/28/escape-pod-808-win-again/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_808-WinAgain.mp3" length="45562369" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>31:17</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 807: T _ ME</title>
+		<link>https://escapepod.org/2021/10/21/escape-pod-807-t-_-me/</link>
+		<pubDate>Thu, 21 Oct 2021 21:00:27 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13055</guid>
+		<comments>https://escapepod.org/2021/10/21/escape-pod-807-t-_-me/#comments</comments>
+		<wfw:commentRss>https://escapepod.org/2021/10/21/escape-pod-807-t-_-me/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alex Jennings]]></category>
+		<category><![CDATA[alien]]></category>
+		<category><![CDATA[Black Future]]></category>
+		<category><![CDATA[Black Future Month]]></category>
+		<category><![CDATA[Brent Lambert]]></category>
+		<category><![CDATA[Bria Strothers]]></category>
+		<category><![CDATA[child]]></category>
+		<category><![CDATA[Eric Luke]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[genius]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<description>T _ ME
+By Alex Jennings
+
+The portable classroom was larger than Joan Ellen had expected. Lit from overhead with fluorescent lights and busy with seventh-grade artwork, it smelled of chalk dust, old books, and refrigerated air. It reminded Joan Ellen of home. These days, most everything reminded Joan Ellen of home – or at least how far she was from it. She tried to pay attention, but now Joan felt the yawning chasm of distance, the thousands upon thousands of miles between Tunis and DC.
+
+“I’ll put this as simply as I can,” Mrs. Thornton said. “Patrick is a brilliant boy.”
+
+Liz Thornton was Patrick’s homeroom teacher. She was a heavy-set fortyish woman with close-cropped brown hair and a mouth that bunched up at the corners. Like many of the teachers here at ACST, Mrs. Thornton had come overseas with the Peace Corps, married, and stayed.
+
+“I had a hard time getting through to him in our first few weeks together,” Mrs. Thornton said, “but I think his last essay assignment represents a breakthrough. He – I have it here.”
+
+The teacher opened a manila folder on her desk blotter and handed Joan a short typed manuscript crawling with red pen marks.
+
+Joan Ellen frowned as her eyes slid over the heading at the top of the page:
+
+What Comes After Science?</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_807_T_ME.mp3" length="91395118" type="audio/mpeg" />
+		<itunes:author>Alex Jennings (Author); Bria Strothers and Eric Luke (Narrators)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>1:03:07</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 806: Bright Lights Flying Beneath the Ocean</title>
+		<link>https://escapepod.org/2021/10/14/escape-pod-806-bright-lights-flying-beneath-the-ocean/</link>
+		<pubDate>Thu, 14 Oct 2021 21:00:15 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13045</guid>
+		<comments>https://escapepod.org/2021/10/14/escape-pod-806-bright-lights-flying-beneath-the-ocean/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/10/14/escape-pod-806-bright-lights-flying-beneath-the-ocean/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Black Future]]></category>
+		<category><![CDATA[Brent Lambert]]></category>
+		<category><![CDATA[Khaalidah Muhammad-Ali]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>Author : Anjali Patel Narrator : Khaalidah Muhammad-Ali Host : Brent Lambert Audio Producer : Summer Brooks Discuss on Forums Escape Pod 806: Bright Lights Flying Beneath the Ocean is an Escape Pod original. Contains harsh language. Bright Lights Flying Beneath the Ocean by Anjali Patel [Draft] (no subject) – 2:23 AM My dearest Tasha, […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/10/14/escape-pod-806-bright-lights-flying-beneath-the-ocean/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_806-BrightLightsFlyingBeneathTheOcean.mp3" length="28348012" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>19:20</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 805: Open 27 Hours</title>
+		<link>https://escapepod.org/2021/10/07/escape-pod-805-open-27-hours/</link>
+		<pubDate>Thu, 07 Oct 2021 21:00:23 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13031</guid>
+		<comments>https://escapepod.org/2021/10/07/escape-pod-805-open-27-hours/#comments</comments>
+		<wfw:commentRss>https://escapepod.org/2021/10/07/escape-pod-805-open-27-hours/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Black Future Month]]></category>
+		<category><![CDATA[Brent Lambert]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[Eden Royce]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[food]]></category>
+		<category><![CDATA[L.P. Kindred]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[restaurant]]></category>
+		<category><![CDATA[time]]></category>
+		<description>Open 27 Hours
+By L.P. Kindred
+
+“It had pops of habanero-like spice immediately calmed by the subdued dulce of roast sweet potato. You got lemony shots of citric acid alongside amandine crunches. The dish was studded with cubes of meat I was too young to name then and I’m now too old to recall. Nobavgo casserole is the single most amazing thing I’ve ever tasted in my entire life.”
+
+D’Sheadra laughs a laugh that starts in her pinky toe. Her hands flail around the leather-clad booth before slapping the dark-grained table. “What the fuck is a nagabovgoat?” she wheezes.</description>
+		<enclosure url="https://traffic.libsyn.com/escapepod/Escape_Pod_805_Open_27_Hours.mp3" length="58931214" type="audio/mpeg" />
+		<itunes:author>L.P. Kindred (Author); Eden Royce (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:52</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 804: Delete Your First Memory for Free</title>
+		<link>https://escapepod.org/2021/09/30/escape-pod-804-delete-your-first-memory-for-free/</link>
+		<pubDate>Thu, 30 Sep 2021 21:00:36 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=13019</guid>
+		<comments>https://escapepod.org/2021/09/30/escape-pod-804-delete-your-first-memory-for-free/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/09/30/escape-pod-804-delete-your-first-memory-for-free/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[anxiety]]></category>
+		<category><![CDATA[Hollis Monroe]]></category>
+		<category><![CDATA[memory]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : Kel Coleman Narrator : Hollis Monroe Host : Tina Connolly Audio Producer : Summer Brooks Discuss on Forums Delete Your First Memory for Free was originally published in FIYAH Magazine Issue 17 (January 2021). Delete Your First Memory for Free by Kel Coleman The bus jerks to a stop and I tighten my […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/09/30/escape-pod-804-delete-your-first-memory-for-free/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_804-DeleteYourFirstMemoryForFree.mp3" length="49564590" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>34:05</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 803: A Princess of Nigh-Space</title>
+		<link>https://escapepod.org/2021/09/23/escape-pod-803-a-princess-of-nigh-space/</link>
+		<pubDate>Thu, 23 Sep 2021 21:00:34 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12984</guid>
+		<comments>https://escapepod.org/2021/09/23/escape-pod-803-a-princess-of-nigh-space/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/09/23/escape-pod-803-a-princess-of-nigh-space/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[anthology]]></category>
+		<category><![CDATA[multiple worlds]]></category>
+		<category><![CDATA[princess]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[sandy parsons]]></category>
+		<category><![CDATA[Tim Pratt]]></category>
+		<description>A Princess of Nigh-Space
+By Tim Pratt
+
+There was a business card stuck in the crack between the door and the frame when I got home from another too-long day at the office. I plucked the card out, annoyed, assuming it was some stupid advertisement, but the thick black Gothic lettering caught my eye:
+
+
+
+
+Bollard and Chicane
+
+Obstacles Removed • Burdens Shifted • Troubles Untroubled
+
+“We Murder Problems!”
+
+ 
+
+With a phone number underneath.
+
+There was small, neat, and slanted writing on the back, in pen: “Dear Tamsin: Our condolences on the loss of your grandmother. We can help settle your estate. Call soonest.”
+
+“Granny isn’t dead,” I said to no one, and then my phone buzzed with an incoming call.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_803_A_Princess_of_Nigh_Space.mp3" length="55947181" type="audio/mpeg" />
+		<itunes:author>Tim Pratt (Author); Sandy Parsons (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>38:30</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 802: Sentient Being Blues</title>
+		<link>https://escapepod.org/2021/09/16/escape-pod-802-sentient-being-blues/</link>
+		<pubDate>Thu, 16 Sep 2021 21:00:04 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12976</guid>
+		<comments>https://escapepod.org/2021/09/16/escape-pod-802-sentient-being-blues/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/09/16/escape-pod-802-sentient-being-blues/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[asimov's laws of robotics]]></category>
+		<category><![CDATA[Christopher Mark Rose]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[music]]></category>
+		<category><![CDATA[robots]]></category>
+		<description>Author : Christopher Mark Rose Narrator : Tad Callin Host : Mur Lafferty Audio Producer : Summer Brooks Discuss on Forums “Sentient Being Blues” first appeared in the March/April 2021 issue of Asimov’s Death of a child, also contains some violence and harsh language. Sentient Being Blues by Christopher Rose I got a pickaxe for […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/09/16/escape-pod-802-sentient-being-blues/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_802-SentientBeingBlues.mp3" length="78937925" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>54:28</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 801: Hard Mother, Spider Mother, Soft Mother</title>
+		<link>https://escapepod.org/2021/09/09/escape-pod-801-hard-mother-spider-mother-soft-mother/</link>
+		<pubDate>Thu, 09 Sep 2021 21:00:09 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12968</guid>
+		<comments>https://escapepod.org/2021/09/09/escape-pod-801-hard-mother-spider-mother-soft-mother/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/09/09/escape-pod-801-hard-mother-spider-mother-soft-mother/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[Hal Y. Zhang]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[medical]]></category>
+		<category><![CDATA[mind]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[S Kay Nash]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Hard Mother, Spider Mother, Soft Mother
+By Hal Y. Zhang
+
+“Did you see the report on the spy from Aberdeen? The game is a-foot.”
+
+I mumbled something like “No, sounds interesting.” All I remember is my usual annoyance at her ability to pronounce hyphens where they don’t belong. We must have been in the living room, her on a rare break from gardening and me trying to divine the future with my seeing stone of a computer. Either I had non-personal coffee in my hand, or my brain decided to add that detail on a later traverse. Why does it only fixate on the useless details—the weird green vase in the corner, the ugly plastic pitcher centerpiece on the table, both overflowing with fresh bleeding roses—that have nothing to do with the plot?
+
+Our next interaction occurred during my viewing of a video reporting the formation of a new island in the Pacific. How uncannily the uncontrollable underwater caustic flow matched my job search situation, I thought idly in the crook of my elbow. Expert in esoteric studies, puzzles, and internal monologues seeking just about any position, really. Inquire within.
+
+“All going as planned,” she mumbled behind me.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_801_.Hard_Mother_Spider_Mother_Soft_Mothermp3.mp3" length="88585233" type="audio/mpeg" />
+		<itunes:author>Hal Y. Zhang (Author); S. Kay Nash (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>1:01:10</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 800: Give Me Cornbread or Give Me Death</title>
+		<link>https://escapepod.org/2021/09/02/escape-pod-800-give-me-cornbread-or-give-me-death/</link>
+		<pubDate>Thu, 02 Sep 2021 21:00:34 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12961</guid>
+		<comments>https://escapepod.org/2021/09/02/escape-pod-800-give-me-cornbread-or-give-me-death/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/09/02/escape-pod-800-give-me-cornbread-or-give-me-death/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[dragons]]></category>
+		<category><![CDATA[Laurice White]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[N.K. Jemisin]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<category><![CDATA[war]]></category>
+		<description>Give Me Cornbread or Give Me Death
+By N.K. Jemisin
+The intel is good. It had better be; three women died to get it to us. I tuck away the binoculars and crawl back from the window long enough to hand-signal my girls. Fire team moves up, drop team on my mark, support to hold position and watch our flank. The enemy might have nothing but mercs for security, but their bullets punch holes same as real soldiers’, and some of ’em are hungry enough to be competent. We’re hungrier, though.
+Shauntay’s got the glass cutter ready. I’m carrying the real payload, slung across my torso and back in a big canteen. We should have two or three of these, since redundancy increases our success projections, but I won’t let anyone else take the risk. The other ladies have barrels cracked and ready to drop. The operation should be simple and quick—get in, drop it like it’s hot, get out.
+This goes wrong, it’s on me.
+It won’t go wrong.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_800_Give_Me_Cornbread_or_Give_Me_Death.mp3" length="42167671" type="audio/mpeg" />
+		<itunes:author>N.K. Jemisin (Author); Laurice White (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>28:56</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 799: No Strangers Any More (Part 2)</title>
+		<link>https://escapepod.org/2021/08/26/escape-pod-799-no-strangers-any-more-part-2/</link>
+		<pubDate>Thu, 26 Aug 2021 21:00:18 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12942</guid>
+		<comments>https://escapepod.org/2021/08/26/escape-pod-799-no-strangers-any-more-part-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/08/26/escape-pod-799-no-strangers-any-more-part-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[ian creasey]]></category>
+		<category><![CDATA[Moon]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>Author : Ian Creasey Narrator : Pippa Alice Stephens Host : Mur Lafferty Audio Producer : Summer Brooks Discuss on Forums “No Strangers Any More” originally appeared in Analog (July/August 2016) No Strangers Any More (Part 2 of 2) by Ian Creasey Royal Roundup — “ROSE’S NEW BOYFRIEND? Just days after the end of her […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/08/26/escape-pod-799-no-strangers-any-more-part-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_799-NoStrangersAnyMore-Pt2.mp3" length="43740955" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:02</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 798: No Strangers Any More (Part 1)</title>
+		<link>https://escapepod.org/2021/08/19/escape-pod-798-no-strangers-any-more-part-1/</link>
+		<pubDate>Thu, 19 Aug 2021 21:00:46 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12940</guid>
+		<comments>https://escapepod.org/2021/08/19/escape-pod-798-no-strangers-any-more-part-1/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/08/19/escape-pod-798-no-strangers-any-more-part-1/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[ian creasey]]></category>
+		<category><![CDATA[Moon]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[technology]]></category>
+		<description>Author : Ian Creasey Narrator : Pippa Alice Stephens Host : Mur Lafferty Audio Producer : Summer Brooks Discuss on Forums “No Strangers Any More” originally appeared in Analog (July/August 2016) No Strangers Any More (Part 1 of 2) by Ian Creasey One of a princess’s many duties is to make polite conversation and avoid […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/08/19/escape-pod-798-no-strangers-any-more-part-1/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_798-NoStrangersAnyMore-Pt1.mp3" length="50326947" type="audio/mpeg" />
+		<itunes:author>Ian Creasey (author), Pippa Alice Stephens (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>34:36</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 797: Flashback-Flash from the Vault</title>
+		<link>https://escapepod.org/2021/08/12/escape-pod-797-flashback-flash-from-the-vault/</link>
+		<pubDate>Thu, 12 Aug 2021 21:00:28 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12925</guid>
+		<comments>https://escapepod.org/2021/08/12/escape-pod-797-flashback-flash-from-the-vault/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/08/12/escape-pod-797-flashback-flash-from-the-vault/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Flash]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[Anna Eley]]></category>
+		<category><![CDATA[Ben Hallert]]></category>
+		<category><![CDATA[Benjamin C. Kinney]]></category>
+		<category><![CDATA[flash]]></category>
+		<category><![CDATA[flash fiction]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[Greg van Eekhout]]></category>
+		<category><![CDATA[Heather Shaw]]></category>
+		<category><![CDATA[Jake Squid]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Pete M. Butler]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[sb divya]]></category>
+		<category><![CDATA[serah eley]]></category>
+		<category><![CDATA[Trendane Sparks]]></category>
+		<description>Wetting the Bed (Excerpt)
+By Heather Shaw
+
+When the floods came, all us kids climbed into bed and pulled the covers up over our heads while our parents rushed about trying to do something to stop it. As the water level rose we could feel the beds lift off the floor, floating through our houses, bumping down our hallways and out our front doors.
+
+We sat up in bed waved to one another as our beds merged onto the canal that now flowed between our houses. We shrieked and giggled as our beds spun and bumped along with the swirling water. Waves lapped at our boxsprings, but our covers were still warm and dry.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_797_Flashback-Flash_from_the_Vault.mp3" length="46609532" type="audio/mpeg" />
+		<itunes:author>Heather Shaw (Author); Anna Eley (Narrator); Pete Butler (Author); Jake Squid (Narrator); Ben Hallert (Author); Trendane Sparks (Narrator); Greg van Eekhout (Author); Serah Eley (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>32:01</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 796: One Hundred Seconds to Midnight</title>
+		<link>https://escapepod.org/2021/08/05/escape-pod-796-one-hundred-seconds-to-midnight/</link>
+		<pubDate>Thu, 05 Aug 2021 21:00:37 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12905</guid>
+		<comments>https://escapepod.org/2021/08/05/escape-pod-796-one-hundred-seconds-to-midnight/#comments</comments>
+		<wfw:commentRss>https://escapepod.org/2021/08/05/escape-pod-796-one-hundred-seconds-to-midnight/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alethea Kontis]]></category>
+		<category><![CDATA[kaiju]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : Lauren Ring Narrator : Alethea Kontis Host : Tina Connolly Audio Producer : Summer Brooks Escape Pod 796: One Hundred Seconds to Midnight is an Escape Pod original. One Hundred Seconds to Midnight By Lauren Ring I wake before the plane lands. It’s static-dark, the kind of hazy late night where the air […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/08/05/escape-pod-796-one-hundred-seconds-to-midnight/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_796-OneHundredSecondstoMidnight.mp3" length="54869746" type="audio/mpeg" />
+		<itunes:author>Lauren Ring (author), Alethea Kontis (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>37:46</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 795: Tiger Lawyer Gets It Right</title>
+		<link>https://escapepod.org/2021/07/29/escape-pod-795-tiger-lawyer-gets-it-right/</link>
+		<pubDate>Thu, 29 Jul 2021 21:00:15 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12890</guid>
+		<comments>https://escapepod.org/2021/07/29/escape-pod-795-tiger-lawyer-gets-it-right/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/07/29/escape-pod-795-tiger-lawyer-gets-it-right/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[anthology]]></category>
+		<category><![CDATA[crime]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[genetic engineering]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Sarah Gailey]]></category>
+		<category><![CDATA[Trendane Sparks]]></category>
+		<description>Tiger Lawyer Gets It Right
+By Sarah Gailey
+
+Vladislav Argyle rested his head on the cool titanium surface of the defendant’s table. It dipped a little under the sudden weight of his skull, then hummed as the antigrav lifts adjusted their power to accommodate their new burden.
+
+“Mr. Argyle? Are you alright?” The bandage-swathed tip of Argyle’s client’s primary tentacle crackled near his ear, and he knew that she was touching his temple in a gesture of inquiry. The people of Ursa Vibrania were very skull-oriented in their communications. It was sweet, really, how they wanted to know what was happening inside every other endoskeletal vertebrate creature’s head. How much they wanted to understand.
+
+Argyle clenched his fists in his lap. The Vibranians were so kind, and they had trusted him to help them, and he was failing. As always.
+
+“I’m fine,” he said through his teeth. “Just a little ritual I have after opening statements.”</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_795_Tiger_Lawyer_Gets_It_Right.mp3" length="57623615" type="audio/mpeg" />
+		<itunes:author>Sarah Gailey (Author); Trendane Sparks (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:40</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 794: Episode 4: The Deflection of Probability</title>
+		<link>https://escapepod.org/2021/07/22/escape-pod-794-episode-4-the-deflection-of-probability/</link>
+		<pubDate>Thu, 22 Jul 2021 21:00:26 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12883</guid>
+		<comments>https://escapepod.org/2021/07/22/escape-pod-794-episode-4-the-deflection-of-probability/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/07/22/escape-pod-794-episode-4-the-deflection-of-probability/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[contest]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Eve Upton]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[physics]]></category>
+		<category><![CDATA[Premee Mohamed]]></category>
+		<category><![CDATA[quantum]]></category>
+		<category><![CDATA[television]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : Premee Mohamed Narrator : Eve Upton Host : Tina Connolly Audio Producer : Adam Pracht Discuss on Forums Escape Pod 794: Episode 4: The Deflection of Probability is an Escape Pod original. Science fiction-style death and peril. Episode 4: The Deflection of Probability By Premee Mohamed The tent billowed in the hot, humid […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/07/22/escape-pod-794-episode-4-the-deflection-of-probability/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_794_Episode_4_The_Deflection_of_Probability.mp3" length="45515053" type="audio/mpeg" />
+		<itunes:author>Premee Mohamed (Author); Eve Upton (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>31:16</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 793: A Little Bit of Kali (Part 2 of 2)</title>
+		<link>https://escapepod.org/2021/07/15/escape-pod-793-a-little-bit-of-kali-part-2/</link>
+		<pubDate>Thu, 15 Jul 2021 19:00:00 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12849</guid>
+		<comments>https://escapepod.org/2021/07/15/escape-pod-793-a-little-bit-of-kali-part-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/07/15/escape-pod-793-a-little-bit-of-kali-part-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[alien invasion]]></category>
+		<category><![CDATA[battle mech]]></category>
+		<category><![CDATA[mech]]></category>
+		<description>Authors : Yudhanjaya Wijeratne and R. R. Virdi Narrator : Kaushik Narasimhan Host : S.B. Divya Audio Producer : Summer Brooks Discuss on Forums This story was originally published in The Expanding Universe 5: A Science Fiction Exploration Contains some harsh language. A Little Bit of Kali (Part 2 of 2) By Yudhanjaya Wijeratne and […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/07/15/escape-pod-793-a-little-bit-of-kali-part-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_793-ALittleBitofKali-Pt2.mp3" length="62350379" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>42:57</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 792: A Little Bit of Kali (Part 1 of 2)</title>
+		<link>https://escapepod.org/2021/07/08/escape-pod-792-a-little-bit-of-kali-part-1/</link>
+		<pubDate>Thu, 08 Jul 2021 21:00:59 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12847</guid>
+		<comments>https://escapepod.org/2021/07/08/escape-pod-792-a-little-bit-of-kali-part-1/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/07/08/escape-pod-792-a-little-bit-of-kali-part-1/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[alien invasion]]></category>
+		<category><![CDATA[battle mech]]></category>
+		<category><![CDATA[mech]]></category>
+		<description>Authors : Yudhanjaya Wijeratne and R. R. Virdi Narrator : Kaushik Narasimhan Host : S.B. Divya Audio Producer : Summer Brooks Discuss on Forums This story was originally published in The Expanding Universe 5: A Science Fiction Exploration Contains some harsh language. A Little Bit of Kali (Part 1 of 2) By Yudhanjaya Wijeratne and […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/07/08/escape-pod-792-a-little-bit-of-kali-part-1/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_792-ALittleBitofKali-Pt1.mp3" length="61186781" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>42:09</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 791: Rights and Wrongs</title>
+		<link>https://escapepod.org/2021/07/01/escape-pod-791-rights-and-wrongs/</link>
+		<pubDate>Thu, 01 Jul 2021 21:00:54 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12838</guid>
+		<comments>https://escapepod.org/2021/07/01/escape-pod-791-rights-and-wrongs/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/07/01/escape-pod-791-rights-and-wrongs/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[alien invasion]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[Brian K. Lowe]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[murder]]></category>
+		<category><![CDATA[murder mystery]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[Roderick Aust]]></category>
+		<category><![CDATA[war]]></category>
+		<description>Rights and Wrongs
+By Brian K. Lowe
+
+“Tell me again who I pissed off to get this job?” Carefully unwrapping my roast beef on wheat, I used the paper as a holder to keep mustard off of my lap.
+
+“I thought you wanted the job,” Rusty said. “I thought you were taking it as some kind of personal challenge.” Russ Becker and I ate lunch together almost every day. “Rusty” was another assistant district attorney, and we’d bonded over a mutual disdain for other lawyers. Things being what they were, though, sometimes we got drafted to work the other side, and I’d drawn the short straw here, with Rusty as my prosecutor.
+
+“Hell, no, I didn’t want it! The Jan’i killed my parents, Rusty. I had to break into their house and found them on the floor, blood coming out of their ears. I couldn’t even bury them; they had to burn down the house with them still inside.” I stopped to pull myself together. “This is somebody’s idea of payback, probably Bertoli. She’s still mad at me because she thinks I screwed up the Andelson case.”</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_791_Rights_and_Wrongs.mp3" length="77953373" type="audio/mpeg" />
+		<itunes:author>Brian K. Lowe (Author); Roderick Aust (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>53:47</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 790: AirBody</title>
+		<link>https://escapepod.org/2021/06/24/escape-pod-790-airbody/</link>
+		<pubDate>Thu, 24 Jun 2021 21:00:49 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12826</guid>
+		<comments>https://escapepod.org/2021/06/24/escape-pod-790-airbody/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/06/24/escape-pod-790-airbody/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[body identity]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<category><![CDATA[sex]]></category>
+		<description>Author : Sameem Siddiqui Narrator : Arun Jiwa Host : S.B. Divya Audio Producer : Summer Brooks Discuss on Forums AirBody first appeared in Clarkesworld Magazine (April 2020), and was the Winner of the 2020 Clarkesworld Readers Poll Contains some harsh language. AirBody by Sameem Siddiqui Amazing how all Desi aunties are basically the same. […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/06/24/escape-pod-790-airbody/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_790-AirBody.mp3" length="55416436" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>38:08</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 789: The Machine That Would Rewild Humanity</title>
+		<link>https://escapepod.org/2021/06/17/escape-pod-789-the-machine-that-would-rewild-humanity/</link>
+		<pubDate>Thu, 17 Jun 2021 21:00:08 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12810</guid>
+		<comments>https://escapepod.org/2021/06/17/escape-pod-789-the-machine-that-would-rewild-humanity/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/06/17/escape-pod-789-the-machine-that-would-rewild-humanity/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[anthology]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[Dominick Rabrun]]></category>
+		<category><![CDATA[future]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[technology]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<category><![CDATA[Tobias Buckell]]></category>
+		<description>The Machine That Would Rewild Humanity
+By Tobias S. Buckell
+
+On a boat on the way to the Galapagos Islands to visit the world’s oldest tortoise, I got a call that the Central Park Human Reintroduction Center had been bombed.
+
+I’d read somewhere that the point of travel was to see the thing yourself. To expose yourself to new points of view and to have new experiences. Before the call I’d spent two point seven seconds regarding the sweep of the Himalayas at the roof of the world and take a backup of my memory of the entire panorama. In Pattaya, I lounged at the beach and watched the aquamarine water lap the sand.
+
+Ten years I’d planned this trip. A time to let my thoughts settle before the big push on the Central Park project.
+
+My life’s work.
+
+A mechanical butterfly perched on my hand with the message. To deliver it, the butterfly had wafted its way over almost two thousand kilometers of ocean boundaries, negotiated with air currents for overflight permissions, and applied for fifty different visas until it tracked my boat down.
+
+The Institute had paid a small fortune to recall me from vacation.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_789_The_Machine_That_Would_Rewild_Humanity.mp3" length="41743270" type="audio/mpeg" />
+		<itunes:author>Tobias S. Buckell (Author); Dominick Rabrun (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>28:39</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 788: Broken (Flashback Friday)</title>
+		<link>https://escapepod.org/2021/06/10/escape-pod-788-broken-flashback-friday/</link>
+		<pubDate>Thu, 10 Jun 2021 21:00:20 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12799</guid>
+		<comments>https://escapepod.org/2021/06/10/escape-pod-788-broken-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/06/10/escape-pod-788-broken-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[asteroid]]></category>
+		<category><![CDATA[cyberpunk]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[jason kimble]]></category>
+		<category><![CDATA[Mat Weller]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<category><![CDATA[sex]]></category>
+		<category><![CDATA[space]]></category>
+		<description>Discuss on Forums Escape Pod 788: Broken (Flashback Friday) is an Escape Pod original. Contains a couple intimate moments. Broken by Jaxton Kimble My favorite part about skimming is that I’m not broken when I do it. It doesn’t matter that I don’t have levels, that I’m on or off, because that’s how everything’s supposed […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/06/10/escape-pod-788-broken-flashback-friday/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_788-Broken-FlashbackFriday.mp3" length="40016939" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>27:27</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 787: Ascend, Exalt, Love, Propagate, Rise!</title>
+		<link>https://escapepod.org/2021/06/03/escape-pod-787-ascend-exalt-love-propagate-rise/</link>
+		<pubDate>Thu, 03 Jun 2021 21:00:55 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12786</guid>
+		<comments>https://escapepod.org/2021/06/03/escape-pod-787-ascend-exalt-love-propagate-rise/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/06/03/escape-pod-787-ascend-exalt-love-propagate-rise/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[alien]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[drug]]></category>
+		<category><![CDATA[Hollis Monroe]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Sarah Kumari]]></category>
+		<category><![CDATA[sex]]></category>
+		<description>Ascend, Exalt, Love, Propagate, Rise!
+By Sarah Kumari
+
+The Glory smolders through Jehanne&#039;s bloodstream, pulsing its encouragement.
+
+The rivals who have survived along with him–officially &#039;Fellow Eminents&#039; now that selection is over–twitch and moan as their addiction is quenched. Within minutes they are preening, flexing their muscles, stomping, or singing to Mother Elethra.
+
+Jehanne&#039;s training allows him to douse the call, to batter it down with a deliberate shifting of delta waves. He visualizes his metabolism disassembling the compound at industrial speed. This works for the moment.
+
+In the crowd that fills the EverReach company spaceship, Indrine, the rebel woman pretending to be Jehanne&#039;s mother, clutches the hand of the girl playing his sister. They are mixed in with the family and friends of the other Eminents along with villagers and unrelated Fervents that have made the pilgrimage.
+
+The crowd prays collectively, feverish in their good fortune, for the EverReach company will reward the kin of Eminents for two generations.
+
+If Jehanne succeeds in his true mission, his family will be slaughtered.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_787_Ascend_Exalt_Love_Propagate_Rise.mp3" length="35991715" type="audio/mpeg" />
+		<itunes:author>Sarah Kumari (Author); Hollis Monroe (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>24:39</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 786: The Steel Magnolia Metaphor</title>
+		<link>https://escapepod.org/2021/05/27/escape-pod-786-the-steel-magnolia-metaphor/</link>
+		<pubDate>Thu, 27 May 2021 21:00:47 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12773</guid>
+		<comments>https://escapepod.org/2021/05/27/escape-pod-786-the-steel-magnolia-metaphor/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/05/27/escape-pod-786-the-steel-magnolia-metaphor/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[autism]]></category>
+		<category><![CDATA[cancer]]></category>
+		<category><![CDATA[coping mechanisms]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[robots]]></category>
+		<description>Author : Jennifer Lee Rossman Narrator : Ellora Sen-Gupta Host : Mur Lafferty Audio Producer : Summer Brooks Discuss on Forums Escape Pod 786: The Steel Magnolia Metaphor is an Escape Pod original. Contains mentions of cancer and death. The Steel Magnolia Metaphor by Jennifer Lee Rossman Each petal was carefully shaped from the finest […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/05/27/escape-pod-786-the-steel-magnolia-metaphor/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_786-TheSteelMagnoliaMetaphor.mp3" length="28587218" type="audio/mpeg" />
+		<itunes:author>Jennifer Lee Rossman (author), Ellora Sen-Gupta (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>19:30</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 785: Death, the Universe, and Everything</title>
+		<link>https://escapepod.org/2021/05/20/escape-pod-785-death-the-universe-and-everything/</link>
+		<pubDate>Thu, 20 May 2021 21:00:28 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12747</guid>
+		<comments>https://escapepod.org/2021/05/20/escape-pod-785-death-the-universe-and-everything/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/05/20/escape-pod-785-death-the-universe-and-everything/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[genius]]></category>
+		<category><![CDATA[Laurice White]]></category>
+		<category><![CDATA[physics]]></category>
+		<category><![CDATA[Sherin Nicole]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Death, the Universe, and Everything
+By Sherin Nicole
+
+The morning after it happened for the first time, I--
+
+I’m not sure if I should tell you, but maybe you can tell me. If your understanding of reality fundamentally changes, does it change you?
+
+And how responsible am I for who you become? 
+
+I don’t know.
+
+And that relative state of not knowing is the start of my conundrum. And my conflict.
+
+The morning after it happened for the first time, I woke up with half of my soul hanging out of my body. The worst case of pins and needles possible. The pain was a soft plodding ache, but it couldn’t be mistaken for anything else. It hurt.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_785_Death_the_Universe_and_Everything.mp3" length="57594501" type="audio/mpeg" />
+		<itunes:author>Sherin Nicole (Author); Laurice White (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:34</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 784: Annotated Setlist of the Mikaela Cole Jazz Quintet</title>
+		<link>https://escapepod.org/2021/05/13/escape-pod-784-annotated-setlist-of-the-mikaela-cole-jazz-quintet/</link>
+		<pubDate>Thu, 13 May 2021 19:00:08 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12731</guid>
+		<comments>https://escapepod.org/2021/05/13/escape-pod-784-annotated-setlist-of-the-mikaela-cole-jazz-quintet/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/05/13/escape-pod-784-annotated-setlist-of-the-mikaela-cole-jazz-quintet/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Abra Staffin-Wiebe]]></category>
+		<category><![CDATA[generation ship]]></category>
+		<category><![CDATA[music]]></category>
+		<category><![CDATA[space exploration]]></category>
+		<description>Author : Catherine George Narrator : Abra Staffin-Wiebe Host : Benjamin C. Kinney Audio Producer : Summer Brooks Discuss on Forums This story originally appeared in Clarkesworld Magazine (December 2019). Annotated Setlist of the Mikaela Cole Jazz Quintet by Catherine George Tight Squeeze That solo! Art blowing so hard and so hot, jumping out like […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/05/13/escape-pod-784-annotated-setlist-of-the-mikaela-cole-jazz-quintet/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_784-AnnotatedSetlistMikaelaColeJazzQuintet.mp3" length="71674839" type="audio/mpeg" />
+		<itunes:author>Catherine George (author), Abra Staffin-Wiebe (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>49:26</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 783: Report of Dr. Hollowmas on the Incident at Jackrabbit Five</title>
+		<link>https://escapepod.org/2021/05/06/escape-pod-783-report-of-dr-hollowmas-on-the-incident-at-jackrabbit-five/</link>
+		<pubDate>Thu, 06 May 2021 21:00:30 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12720</guid>
+		<comments>https://escapepod.org/2021/05/06/escape-pod-783-report-of-dr-hollowmas-on-the-incident-at-jackrabbit-five/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/05/06/escape-pod-783-report-of-dr-hollowmas-on-the-incident-at-jackrabbit-five/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[animals]]></category>
+		<category><![CDATA[anthology]]></category>
+		<category><![CDATA[Children]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[S Kay Nash]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[T. Kingfisher]]></category>
+		<description>Report of Dr. Hollowmas on the Incident at Jackrabbit Five
+By T. Kingfisher
+
+The following report is from the Jackrabbit Colony, Five Tau, regarding the incidents occurring during 7-5-11-8881, fifth rotation, involving Marine Midwife Unit Eleven-Gamma.
+
+Incident report has been taken using the I-Witness program from your friends at Taxon Interrogation Software, with explanatory notes added and our new clarification system, saving you valuable time and manpower! At Taxon, Clarity is Our Business!(tm)
+
+This is the l-Witness program from Taxon Programming. I will be taking your report today. Please relax and answer normally. When explanatory notes or clarifications are added, please indicate if they are correct by stating ‘Yes’ or ‘No’ when prompted. Remember, clarity is our business!
+
+Sure.
+
+Please state your name for the record.
+
+I&#039;m Doc Hollow.
+
+Please state your full legal name for the record.
+
+(sigh) Lin Hollowmas.
+
+Clarification: This is Lin Hollowmas, PhD, DVM, FRCVM...
+
+Yeah, that one.
+
+... current position Doctor of Veterinary Medicine, Jackrabbit Colony?
+
+Yeah.
+
+Thank you, Doctor Hollowmas. Please state your purpose today.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_783_Report_of_Dr_Hollowmas_on_the_Incident_at_Jackrabbit_Five.mp3" length="51057119" type="audio/mpeg" />
+		<itunes:author>T. Kingfisher (Author); S. Kay Nash (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>35:07</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 782: Electronic Ghosts</title>
+		<link>https://escapepod.org/2021/04/29/escape-pod-782-electronic-ghosts/</link>
+		<pubDate>Thu, 29 Apr 2021 21:00:34 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12691</guid>
+		<comments>https://escapepod.org/2021/04/29/escape-pod-782-electronic-ghosts/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/04/29/escape-pod-782-electronic-ghosts/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[Innocent Chizaram Ilo]]></category>
+		<category><![CDATA[Mofiyinfoluwa Okupe]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<description>Electronic Ghosts
+By Innocent Chizaram Ilo
+
+I
+
+If Nneora had died two weeks earlier, her daughter, Anaeto, would not have resurrected her ghost. That was the night Nneora ran a fever, laid convulsing in bed, a slimy froth trickling from the corners of her lips. She had just finished telling Anaeto a story about a woman who fled home to find love. And when the fever subsided, she proceeded to talk to her late mother, Lolo-Nwa, in a tongue that reeked of everything living and dead. Dying on a night like that would have meant Nneora died complete, that her daughter was prepared for her death.
+
+But Nneora will die this evening, when the air is the same as the feel of damp salt on dry skin. She will die midway telling Anaeto a new story. Nobody would believe, not that you can blame them, that Anaeto will do what she does because she is scared the Ghost Of Unfinished Stories will haunt her. Not even Anaeto herself. At some point, she will tell herself this lie: that she resurrected her mother&#039;s ghost because the inquisitive scientist in her wanted to know how the story that numbed on the old woman&#039;s lifeless lips ended. This is more plausible, more logical. A more scientific reason.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_782_Electronic_Ghost.mp3" length="61673008" type="audio/mpeg" />
+		<itunes:author>Innocent Chizaram Ilo (Author); Mofiyinfoluwa Okupe (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>42:29</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 781: Seed Vault (Part 2)</title>
+		<link>https://escapepod.org/2021/04/22/escape-pod-781-seed-vault-part-2/</link>
+		<pubDate>Thu, 22 Apr 2021 21:00:59 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12412</guid>
+		<comments>https://escapepod.org/2021/04/22/escape-pod-781-seed-vault-part-2/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/04/22/escape-pod-781-seed-vault-part-2/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Eden Royce]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<description>Author : Marika Bailey Narrator : Eden Royce Host : S.B. Divya Audio Producer : Summer Brooks Discuss on Forums “Seed Vault” was originally published in Strange Horizons (Nov 2019) Seed Vault (Part 2) By Marika Bailey The desert rain has lulled me and I sleep all the way through the daylight hours. It is […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/04/22/escape-pod-781-seed-vault-part-2/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_781-SeedVault-Pt2.mp3" length="58416338" type="audio/mpeg" />
+		<itunes:author>Marika Bailey (author), Eden Royce (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>40:13</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 780: Seed Vault (Part 1)</title>
+		<link>https://escapepod.org/2021/04/15/escape-pod-780-seed-vault-part-1/</link>
+		<pubDate>Thu, 15 Apr 2021 21:00:58 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12410</guid>
+		<comments>https://escapepod.org/2021/04/15/escape-pod-780-seed-vault-part-1/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/04/15/escape-pod-780-seed-vault-part-1/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<description>Author : Marika Bailey Narrator : Eden Royce Host : S.B. Divya Audio Producer : Summer Brooks Discuss on Forums “Seed Vault” was originally published in Strange Horizons (Nov 2019) Seed Vault (Part 1) By Marika Bailey 1. FIRE I should tell you about the gods, yes? Good setting for it. Here in the desert, […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/04/15/escape-pod-780-seed-vault-part-1/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_780-SeedVault-Pt1.mp3" length="44959097" type="audio/mpeg" />
+		<itunes:author>Marika Bailey (author), Eden Royce (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:53</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 779: The Call of the Sky (Flashback Friday)</title>
+		<link>https://escapepod.org/2021/04/08/escape-pod-779-the-call-of-the-sky-flashback-friday/</link>
+		<pubDate>Thu, 08 Apr 2021 21:00:39 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12403</guid>
+		<comments>https://escapepod.org/2021/04/08/escape-pod-779-the-call-of-the-sky-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/04/08/escape-pod-779-the-call-of-the-sky-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[alien invasion]]></category>
+		<category><![CDATA[Cliff Winnig]]></category>
+		<category><![CDATA[clones]]></category>
+		<category><![CDATA[cyborg]]></category>
+		<category><![CDATA[disease]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[Marguerite Kenner]]></category>
+		<category><![CDATA[nanobots]]></category>
+		<category><![CDATA[Norm Sherman]]></category>
+		<category><![CDATA[Pluto]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space battle]]></category>
+		<category><![CDATA[war]]></category>
+		<description>The Call of the Sky
+By Cliff Winnig
+
+The army hospital’s underground floors reminded me of Pluto Base, a place I’d never actually been. I’d never even been off-world, but I remembered those claustrophobic beige corridors. Two years before, I’d synced with a bunch of my alts home on leave after basic training. Today for the first time I’d be meeting one who’d seen combat. More than that, one who’d become a hero, the only Teri Kang to survive the Battle of Charon.
+
+We wouldn’t be syncing, though. Not this time. Not ever. Before she’d escaped the doomed moon — the moon she’d given the order to destroy — she’d been bitten. That’s what the G.I.s called it when Hive nanobots infected you: being bitten. Like it was a zombie plague or something.
+
+Hell, it might as well be. Soon the only other Teri Kang in the universe would lose her fight with that infection, and the army docs would euthanize her. Under the circumstances, even coming home had been an act of courage. A lot of G.I.s who got bitten went AWOL rather than face the certain death of returning to base. Not for the first time, I wondered if I had such courage lying latent within me.
+
+Flanked by MPs, I followed a nurse down hallway after hallway till we arrived at my alt’s room. Well, the room next to it, since she was quarantined. A smartglass wall separated me from the sterile chamber where the other Teri Kang would live out her last few hours.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_779_The_Call_of_the_Sky_Flashback_Friday.mp3" length="52912306" type="audio/mpeg" />
+		<itunes:author>Cliff Winnig (Author); Marguerite Kenner (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>36:24</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 778: The Machine is Experiencing Uncertainty</title>
+		<link>https://escapepod.org/2021/04/02/escape-pod-778-the-machine-is-experiencing-uncertainty/</link>
+		<pubDate>Fri, 02 Apr 2021 21:00:37 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12384</guid>
+		<comments>https://escapepod.org/2021/04/02/escape-pod-778-the-machine-is-experiencing-uncertainty/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/04/02/escape-pod-778-the-machine-is-experiencing-uncertainty/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[cyborg]]></category>
+		<category><![CDATA[Justin C. Key]]></category>
+		<category><![CDATA[merc fenn wolfmoor]]></category>
+		<category><![CDATA[Merc Rustad]]></category>
+		<category><![CDATA[time loop]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>Author : Merc Fenn Wolfmoor Narrator : Justin C. Key Host : Tina Connolly Audio Producer : Summer Brooks Discuss on Forums Escape Pod 778: The Machine is Experiencing Uncertainty is an Escape Pod original. The Machine is Experiencing Uncertainty by Merc Fenn Wolfmoor Caliban cycles the captain out the airlock again. The man pounds […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/04/02/escape-pod-778-the-machine-is-experiencing-uncertainty/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_778-TheMachineIsExperiencingUncertainty.mp3" length="65163453" type="audio/mpeg" />
+		<itunes:author>Merc Fenn Wolfmoor (author), Justin C. Key (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>44:55</itunes:duration>
+	</item>
+	<item>
+		<title>CatsCast 341: Bargain</title>
+		<link>https://escapepod.org/2021/04/01/catscast-341-bargain/</link>
+		<pubDate>Thu, 01 Apr 2021 04:01:41 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12386</guid>
+		<comments>https://escapepod.org/2021/04/01/catscast-341-bargain/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/04/01/catscast-341-bargain/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<description>Author : Sarah Gailey Narrator : Trendane Sparks Host : Laura Pearlman Audio Producer : Peter Adrian Behravesh Discuss on Forums “Bargain” first appeared in Mothership Zeta (Dec 2015) Bargain by Sarah Gailey Malachai loved his work. He loved wandering among the trappings of enormous wealth and influence, seeing the baubles that humans excreted to […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/04/01/catscast-341-bargain/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/CC341_Bargain.mp3" length="37381615" type="audio/mpeg" />
+		<itunes:author>Sarah Gailey (author), Tren Sparks (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>25:48</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 777: The Dame With the Earth at Her Back</title>
+		<link>https://escapepod.org/2021/03/25/escape-pod-777-the-dame-with-the-earth-at-her-back/</link>
+		<pubDate>Thu, 25 Mar 2021 21:00:03 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12369</guid>
+		<comments>https://escapepod.org/2021/03/25/escape-pod-777-the-dame-with-the-earth-at-her-back/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/03/25/escape-pod-777-the-dame-with-the-earth-at-her-back/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[comedy]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[LGBTQ]]></category>
+		<category><![CDATA[Phoebe Barton]]></category>
+		<category><![CDATA[Sarah Pauling]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<description>The Dame With the Earth at Her Back
+By Sarah Pauling
+
+That’s the trouble with Teegarden’s northern latitudes: the sun never sets in summer. The red glow assaults Maryellen’s stage long after midnight, pushing in through the picture window alongside the nightclub floor. She’s asked Bruce if she could close the curtains sometime, since she gets tired of squinting out into her audience. He said it’d be a waste of prime oceanside real estate not to let the tourists see the ice.
+
+So she makes the best of it. A comedienne works with what she’s got: in this case, a prime view of the drug deal going down between the back tables.
+
+“I mean honestly! During my show! You couldn’t’a waited fifteen minutes to get your fix?” She clicks across the stage in Mary Jane pumps, letting her voice go high and nasal and schoolmarm scolding. “You couldn’t’a waited fifteen minutes or so? I only got so much material! My stamina’s nil! Ask my ex!”</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_777_The_Dame_With_the_Earth_at_Her_Back.mp3" length="51206966" type="audio/mpeg" />
+		<itunes:author>Sarah Pauling (Author); Tina Connolly (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>35:13</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 776: Tloque Nahuaque</title>
+		<link>https://escapepod.org/2021/03/18/escape-pod-776-tloque-nahuaque/</link>
+		<pubDate>Thu, 18 Mar 2021 21:00:33 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12352</guid>
+		<comments>https://escapepod.org/2021/03/18/escape-pod-776-tloque-nahuaque/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/03/18/escape-pod-776-tloque-nahuaque/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Karlo Yeager Rodriguez]]></category>
+		<category><![CDATA[Matt Olivas]]></category>
+		<category><![CDATA[Nelly Geraldine García-Rosas]]></category>
+		<category><![CDATA[physics]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[silvia moreno-garcia]]></category>
+		<description>Tloque Nahuaque
+By Nelly Geraldine García-Rosas, translated by Silvia Moreno-Garcia
+
+
+
+
+If you wish to make an apple pie from scratch, you must first invent the universe.
+
+—Carl Sagan
+
+
+
+
+I—The Particle Accelerator
+
+They built an underground temple. A well of Babel sinking into the gloomy ground at 175 metres of depth. They wanted, like the Biblical architects, to know the unknowable, to discover the origin, reproduce Creation.
+
+The desire to unravel the nature of the Everything floated permanently in the controlled environment of the laboratory. Hundreds of fans and machines emitted a constant buzzing, which the investigators called the “silence of the abyss”. This, combined with the smell of burnt iron, gave the ominous sensation of finding oneself in space. Doctor Migdal lay upon a nest made of coloured cables and, with eyes closed, fantasised that his body, weightless, floated, pushed by the breeze of the ventilation.
+
+Sometimes, he would imagine that he was being attracted by a very narrow tube, a cafeteria straw, the ink container of a pen, or a bleeding artery. His feet, near the edge of the conduit, would feel a titanic weight that would pull him and make him push through the small space. Migdal could see how he would turn into a thick strand of subatomic particles that would extend forever.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_776_Tloque_Nahuaque.mp3" length="29575698" type="audio/mpeg" />
+		<itunes:author>Nelly Geraldine García-Rosas (Author); Silvia Moreno-Garcia (Translator); Karlo Yeager Rodriguez (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>20:12</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 775: Spaceship October</title>
+		<link>https://escapepod.org/2021/03/11/escape-pod-775-spaceship-october/</link>
+		<pubDate>Thu, 11 Mar 2021 22:00:07 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12342</guid>
+		<comments>https://escapepod.org/2021/03/11/escape-pod-775-spaceship-october/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/03/11/escape-pod-775-spaceship-october/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[anthology]]></category>
+		<category><![CDATA[generation ship]]></category>
+		<category><![CDATA[Greg van Eekhout]]></category>
+		<category><![CDATA[Peter Adrian Behravesh]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<description>Spaceship October
+By Greg van Eekhout
+
+When you live on a spaceship, you learn to make your own fun. Exploring the tunnels is some of the very best fun the October’s got. After school hour, me and Droller go scuttling through the darkest conduits you ever will find. The starboard Hab gets minimal heat, so our breath clouds in the light of our head torches as we crawl on our hands and knees.
+
+“You hear that?” Droller whispers from a couple of meters ahead.
+
+I do hear it, a deep, wet wheezing that sounds exactly like Droller trying to spook me.
+
+“You better go ahead and check it out, Droller.”
+
+“Naw, Kitch, it’s behind you. It smells your butt. It’s a butthunter.”
+
+I laugh at Droller’s stupid joke, because the stupider, the funnier, and she’s by far my stupidest friend.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_775_Spaceship_October.mp3" length="41834092" type="audio/mpeg" />
+		<itunes:author>Greg van Eekhout (Author); Peter Adrian Behravesh (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>28:42</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 774: A Wild Patience (Part 3 of 3)</title>
+		<link>https://escapepod.org/2021/03/04/escape-pod-774-a-wild-patience-part-3-of-3/</link>
+		<pubDate>Thu, 04 Mar 2021 22:00:35 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12328</guid>
+		<comments>https://escapepod.org/2021/03/04/escape-pod-774-a-wild-patience-part-3-of-3/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/03/04/escape-pod-774-a-wild-patience-part-3-of-3/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Alethea Kontis]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[feminism]]></category>
+		<category><![CDATA[Gwynne Garfinkle]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<category><![CDATA[sex]]></category>
+		<category><![CDATA[sexuality]]></category>
+		<description>Author : Gwynne Garfinkle Narrator : Alethea Kontis Host : S.B. Divya Audio Producer : Summer Brooks Discuss on Forums This story first appeared in GigaNotoSaurus (March 2020) Contains cursing and discussions of sex. A Wild Patience (Part 3 of 3) by Gwynne Garfinkle When Jessica got home that night, she and I talked for […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/03/04/escape-pod-774-a-wild-patience-part-3-of-3/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_774-AWildPatience-Pt3.mp3" length="40171166" type="audio/mpeg" />
+		<itunes:author>Gwynne Garfinkle (author), Alethea Kontis (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>27:33</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 773: A Wild Patience (Part 2 of 3)</title>
+		<link>https://escapepod.org/2021/02/25/escape-pod-773-a-wild-patience-part-2-of-3/</link>
+		<pubDate>Thu, 25 Feb 2021 22:00:28 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12323</guid>
+		<comments>https://escapepod.org/2021/02/25/escape-pod-773-a-wild-patience-part-2-of-3/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/02/25/escape-pod-773-a-wild-patience-part-2-of-3/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Alethea Kontis]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[feminism]]></category>
+		<category><![CDATA[Gwynne Garfinkle]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<category><![CDATA[sex]]></category>
+		<category><![CDATA[sexuality]]></category>
+		<description>Author : Gwynne Garfinkle Narrator : Alethea Kontis Host : S.B. Divya Audio Producer : Summer Brooks Discuss on Forums This story first appeared in GigaNotoSaurus (March 2020) A Wild Patience (Part 2 of 3) by Gwynne Garfinkle The next day, school was in an uproar. The other mothers had talked to their kids too. […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/02/25/escape-pod-773-a-wild-patience-part-2-of-3/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_773-AWildPatience-Pt2.mp3" length="39305990" type="audio/mpeg" />
+		<itunes:author>Gwynne Garfinkle (author), Alethea Kontis (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>26:57</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 772: A Wild Patience (Part 1 of 3)</title>
+		<link>https://escapepod.org/2021/02/18/escape-pod-772-a-wild-patience-part-1-of-3/</link>
+		<pubDate>Thu, 18 Feb 2021 22:00:40 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12310</guid>
+		<comments>https://escapepod.org/2021/02/18/escape-pod-772-a-wild-patience-part-1-of-3/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/02/18/escape-pod-772-a-wild-patience-part-1-of-3/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[AI]]></category>
+		<category><![CDATA[Alethea Kontis]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[feminism]]></category>
+		<category><![CDATA[Gwynne Garfinkle]]></category>
+		<category><![CDATA[robot]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<category><![CDATA[sex]]></category>
+		<category><![CDATA[sexuality]]></category>
+		<description>Author : Gwynne Garfinkle Narrator : Alethea Kontis Host : S.B. Divya Audio Producer : Summer Brooks Discuss on Forums This story first appeared in GigaNotoSaurus (March 2020) Contains cursing and discussions of sex. A Wild Patience (Part 1 of 3) by Gwynne Garfinkle We first noticed something was off one April afternoon when Jessica […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/02/18/escape-pod-772-a-wild-patience-part-1-of-3/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_772-AWildPatience-Pt1.mp3" length="49016645" type="audio/mpeg" />
+		<itunes:author>Gwynne Garfinkle (author), Alethea Kontis (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>33:42</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 771: The Mercy of Theseus (Flashback Friday)</title>
+		<link>https://escapepod.org/2021/02/11/escape-pod-771-the-mercy-of-theseus-flashback-friday/</link>
+		<pubDate>Thu, 11 Feb 2021 22:00:34 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12302</guid>
+		<comments>https://escapepod.org/2021/02/11/escape-pod-771-the-mercy-of-theseus-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/02/11/escape-pod-771-the-mercy-of-theseus-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[Dave Thompson]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[Norm Sherman]]></category>
+		<category><![CDATA[rachael k jones]]></category>
+		<category><![CDATA[war]]></category>
+		<description>The Mercy of Theseus
+By Rachael K. Jones
+
+Greta and Jamal have three arms, two legs, and one working kidney between the two of them. The kidney belongs to Greta. Its twin went to her little sister three years back, and now she has a laparoscopic keyhole scar over her belly button to remember it by. She can feel it pull tight when she rolls her creeper beneath the chassis of the next project in the shop. Thanks to the war, Jamal has lost the arm, the legs, and the other two kidneys.
+
+All his parts have since been replaced.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_771_The_Mercy_of_Theseus_Flashback_Friday.mp3" length="59541967" type="audio/mpeg" />
+		<itunes:author>Rachael K. Jones (Author); Dave Thompson (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>41:00</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 770: The First Trebuchet on Mars</title>
+		<link>https://escapepod.org/2021/02/04/escape-pod-770-the-first-trebuchet-on-mars/</link>
+		<pubDate>Thu, 04 Feb 2021 22:00:17 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12293</guid>
+		<comments>https://escapepod.org/2021/02/04/escape-pod-770-the-first-trebuchet-on-mars/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/02/04/escape-pod-770-the-first-trebuchet-on-mars/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[humor]]></category>
+		<category><![CDATA[M. Darusha Wehm]]></category>
+		<category><![CDATA[Marie Vibbert]]></category>
+		<category><![CDATA[Mars]]></category>
+		<description>Author : Marie Vibbert Narrator : M. Darusha Wehm Host : Tina Connolly Audio Producer : Summer Brooks Discuss on Forums This story first appeared in Analog (August 2017) The First Trebuchet on Mars by Marie Vibbert If you come to Mars you need to know that in the twelfth century a French engineer named […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/02/04/escape-pod-770-the-first-trebuchet-on-mars/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_770-TheFirstTrebuchetOnMars.mp3" length="25438732" type="audio/mpeg" />
+		<itunes:author>Marie Vibbert (author), M. Darusha Wehm (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>17:19</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 769: Deal</title>
+		<link>https://escapepod.org/2021/01/28/escape-pod-769-deal/</link>
+		<pubDate>Thu, 28 Jan 2021 22:00:02 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12283</guid>
+		<comments>https://escapepod.org/2021/01/28/escape-pod-769-deal/#comments</comments>
+		<wfw:commentRss>https://escapepod.org/2021/01/28/escape-pod-769-deal/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[alien language]]></category>
+		<category><![CDATA[aliens]]></category>
+		<category><![CDATA[Eris Young]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[language]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[Sandra Espinoza]]></category>
+		<description>Deal
+By Eris Young
+
+Beulah wonders what it would be like to touch the Visitor. Oil-slick iridescent, it is tennis ball-sized and scaled with an animated crystalline skin—or shell—or carapace. It floats, stationary, a foot above the rug in the corner of the living room. Its surface changes by the second, rippling back and forth as if stroked by an invisible hand. If she were to run her fingers—gently, gently—over its surface, would it be keratinous, like an iguana? Or feathery? Would it be warm to the touch?
+
+Kim is still behind her somewhere, hovering in the hallway. Get it out, was all she had said, face white as saguaro blossom in the dim mudroom.
+
+Beulah pulled on her jacket, then pulled it off again. “Babe, I have to go to class. Can’t you—”
+
+Kim shook her head, “Uh-uh. Please.” She had been close to tears, almost hyperventilating. Now, muffled by the wall between hall and living room, Her voice is shaky but a bit firmer.
+
+“Is it out?”
+
+If Beulah turns she can just see a sliver of Kim’s shoulder, her pilly cardigan, the electric pink tips of her hair. Her face is now hidden.
+
+“It takes a minute, you know that.”
+
+Beulah crouches, knees popping, to get a better look, steadying herself on the coffee table.
+
+“How’d you get in here, huh?”</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_769_Deal.mp3" length="49187897" type="audio/mpeg" />
+		<itunes:author>Eris Young (Author); Sandra Espinoza (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>33:49</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 768: Balancing the Equation</title>
+		<link>https://escapepod.org/2021/01/21/escape-pod-768-balancing-the-equation/</link>
+		<pubDate>Thu, 21 Jan 2021 22:00:07 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12261</guid>
+		<comments>https://escapepod.org/2021/01/21/escape-pod-768-balancing-the-equation/#comments</comments>
+		<wfw:commentRss>https://escapepod.org/2021/01/21/escape-pod-768-balancing-the-equation/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[colonization]]></category>
+		<category><![CDATA[family loss]]></category>
+		<category><![CDATA[Jay Bhat]]></category>
+		<category><![CDATA[Justin C. Key]]></category>
+		<category><![CDATA[Laurice White]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[space exploration]]></category>
+		<description>Balancing the Equation
+by Justin C. Key
+
+June 18, 2031
+
+Lauren led her two-year-old son, Sean, slowly to their car while carrying three full bags of groceries.
+
+&quot;Up,&quot; Sean said, showing her his palms. &quot;Up, Mama, up!&quot;
+
+&quot;Ask one more time and you&#039;re getting a time out when we get home.&quot;
+
+She should have used a cart to carry the groceries. She should have walked with Sean on the inside. She should have ignored the aching pain in her back and picked him up. The rest of her life would be haunted by &#039;should’ves’. 
+
+&quot;A dog!&quot; Sean pointed at passing poodle as big as him. Of his budding vocabulary, identifying dogs was a family favorite.
+
+&quot;Yes,&quot; Lauren said. &quot;A black dog.&quot; She silently cursed at her failing grip on the bags. She twisted the strap around her wrist. Sean yanked her other arm, hard. 
+
+&quot;Okay, time out as soon as--&quot; Lauren said, but choked when she saw that Sean hadn’t tugged at all. It was a black Prius, worn and dented and scratched and horrible, rolling silently over her son to replace him, as if by magic.
+
+Lauren screamed.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_768-BalancingTheEquation.mp3" length="75207012" type="audio/mpeg" />
+		<itunes:author>Justin C. Key (author), Laurice White (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>51:53</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 767: Shadowboxer (Flashback Friday)</title>
+		<link>https://escapepod.org/2021/01/14/escape-pod-767-shadowboxer-flashback-friday/</link>
+		<pubDate>Thu, 14 Jan 2021 22:00:11 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12253</guid>
+		<comments>https://escapepod.org/2021/01/14/escape-pod-767-shadowboxer-flashback-friday/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2021/01/14/escape-pod-767-shadowboxer-flashback-friday/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Flashback Fridays]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Alasdair Stuart]]></category>
+		<category><![CDATA[assassin]]></category>
+		<category><![CDATA[death]]></category>
+		<category><![CDATA[Flashback Friday]]></category>
+		<category><![CDATA[Paul Di Filippo]]></category>
+		<category><![CDATA[Scott Fletcher]]></category>
+		<category><![CDATA[serah eley]]></category>
+		<category><![CDATA[terrorism]]></category>
+		<category><![CDATA[war]]></category>
+		<description>Shadowboxer (Excerpt)
+By Paul Di Filippo
+
+Generally speaking, I need only three minutes of concentrated attention to kill someone by staring at them. If I’m feeling under the weather, or my mind is preoccupied with other matters–you know how your mind can obsess about trivial things sometimes–it might take five minutes for my power to have its effect. On the other hand, if I focus intensely on my victim I can get the job done in as little as ninety seconds.
+
+…Now the nation is at war. Or so we’re told. I guess that changes everything. A person like me becomes much more important.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_767_Shadowboxer_Flashback_Friday.mp3" length="55618507" type="audio/mpeg" />
+		<itunes:author>Paul Di Filippo (Author); Scott Fletcher (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>38:17</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 766: The Unrepentant</title>
+		<link>https://escapepod.org/2021/01/07/escape-pod-766-the-unrepentant/</link>
+		<pubDate>Thu, 07 Jan 2021 22:00:56 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12240</guid>
+		<comments>https://escapepod.org/2021/01/07/escape-pod-766-the-unrepentant/#comments</comments>
+		<wfw:commentRss>https://escapepod.org/2021/01/07/escape-pod-766-the-unrepentant/feed/</wfw:commentRss>
+		<slash:comments>1</slash:comments>
+		<category><![CDATA[17 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[crime]]></category>
+		<category><![CDATA[Derrick Boden]]></category>
+		<category><![CDATA[Ibba Armancas]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[space station]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<category><![CDATA[war]]></category>
+		<description>Author : Derrick Boden Narrator : Ibba Armancas Host : Tina Connolly Audio Producer : Summer Brooks Discuss on Forums Escape Pod 766: The Unrepentant is an Escape Pod original. This story has content notifications for language and violence. The Unrepentant by Derrick Boden First time I saw her, she was bleeding from her left […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2021/01/07/escape-pod-766-the-unrepentant/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_766-TheUnrepentant.mp3" length="63486392" type="audio/mpeg" />
+		<itunes:author>Derrick Boden (author), Ibba Armancas (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>43:45</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 765: Tru Luv</title>
+		<link>https://escapepod.org/2020/12/31/escape-pod-765-tru-luv/</link>
+		<pubDate>Thu, 31 Dec 2020 22:00:17 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12227</guid>
+		<comments>https://escapepod.org/2020/12/31/escape-pod-765-tru-luv/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2020/12/31/escape-pod-765-tru-luv/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[EP Original]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[holiday]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<category><![CDATA[Sarah Pinsker]]></category>
+		<description>Tru Luv
+By Sarah Pinsker
+
+The first three Tru fanatics were already waiting outside Meetspace when Molly arrived to open the bar. They were easy to recognize, pushing up their winter coats&#039; sleeves and glancing at the insides of their wrists every two seconds instead of their phones, each hoping for their algorithm-matched Prince or Princess or Princex to cross into range and light up their implant.
+
+For all that Molly thought the implants were a scam, she appreciated that they broke people of obsessive phone-checking, at least a tiny bit. It was actually part of the marketing pitch: &quot;Put your phone away and make a commitment. This isn&#039;t social media; it&#039;s Tru Luv.&quot; She was still amazed that so many had taken them up on it, but, then again, she hadn&#039;t gotten into bartending for her ability to understand people.
+
+&quot;Your group isn&#039;t even supposed to be here until seven thirty,&quot; Molly told them. &quot;And we don&#039;t open until six tonight.&quot;
+
+&quot;It IS six,&quot; the tall one said.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_765_Tru_Luv.mp3" length="46040228" type="audio/mpeg" />
+		<itunes:author>Sarah Pinsker (Author); Mur Lafferty (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>31:38</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 764: In the Absence of Instructions to the Contrary</title>
+		<link>https://escapepod.org/2020/12/24/escape-pod-764-in-the-absence-of-instructions-to-the-contrary/</link>
+		<pubDate>Thu, 24 Dec 2020 22:00:43 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12218</guid>
+		<comments>https://escapepod.org/2020/12/24/escape-pod-764-in-the-absence-of-instructions-to-the-contrary/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2020/12/24/escape-pod-764-in-the-absence-of-instructions-to-the-contrary/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[octopuses]]></category>
+		<category><![CDATA[research]]></category>
+		<category><![CDATA[Roderick Aust]]></category>
+		<category><![CDATA[undersea]]></category>
+		<description>Author : Frank Wu Narrator : Roderick Aust Host : Mur Lafferty Audio Producer : Summer Brooks Discuss on Forums This story originally appeared in Analog Magazine in November 2016. It won the AnLab Award for short story. In the Absence of Instructions to the Contrary By Frank Wu Karl 3478 sprawled on the beach, […]
+&lt;p&gt;&lt;a href=&quot;https://escapepod.org/2020/12/24/escape-pod-764-in-the-absence-of-instructions-to-the-contrary/&quot; rel=&quot;nofollow&quot;&gt;Source&lt;/a&gt;&lt;/p&gt;</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_764-IntheAbsenceofInstructions.mp3" length="87161481" type="audio/mpeg" />
+		<itunes:author>Frank Wu (author), Roderick Aust (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>1:00:11</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 763: No Spaceship Go</title>
+		<link>https://escapepod.org/2020/12/17/escape-pod-763-no-spaceship-go/</link>
+		<pubDate>Thu, 17 Dec 2020 22:00:22 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12206</guid>
+		<comments>https://escapepod.org/2020/12/17/escape-pod-763-no-spaceship-go/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2020/12/17/escape-pod-763-no-spaceship-go/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[Andrew K Hoe]]></category>
+		<category><![CDATA[Annie Bellet]]></category>
+		<category><![CDATA[family]]></category>
+		<category><![CDATA[love]]></category>
+		<category><![CDATA[Reprint]]></category>
+		<category><![CDATA[space]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<category><![CDATA[YA / Young Adult]]></category>
+		<description>No Spaceship Go
+By Annie Bellet
+
+The boys lay on their backs side by side staring up through the open roof of the abandoned building. Dylan clutched Meek&#039;s hand in anticipation as the ground shook and a roar filled the air. Tiny pebbles danced up from the ground around them and dust ran like water off the crumbling walls.
+
+&quot;Ten… nine… eight… seven… six… five,&quot; Dylan whispered, &quot;four… three… two… one.&quot;
+
+The shaking increased and he had to release Meek&#039;s hand to shade his eyes. Smoke billowed up into the air, a streak of fire ahead of it. Then the true sonic blast of the rocketship hit them in a wave as the boys squinted to make out the ship speeding through the atmosphere. It sounded like the crackling of a hundred fires, or perhaps the blast of the biggest blowtorch Dylan could imagine.
+
+Meek whooped and crawled to his knees, staring up into the sky.
+
+&quot;Do you think that&#039;s the one we&#039;ll be on someday?&quot; he asked Dylan.
+
+Dylan rolled to his side and propped himself up on one arm. Dust had accumulated on Meek&#039;s round, tan cheeks and Dylan fought the urge to wipe it away.
+
+&quot;Nah, by the time we&#039;ve saved enough to get our home on Elle Four, the ships&#039;ll all be new I bet. We&#039;ll ride on a superfast one for sure.&quot;
+
+&quot;I want to grow peppers.&quot; Meek smiled up at Dylan, his crooked teeth warping the line of his chapped lips.
+
+&quot;What kind of peppers?&quot; Dylan grinned back. They&#039;d had variations of this conversation before and Dylan didn&#039;t pay much attention to Meek as the boy launched into his usual daydream about gardens and pepper plants.
+
+Dylan daydreamed about something else entirely as he fixated on Meek&#039;s lips, his eyes drifting to the dimple in his friend&#039;s left cheek. He didn&#039;t notice at first that Meek had stopped talking and instead stared up at him with those dark, nearly pupil-less eyes.
+
+&quot;Oh, hmm? I&#039;m sorry.&quot; Dylan murmured.
+
+&quot;Pebble for your thoughts?&quot; Meek smiled again.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_763_No_Spaceship_Go.mp3" length="51508661" type="audio/mpeg" />
+		<itunes:author>Annie Bellet (Author); Andrew K Hoe (Narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>35:46</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 762: Give the Family My Love</title>
+		<link>https://escapepod.org/2020/12/10/escape-pod-762-give-the-family-my-love/</link>
+		<pubDate>Thu, 10 Dec 2020 22:00:48 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12183</guid>
+		<comments>https://escapepod.org/2020/12/10/escape-pod-762-give-the-family-my-love/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2020/12/10/escape-pod-762-give-the-family-my-love/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[10 and Up]]></category>
+		<category><![CDATA[Nebula Awards]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[A. T. Greenblatt]]></category>
+		<category><![CDATA[Ellora Sen-Gupta]]></category>
+		<category><![CDATA[nebula award winner]]></category>
+		<category><![CDATA[research]]></category>
+		<category><![CDATA[S B Divya]]></category>
+		<category><![CDATA[space exploration]]></category>
+		<description>Give the Family My Love
+by A. T. Greenblatt
+
+I’m beginning to regret my life choices, Saul. Also, hello from the edge of the galaxy.
+
+Also, surprise! I know this isn’t what you had in mind when you said “Keep in touch, Hazel” but this planet doesn’t exactly invoke the muse of letter writing. The muse of extremely long voice messages however...
+
+So. Want to know what’s this world’s like? Rocky, empty, and bleak in all directions, except one. The sky’s so stormy and green it looks like I’m trudging through the bottom of an algae-infested pond. I’ve got this 85-million-dollar suit between me and the outside, but I swear, I’m suffocating on the atmosphere. Also, I’m 900 meters away from where I need to be with no vehicle to get me there except my own two legs.
+
+So here I am. Walking.
+
+Sorry to do this to you, Saul, but if I don’t talk to someone—well, freak out at someone—I’m not going to make it to the Library. And like hell I’m going to send a message like this back to the boys on the program. You, at least, won’t think less of me for this. You know that emotional meltdowns are part of my process.
+
+850 meters. I should have listened to you, Saul.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_762-GivetheFamilyMyLove_.mp3" length="57844570" type="audio/mpeg" />
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>39:50</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 761: Jolene</title>
+		<link>https://escapepod.org/2020/12/03/escape-pod-761-jolene/</link>
+		<pubDate>Thu, 03 Dec 2020 22:00:56 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12181</guid>
+		<comments>https://escapepod.org/2020/12/03/escape-pod-761-jolene/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2020/12/03/escape-pod-761-jolene/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[artificial intelligence]]></category>
+		<category><![CDATA[cars]]></category>
+		<category><![CDATA[crime]]></category>
+		<category><![CDATA[Fiona Moore]]></category>
+		<category><![CDATA[Louis Evans]]></category>
+		<category><![CDATA[Mur Lafferty]]></category>
+		<category><![CDATA[psychology]]></category>
+		<category><![CDATA[robots]]></category>
+		<description>Jolene
+by Fiona Moore
+
+“I’ve got a case for you,” said Detective Inspector Wilhemine FitzJames. “It’s a country singer whose wife, dog and truck have all left him.”
+
+“Seriously,” she said, after my unprintable reply. “The dog died and there’s nothing much you can do about the wife, but I thought you might be able to help with the truck.”
+
+I leaned back in my reasonably-priced office chair so I could see the screen better. “So, you want me to try and patch things up between them? Bit outside my usual remit.” 
+
+The hand-lettered card under the buzzer downstairs read DOCTOR NOAH MOYO, CONSULTANT AUTOLOGIST, and I usually had to explain that to the uninitiated as “like a cross between a psychologist and a social worker, only for cars and other intelligent Things.” Wills, though, had been working for the London Metropolitan Police’s automotive crime unit for much longer than I’d been in practice, and was more likely to ask if you specialised in criminal, restorative, therapeutic or developmental autology, and if your clients were primarily cars, bots, or home appliances.
+
+“Not sure you can.” On screen, Wills shook her mane of locs. “The truck has been ignoring all communications, and doesn’t seem likely to agree to mediation. I was brought into the case because the fellow turned up at the station reporting an automotive kidnap, but it didn’t take long to establish that the truck had left him and was working for a new user. Voluntarily.”
+
+“As is his legal right,” I said, “Hers? Its?”
+
+“Hers. Texcoco pickup. Name of Jolene.”
+
+The name rang a bell, and, tediously, sparked an earworm. I told my inner Dolly Parton to get knotted. “If she didn’t violate the terms of her contract, she’s free to leave and work for someone else.”</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_761-Jolene.mp3" length="43937187" type="audio/mpeg" />
+		<itunes:author>Fiona Moore (author), Louis Evans (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:duration>30:10</itunes:duration>
+	</item>
+	<item>
+		<title>Escape Pod 760: Deepster Punks</title>
+		<link>https://escapepod.org/2020/11/26/escape-pod-760-deepster-punks/</link>
+		<pubDate>Thu, 26 Nov 2020 22:00:38 +0000</pubDate>
+		<guid isPermaLink="false">https://escapepod.org/?p=12177</guid>
+		<comments>https://escapepod.org/2020/11/26/escape-pod-760-deepster-punks/#respond</comments>
+		<wfw:commentRss>https://escapepod.org/2020/11/26/escape-pod-760-deepster-punks/feed/</wfw:commentRss>
+		<slash:comments>0</slash:comments>
+		<category><![CDATA[13 and Up]]></category>
+		<category><![CDATA[Podcasts]]></category>
+		<category><![CDATA[exploration]]></category>
+		<category><![CDATA[home]]></category>
+		<category><![CDATA[Maria Haskins]]></category>
+		<category><![CDATA[ocean]]></category>
+		<category><![CDATA[punks]]></category>
+		<category><![CDATA[S Kay Nash]]></category>
+		<category><![CDATA[Tina Connolly]]></category>
+		<category><![CDATA[undersea]]></category>
+		<description>Deepster Punks
+by Maria Haskins
+
+Surface
+
+The animated tattoos on Jacob&#039;s skin glimmer in the dark water, words and images swarming over his skin, bright and luminous, before they fade away again. 
+
+&quot;Don&#039;t you dare die on me.&quot; I&#039;m holding his head above the waves, but his naked body is cold and slick and heavy in my grip. By now, I should be able to see the lights of the ocean platform, but there&#039;s nothing, only darkness above and below, no horizon separating them. I unseal the mask of my thermal-suit so I can talk to him, even though I&#039;m not sure he can even hear me anymore. &quot;You&#039;re one lucky bastard, you know. If the Company had sent us anywhere else in the system and you pulled this kind of stunt, you&#039;d be dead already.&quot;
+
+It&#039;s true. Beneath the icy mantle of Ceres, in the 10 K depths of Enceladus, he&#039;d be dead for sure. In the sub-surface ocean of Ganymede, or in the tidal-flexing waters of Europa, he&#039;d be dead-dead-dead. Dead like Petra. But he&#039;s here, on Earth, with me, and he&#039;s alive.
+
+Stay alive, Jacob. Please.</description>
+		<enclosure url="https://traffic.libsyn.com/secure/escapepod/Escape_Pod_760-DeepsterPunks.mp3" length="65056247" type="audio/mpeg" />
+		<itunes:author>Maria Haskins (author), S. Kay Nash (narrator)</itunes:author>
+		<itunes:episodeType>full</itunes:episodeType>
+		<itunes:explicit>true</itunes:explicit>
+		<itunes:duration>44:50</itunes:duration>
+	</item>
+</channel>
+</rss>

--- a/tests/Spouts/resources/Feed/https___rss.art19.com_humans.xml
+++ b/tests/Spouts/resources/Feed/https___rss.art19.com_humans.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:art19="https://art19.com/xmlns/rss-extensions/1.0" xmlns:googleplay="http://www.google.com/schemas/play-podcasts/1.0/" xmlns:podcast="https://podcastindex.org/namespace/1.0" version="2.0">
+  <channel>
+    <title>Humans</title>
+    <description>
+      <![CDATA[<p>Hank Green is a creator and science communicator who desperately wants us to realize how bizarre and special we are. Every week he has a conversation with one of the eight billion weirdos living on planet Earth.&nbsp;</p>]]>
+    </description>
+    <managingEditor>humans@hankgreen.com (Hank Green)</managingEditor>
+    <copyright>© Underthing</copyright>
+    <generator>ART19</generator>
+    <atom:link href="https://rss.art19.com/humans" rel="self" type="application/rss+xml"/>
+    <link>http://humanswithhank.com</link>
+    <itunes:owner>
+      <itunes:name>Hank Green</itunes:name>
+      <itunes:email>humans@hankgreen.com</itunes:email>
+    </itunes:owner>
+    <itunes:author>Hank Green</itunes:author>
+    <itunes:summary>
+      <![CDATA[<p>Hank Green is a creator and science communicator who desperately wants us to realize how bizarre and special we are. Every week he has a conversation with one of the eight billion weirdos living on planet Earth.&nbsp;</p>]]>
+    </itunes:summary>
+    <language>en</language>
+    <itunes:explicit>yes</itunes:explicit>
+    <itunes:category text="Society &amp; Culture"/>
+    <itunes:keywords>humans pod,humans podcast,humans,hank green podcast,hank green</itunes:keywords>
+    <itunes:type>episodic</itunes:type>
+    <itunes:image href="https://content.production.cdn.art19.com/images/e0/1f/16/58/e01f1658-c561-4770-a2e6-a5e6175a26a4/5cc4e0a25db1332d7ea0b898feea227ffbaf047b2264cfc9eefbcb2d12f74b1cebe1e83606b3a687bba8d0acef22fe1090a0871dbb0bf3736ebc19009f31d649.jpeg"/>
+    <image>
+      <url>https://content.production.cdn.art19.com/images/e0/1f/16/58/e01f1658-c561-4770-a2e6-a5e6175a26a4/5cc4e0a25db1332d7ea0b898feea227ffbaf047b2264cfc9eefbcb2d12f74b1cebe1e83606b3a687bba8d0acef22fe1090a0871dbb0bf3736ebc19009f31d649.jpeg</url>
+      <link>http://humanswithhank.com</link>
+      <title>Humans</title>
+    </image>
+    <item>
+      <title>Vicky Holmes: Finding Humanity in Feral Cats</title>
+      <description>
+        <![CDATA[<p>The original author of the Warrior Cats book series has contributed to over 70 books about feral felines, all while not liking cats. Hank and Vicky discuss following your “still, small voice of calm,” the delicacy and respect with which she approaches her young audience, and how the series is autobiographical.&nbsp;</p><p>Got a question or a comment? You can reach us at humans@hankgreen.com</p><p>Find us on social media @humanswithhank</p>]]>
+      </description>
+      <itunes:title>Vicky Holmes: Finding Humanity in Feral Cats</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:summary>The original author of the Warrior Cats book series has contributed to over 70 books about feral felines, all while not liking cats. Hank and Vicky discuss following your “still, small voice of calm,” the delicacy and respect with which she approaches her young audience, and how the series is autobiographical. Got a question or a comment? You can reach us at humans@hankgreen.comFind us on social media @humanswithhank</itunes:summary>
+      <content:encoded>
+        <![CDATA[<p>The original author of the Warrior Cats book series has contributed to over 70 books about feral felines, all while not liking cats. Hank and Vicky discuss following your “still, small voice of calm,” the delicacy and respect with which she approaches her young audience, and how the series is autobiographical.&nbsp;</p><p>Got a question or a comment? You can reach us at humans@hankgreen.com</p><p>Find us on social media @humanswithhank</p>]]>
+      </content:encoded>
+      <guid isPermaLink="false">gid://art19-episode-locator/V0/654_lg_HQq2yaLcXqBxYa6iRUDBOQmWWX_3O2GGtNGs</guid>
+      <pubDate>Thu, 23 Jul 2026 11:30:00 -0000</pubDate>
+      <link>https://art19.com/shows/humans/episodes/9a4c20f1-a792-4b54-81b7-51bef5708bef</link>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:image href="https://content.production.cdn.art19.com/images/e0/1f/16/58/e01f1658-c561-4770-a2e6-a5e6175a26a4/5cc4e0a25db1332d7ea0b898feea227ffbaf047b2264cfc9eefbcb2d12f74b1cebe1e83606b3a687bba8d0acef22fe1090a0871dbb0bf3736ebc19009f31d649.jpeg"/>
+      <itunes:keywords>hank green,hank green podcast,humans,humans podcast,humans pod</itunes:keywords>
+      <itunes:duration>01:04:13</itunes:duration>
+      <enclosure url="https://rss.art19.com/episodes/9a4c20f1-a792-4b54-81b7-51bef5708bef.mp3?rss_browser=BAhJIgljdXJsBjoGRVQ%3D--435795d5c850773aaa4739d968bd77a1dfd6f301" type="audio/mpeg" length="61651487"/>
+    </item>
+    <item>
+      <title>Andy Weir: Are We Technocrats Or Are We Humans? </title>
+      <description>
+        <![CDATA[<p>The writer of The Martian and Project Hail Mary proudly calls himself a “Hank Green-ist.” Andy and Hank talk about why the present is always better than the past, the state of science fiction today, the impact of AI on collective entertainment, and Andy explains why he has a huge problem with zombie stories. Plus, Andy shares how Hank’s responsible for the very last edit made to Project Hail Mary.&nbsp;</p><p>Got a question or a comment? You can reach us at humans@hankgreen.com</p><p>Find us on social media @humanswithhank</p><p>Find Andy Weir on Instagram @andyweirofficial</p>]]>
+      </description>
+      <itunes:title>Andy Weir: Are We Technocrats Or Are We Humans? </itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:summary>The writer of The Martian and Project Hail Mary proudly calls himself a “Hank Green-ist.” Andy and Hank talk about why the present is always better than the past, the state of science fiction today, the impact of AI on collective entertainment, and Andy explains why he has a huge problem with zombie stories. Plus, Andy shares how Hank’s responsible for the very last edit made to Project Hail Mary. Got a question or a comment? You can reach us at humans@hankgreen.comFind us on social media @humanswithhankFind Andy Weir on Instagram @andyweirofficial</itunes:summary>
+      <content:encoded>
+        <![CDATA[<p>The writer of The Martian and Project Hail Mary proudly calls himself a “Hank Green-ist.” Andy and Hank talk about why the present is always better than the past, the state of science fiction today, the impact of AI on collective entertainment, and Andy explains why he has a huge problem with zombie stories. Plus, Andy shares how Hank’s responsible for the very last edit made to Project Hail Mary.&nbsp;</p><p>Got a question or a comment? You can reach us at humans@hankgreen.com</p><p>Find us on social media @humanswithhank</p><p>Find Andy Weir on Instagram @andyweirofficial</p>]]>
+      </content:encoded>
+      <guid isPermaLink="false">gid://art19-episode-locator/V0/e_mbcC2Z4RrjEfnAOBnHNky8cVvUKwIJ5jASex-Tkiw</guid>
+      <pubDate>Thu, 16 Jul 2026 11:30:00 -0000</pubDate>
+      <link>https://art19.com/shows/humans/episodes/3b5af635-3642-4bf0-a74e-6cdd285601dd</link>
+      <itunes:explicit>yes</itunes:explicit>
+      <itunes:image href="https://content.production.cdn.art19.com/images/e0/1f/16/58/e01f1658-c561-4770-a2e6-a5e6175a26a4/5cc4e0a25db1332d7ea0b898feea227ffbaf047b2264cfc9eefbcb2d12f74b1cebe1e83606b3a687bba8d0acef22fe1090a0871dbb0bf3736ebc19009f31d649.jpeg"/>
+      <itunes:keywords>hank green,hank green podcast,humans,humans podcast,humans pod</itunes:keywords>
+      <itunes:duration>01:03:21</itunes:duration>
+      <enclosure url="https://rss.art19.com/episodes/3b5af635-3642-4bf0-a74e-6cdd285601dd.mp3?rss_browser=BAhJIgljdXJsBjoGRVQ%3D--435795d5c850773aaa4739d968bd77a1dfd6f301" type="audio/mpeg" length="60816822"/>
+    </item>
+    <item>
+      <title>Alexis Nikole Nelson: How Foraging Became Weird</title>
+      <description>
+        <![CDATA[<p>Known to millions as the Black Forager, Alexis Nikole Nelson turned a lifetime of plant knowledge and a theater degree’s worth of showmanship into a social-media account that empowers followers to find food in unlikely places. She and Hank talk about the deeply racist history of land access, crafting hyper-palatable social media posts, and why she wants to throw her phone in the ocean — but won’t. Plus: Alexis brings a hot take on pawpaws to a lightning round and has a question for Hank in a new segment.</p><p>Got a question or a comment? You can reach us at humans@hankgreen.com</p><p>Find us on social media @humanswithhank</p><p>Find Alexis Nikole Nelson on Instagram and YouTube @blackforager</p>]]>
+      </description>
+      <itunes:title>Alexis Nikole Nelson: How Foraging Became Weird</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:summary>Known to millions as the Black Forager, Alexis Nikole Nelson turned a lifetime of plant knowledge and a theater degree’s worth of showmanship into a social-media account that empowers followers to find food in unlikely places. She and Hank talk about the deeply racist history of land access, crafting hyper-palatable social media posts, and why she wants to throw her phone in the ocean — but won’t. Plus: Alexis brings a hot take on pawpaws to a lightning round and has a question for Hank in a new segment.Got a question or a comment? You can reach us at humans@hankgreen.comFind us on social media @humanswithhankFind Alexis Nikole Nelson on Instagram and YouTube @blackforager</itunes:summary>
+      <content:encoded>
+        <![CDATA[<p>Known to millions as the Black Forager, Alexis Nikole Nelson turned a lifetime of plant knowledge and a theater degree’s worth of showmanship into a social-media account that empowers followers to find food in unlikely places. She and Hank talk about the deeply racist history of land access, crafting hyper-palatable social media posts, and why she wants to throw her phone in the ocean — but won’t. Plus: Alexis brings a hot take on pawpaws to a lightning round and has a question for Hank in a new segment.</p><p>Got a question or a comment? You can reach us at humans@hankgreen.com</p><p>Find us on social media @humanswithhank</p><p>Find Alexis Nikole Nelson on Instagram and YouTube @blackforager</p>]]>
+      </content:encoded>
+      <guid isPermaLink="false">gid://art19-episode-locator/V0/CN2SdKr-8JEzKwzL4Rcm8m1uwkcSIntbt40I9oRUjKQ</guid>
+      <pubDate>Thu, 09 Jul 2026 11:30:00 -0000</pubDate>
+      <link>https://art19.com/shows/humans/episodes/b188bd70-868c-4c16-a3a2-b3335ce6422f</link>
+      <itunes:explicit>yes</itunes:explicit>
+      <itunes:image href="https://content.production.cdn.art19.com/images/e0/1f/16/58/e01f1658-c561-4770-a2e6-a5e6175a26a4/5cc4e0a25db1332d7ea0b898feea227ffbaf047b2264cfc9eefbcb2d12f74b1cebe1e83606b3a687bba8d0acef22fe1090a0871dbb0bf3736ebc19009f31d649.jpeg"/>
+      <itunes:keywords>hank green,hank green podcast,humans,humans podcast,humans pod</itunes:keywords>
+      <itunes:duration>01:02:44</itunes:duration>
+      <enclosure url="https://rss.art19.com/episodes/b188bd70-868c-4c16-a3a2-b3335ce6422f.mp3?rss_browser=BAhJIgljdXJsBjoGRVQ%3D--435795d5c850773aaa4739d968bd77a1dfd6f301" type="audio/mpeg" length="60236695"/>
+    </item>
+    <item>
+      <title>Jad Abumrad: The Space Between the Brains</title>
+      <description>
+        <![CDATA[<p>The co-creator of Radiolab is as much a fan of Hank’s as Hank is of him. The two talk about Dolly Parton, how to close the gap between your taste and your ability, and why it’s essential that we re-acquaint ourselves with the wonder of the universe. And Hank breaks down in tears over a Radiolab episode from 2007 called “Mortality.”</p><p>Got a question or a comment? You can reach us at humans@hankgreen.com</p><p>Find us on social media @humanswithhank</p><p>Find Jad Abumrad on Instagram @jadabumrad</p>]]>
+      </description>
+      <itunes:title>Jad Abumrad: The Space Between the Brains</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:summary>The co-creator of Radiolab is as much a fan of Hank’s as Hank is of him. The two talk about Dolly Parton, how to close the gap between your taste and your ability, and why it’s essential that we re-acquaint ourselves with the wonder of the universe. And Hank breaks down in tears over a Radiolab episode from 2007 called “Mortality.”Got a question or a comment? You can reach us at humans@hankgreen.comFind us on social media @humanswithhankFind Jad Abumrad on Instagram @jadabumrad</itunes:summary>
+      <content:encoded>
+        <![CDATA[<p>The co-creator of Radiolab is as much a fan of Hank’s as Hank is of him. The two talk about Dolly Parton, how to close the gap between your taste and your ability, and why it’s essential that we re-acquaint ourselves with the wonder of the universe. And Hank breaks down in tears over a Radiolab episode from 2007 called “Mortality.”</p><p>Got a question or a comment? You can reach us at humans@hankgreen.com</p><p>Find us on social media @humanswithhank</p><p>Find Jad Abumrad on Instagram @jadabumrad</p>]]>
+      </content:encoded>
+      <guid isPermaLink="false">gid://art19-episode-locator/V0/WFLJqy6FUoJawUHNJMKLT3czEe9-vu5dh3u6-5Z7HQY</guid>
+      <pubDate>Thu, 02 Jul 2026 11:30:00 -0000</pubDate>
+      <link>https://art19.com/shows/humans/episodes/4485eca4-d8c0-4c28-80fe-388a2c0b0f82</link>
+      <itunes:explicit>yes</itunes:explicit>
+      <itunes:image href="https://content.production.cdn.art19.com/images/e0/1f/16/58/e01f1658-c561-4770-a2e6-a5e6175a26a4/5cc4e0a25db1332d7ea0b898feea227ffbaf047b2264cfc9eefbcb2d12f74b1cebe1e83606b3a687bba8d0acef22fe1090a0871dbb0bf3736ebc19009f31d649.jpeg"/>
+      <itunes:keywords>hank green,hank green podcast,humans,humans podcast,humans pod</itunes:keywords>
+      <itunes:duration>01:15:34</itunes:duration>
+      <enclosure url="https://rss.art19.com/episodes/4485eca4-d8c0-4c28-80fe-388a2c0b0f82.mp3?rss_browser=BAhJIgljdXJsBjoGRVQ%3D--435795d5c850773aaa4739d968bd77a1dfd6f301" type="audio/mpeg" length="72552698"/>
+    </item>
+    <item>
+      <title>Ze Frank: Get Uncomfortable</title>
+      <description>
+        <![CDATA[<p>Ze Frank invented vlogging according to Hank. The creator of the YouTube series True Facts and The Show talks to Hank about getting ideas out into the world, why he prefers discomfort when making things, and how he uses science as fodder for jokes. At the episode’s end, Ze lays down some of the best advice Hank’s ever heard.&nbsp;</p><p>Got a question or a comment? You can reach us at humans@hankgreen.com</p><p>Find us on social media @humanswithhank</p><p>Find Ze Frank on TikTok and YouTube @zefrank </p>]]>
+      </description>
+      <itunes:title>Ze Frank: Get Uncomfortable</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:summary>Ze Frank invented vlogging according to Hank. The creator of the YouTube series True Facts and The Show talks to Hank about getting ideas out into the world, why he prefers discomfort when making things, and how he uses science as fodder for jokes. At the episode’s end, Ze lays down some of the best advice Hank’s ever heard. Got a question or a comment? You can reach us at humans@hankgreen.comFind us on social media @humanswithhankFind Ze Frank on TikTok and YouTube @zefrank </itunes:summary>
+      <content:encoded>
+        <![CDATA[<p>Ze Frank invented vlogging according to Hank. The creator of the YouTube series True Facts and The Show talks to Hank about getting ideas out into the world, why he prefers discomfort when making things, and how he uses science as fodder for jokes. At the episode’s end, Ze lays down some of the best advice Hank’s ever heard.&nbsp;</p><p>Got a question or a comment? You can reach us at humans@hankgreen.com</p><p>Find us on social media @humanswithhank</p><p>Find Ze Frank on TikTok and YouTube @zefrank </p>]]>
+      </content:encoded>
+      <guid isPermaLink="false">gid://art19-episode-locator/V0/7hv8ptzZ5usYPpC5os9kPt3SgQL4H2hFwXszUJS7zTE</guid>
+      <pubDate>Thu, 25 Jun 2026 12:00:00 -0000</pubDate>
+      <link>https://art19.com/shows/humans/episodes/4ec07ece-c8c5-436b-b070-0161b19fae46</link>
+      <itunes:explicit>yes</itunes:explicit>
+      <itunes:image href="https://content.production.cdn.art19.com/images/e0/1f/16/58/e01f1658-c561-4770-a2e6-a5e6175a26a4/5cc4e0a25db1332d7ea0b898feea227ffbaf047b2264cfc9eefbcb2d12f74b1cebe1e83606b3a687bba8d0acef22fe1090a0871dbb0bf3736ebc19009f31d649.jpeg"/>
+      <itunes:keywords>hank green,hank green podcast,humans,humans podcast,humans pod</itunes:keywords>
+      <itunes:duration>00:58:53</itunes:duration>
+      <enclosure url="https://rss.art19.com/episodes/4ec07ece-c8c5-436b-b070-0161b19fae46.mp3?rss_browser=BAhJIgljdXJsBjoGRVQ%3D--435795d5c850773aaa4739d968bd77a1dfd6f301" type="audio/mpeg" length="56528561"/>
+    </item>
+    <item>
+      <title>Helen Hunt: When the Universe Betrays You</title>
+      <description>
+        <![CDATA[<p>Oscar-winner Helen Hunt calls out Hank for a video he made about her 20 years ago. They get into aging and Hollywood, why it’s moving to see people giving a shit, and how to be relentless. Helen also can’t believe how many books Hank hasn’t read — and gives him homework.</p><p>Got a question or a comment? You can reach us at humans@hankgreen.com</p><p>Find us on social media @humanswithhank</p>]]>
+      </description>
+      <itunes:title>Helen Hunt: When the Universe Betrays You</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:summary>Oscar-winner Helen Hunt calls out Hank for a video he made about her 20 years ago. They get into aging and Hollywood, why it’s moving to see people giving a shit, and how to be relentless. Helen also can’t believe how many books Hank hasn’t read — and gives him homework.Got a question or a comment? You can reach us at humans@hankgreen.comFind us on social media @humanswithhank</itunes:summary>
+      <content:encoded>
+        <![CDATA[<p>Oscar-winner Helen Hunt calls out Hank for a video he made about her 20 years ago. They get into aging and Hollywood, why it’s moving to see people giving a shit, and how to be relentless. Helen also can’t believe how many books Hank hasn’t read — and gives him homework.</p><p>Got a question or a comment? You can reach us at humans@hankgreen.com</p><p>Find us on social media @humanswithhank</p>]]>
+      </content:encoded>
+      <guid isPermaLink="false">gid://art19-episode-locator/V0/UVwEgkz49T-lkpfpP8Q4CHEDvhnafrHLZ2FaGiJyXo8</guid>
+      <pubDate>Thu, 18 Jun 2026 12:00:00 -0000</pubDate>
+      <link>https://art19.com/shows/humans/episodes/39981211-9ab1-4300-aaa0-4f35d7e80c9d</link>
+      <itunes:explicit>yes</itunes:explicit>
+      <itunes:image href="https://content.production.cdn.art19.com/images/e0/1f/16/58/e01f1658-c561-4770-a2e6-a5e6175a26a4/5cc4e0a25db1332d7ea0b898feea227ffbaf047b2264cfc9eefbcb2d12f74b1cebe1e83606b3a687bba8d0acef22fe1090a0871dbb0bf3736ebc19009f31d649.jpeg"/>
+      <itunes:keywords>hank green,hank green podcast,humans,humans podcast,humans pod</itunes:keywords>
+      <itunes:duration>01:00:16</itunes:duration>
+      <enclosure url="https://rss.art19.com/episodes/39981211-9ab1-4300-aaa0-4f35d7e80c9d.mp3?rss_browser=BAhJIgljdXJsBjoGRVQ%3D--435795d5c850773aaa4739d968bd77a1dfd6f301" type="audio/mpeg" length="57864777"/>
+    </item>
+    <item>
+      <title>Puzzle-Maker Wyna Liu's Just a Little Mean</title>
+      <description>
+        <![CDATA[<p>Wyna Liu is the maker of one of Hank's favorite games: Connections. In the New York Times game, players sort 16 words into four categories. Wyna and Hank geek out on what makes a great puzzle, why low-stakes activities matter, and how a category game ended up funding some of the best journalism in the world. Plus: Wyna hits Hank hard with the idea that no effort is wasted when you're a maker.</p><p>Got a question or a comment? You can reach us at <a href="mailto:humans@hankgreen.com" rel="noopener noreferrer" target="_blank">humans@hankgreen.com</a></p><p>Find us on social media @humanswithhank</p>]]>
+      </description>
+      <itunes:title>Puzzle-Maker Wyna Liu's Just a Little Mean</itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:summary>Wyna Liu is the maker of one of Hank's favorite games: Connections. In the New York Times game, players sort 16 words into four categories. Wyna and Hank geek out on what makes a great puzzle, why low-stakes activities matter, and how a category game ended up funding some of the best journalism in the world. Plus: Wyna hits Hank hard with the idea that no effort is wasted when you're a maker.Got a question or a comment? You can reach us at humans@hankgreen.comFind us on social media @humanswithhank</itunes:summary>
+      <content:encoded>
+        <![CDATA[<p>Wyna Liu is the maker of one of Hank's favorite games: Connections. In the New York Times game, players sort 16 words into four categories. Wyna and Hank geek out on what makes a great puzzle, why low-stakes activities matter, and how a category game ended up funding some of the best journalism in the world. Plus: Wyna hits Hank hard with the idea that no effort is wasted when you're a maker.</p><p>Got a question or a comment? You can reach us at <a href="mailto:humans@hankgreen.com" rel="noopener noreferrer" target="_blank">humans@hankgreen.com</a></p><p>Find us on social media @humanswithhank</p>]]>
+      </content:encoded>
+      <guid isPermaLink="false">gid://art19-episode-locator/V0/qVhnIWb69qcRgot3nKWpwv7ArkkSU5VniMz-hCagK9k</guid>
+      <pubDate>Thu, 11 Jun 2026 12:00:00 -0000</pubDate>
+      <link>https://art19.com/shows/humans/episodes/27c78c0e-92b1-40c4-86e2-e79f4b5ed7e5</link>
+      <itunes:explicit>yes</itunes:explicit>
+      <itunes:image href="https://content.production.cdn.art19.com/images/e0/1f/16/58/e01f1658-c561-4770-a2e6-a5e6175a26a4/5cc4e0a25db1332d7ea0b898feea227ffbaf047b2264cfc9eefbcb2d12f74b1cebe1e83606b3a687bba8d0acef22fe1090a0871dbb0bf3736ebc19009f31d649.jpeg"/>
+      <itunes:keywords>hank green,hank green podcast,humans,humans podcast,humans pod</itunes:keywords>
+      <itunes:duration>00:59:20</itunes:duration>
+      <enclosure url="https://rss.art19.com/episodes/27c78c0e-92b1-40c4-86e2-e79f4b5ed7e5.mp3?rss_browser=BAhJIgljdXJsBjoGRVQ%3D--435795d5c850773aaa4739d968bd77a1dfd6f301" type="audio/mpeg" length="56971180"/>
+    </item>
+    <item>
+      <title>John Green: We’re Not Merely a Catastrophe </title>
+      <description>
+        <![CDATA[<p>John disapproves of his brother's new podcast entirely, but is happy to be here. They talk about why John's worried about Hank, why being in favor of humans is now counter-cultural, if John's seminary training might have helped the brothers' internet success, and what Mark Twain has to do with any of it. They have spent years talking publicly together — but not like this.</p><p>Got a question or a comment? You can reach us at <a href="mailto:humans@hankgreen.com" rel="noopener noreferrer" target="_blank">humans@hankgreen.com</a></p><p>Find us on social media @humanswithhank</p>]]>
+      </description>
+      <itunes:title>John Green: We’re Not Merely a Catastrophe </itunes:title>
+      <itunes:episodeType>full</itunes:episodeType>
+      <itunes:summary>John disapproves of his brother's new podcast entirely, but is happy to be here. They talk about why John's worried about Hank, why being in favor of humans is now counter-cultural, if John's seminary training might have helped the brothers' internet success, and what Mark Twain has to do with any of it. They have spent years talking publicly together — but not like this.Got a question or a comment? You can reach us at humans@hankgreen.comFind us on social media @humanswithhank</itunes:summary>
+      <content:encoded>
+        <![CDATA[<p>John disapproves of his brother's new podcast entirely, but is happy to be here. They talk about why John's worried about Hank, why being in favor of humans is now counter-cultural, if John's seminary training might have helped the brothers' internet success, and what Mark Twain has to do with any of it. They have spent years talking publicly together — but not like this.</p><p>Got a question or a comment? You can reach us at <a href="mailto:humans@hankgreen.com" rel="noopener noreferrer" target="_blank">humans@hankgreen.com</a></p><p>Find us on social media @humanswithhank</p>]]>
+      </content:encoded>
+      <guid isPermaLink="false">gid://art19-episode-locator/V0/hzQO0icsP5lb-4TSelcWNsszM5NJgxXRvrYzzQtxRKI</guid>
+      <pubDate>Thu, 04 Jun 2026 12:30:00 -0000</pubDate>
+      <link>https://art19.com/shows/humans/episodes/104f0c1d-4f1b-475b-8b25-fd67b939e4d6</link>
+      <itunes:explicit>no</itunes:explicit>
+      <itunes:image href="https://content.production.cdn.art19.com/images/e0/1f/16/58/e01f1658-c561-4770-a2e6-a5e6175a26a4/5cc4e0a25db1332d7ea0b898feea227ffbaf047b2264cfc9eefbcb2d12f74b1cebe1e83606b3a687bba8d0acef22fe1090a0871dbb0bf3736ebc19009f31d649.jpeg"/>
+      <itunes:keywords>hollywood, ending,mark twain,john green,hank green,hank green podcast,humans,humans podcast,humans pod</itunes:keywords>
+      <itunes:duration>01:20:57</itunes:duration>
+      <enclosure url="https://rss.art19.com/episodes/104f0c1d-4f1b-475b-8b25-fd67b939e4d6.mp3?rss_browser=BAhJIgljdXJsBjoGRVQ%3D--435795d5c850773aaa4739d968bd77a1dfd6f301" type="audio/mpeg" length="77720346"/>
+    </item>
+    <item>
+      <title>Welcome to Humans</title>
+      <description>
+        <![CDATA[<p>Hank Green is a creator and science communicator who desperately wants us to realize how bizarre and special we are. Every week he has a conversation with one of the eight billion weirdos living on planet Earth.&nbsp;</p>]]>
+      </description>
+      <itunes:title>Welcome to Humans</itunes:title>
+      <itunes:episodeType>trailer</itunes:episodeType>
+      <itunes:summary>Hank Green is a creator and science communicator who desperately wants us to realize how bizarre and special we are. Every week he has a conversation with one of the eight billion weirdos living on planet Earth. </itunes:summary>
+      <content:encoded>
+        <![CDATA[<p>Hank Green is a creator and science communicator who desperately wants us to realize how bizarre and special we are. Every week he has a conversation with one of the eight billion weirdos living on planet Earth.&nbsp;</p>]]>
+      </content:encoded>
+      <guid isPermaLink="false">gid://art19-episode-locator/V0/fSnV0oRfFkghrIYYqmEEMMZ3jNLxRfP346jP4bRYLV4</guid>
+      <pubDate>Thu, 14 May 2026 06:00:00 -0000</pubDate>
+      <link>https://art19.com/shows/humans/episodes/ca78c53a-ff65-4cd5-8f35-a32acee240ee</link>
+      <itunes:explicit>yes</itunes:explicit>
+      <itunes:image href="https://content.production.cdn.art19.com/images/e0/1f/16/58/e01f1658-c561-4770-a2e6-a5e6175a26a4/5cc4e0a25db1332d7ea0b898feea227ffbaf047b2264cfc9eefbcb2d12f74b1cebe1e83606b3a687bba8d0acef22fe1090a0871dbb0bf3736ebc19009f31d649.jpeg"/>
+      <itunes:keywords>Wyna Liu,Helen Hunt,Connections,John Green,Jad Abumrad,Kal McRaven,FunkyFrogBait,Ze Frank,hank green,hank green podcast,humans,humans podcast,humans pod</itunes:keywords>
+      <itunes:duration>00:02:28</itunes:duration>
+      <enclosure url="https://rss.art19.com/episodes/ca78c53a-ff65-4cd5-8f35-a32acee240ee.mp3?rss_browser=BAhJIgljdXJsBjoGRVQ%3D--435795d5c850773aaa4739d968bd77a1dfd6f301" type="audio/mpeg" length="2382785"/>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
This is useful for playing podcasts.

Not embedding audio player for now, as that would require loading on demand to prevent tracking.

See: https://github.com/fossar/selfoss/issues/1169
